### PR TITLE
Fix Home navigation to prevent logging out

### DIFF
--- a/phd-advisor-frontend/src/App.js
+++ b/phd-advisor-frontend/src/App.js
@@ -49,11 +49,6 @@ function App() {
 
   const navigateToHome = () => {
     setCurrentView('home');
-    setIsAuthenticated(false);
-    setUser(null);
-    setAuthToken(null);
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('user');
   };
 
   const handleAuthSuccess = (userData, token) => {
@@ -77,7 +72,10 @@ function App() {
       <ThemeProvider>
         <div className="App">
           {currentView === 'home' && (
-            <HomePage onNavigateToChat={navigateToAuth} />
+            <HomePage
+              onNavigateToChat={isAuthenticated ? navigateToChat : navigateToAuth}
+              isAuthenticated={isAuthenticated}
+            />
           )}
           {currentView === 'auth' && (
             <AuthPage onAuthSuccess={handleAuthSuccess} />

--- a/phd-advisor-frontend/src/pages/HomePage.js
+++ b/phd-advisor-frontend/src/pages/HomePage.js
@@ -4,7 +4,7 @@ import AdvisorCard from '../components/AdvisorCard';
 import ThemeToggle from '../components/ThemeToggle';
 import { useAppConfig } from '../contexts/AppConfigContext';
 
-const HomePage = ({ onNavigateToChat }) => {
+const HomePage = ({ onNavigateToChat, isAuthenticated }) => {
   const { config, advisors, resolveIcon } = useAppConfig();
 
   const UsersIcon = resolveIcon('Users');
@@ -44,7 +44,7 @@ const HomePage = ({ onNavigateToChat }) => {
             className="cta-button"
           >
             <MessageCircle className="cta-icon" />
-            <span>Start Conversation</span>
+            <span>{isAuthenticated ? 'Continue Conversation' : 'Start Conversation'}</span>
             <ArrowRight className="cta-arrow" />
           </button>
         </div>


### PR DESCRIPTION
# Description
Stop clearing auth state when navigating to Home so the Home button no longer logs the user out
Show Continue Conversation when already logged in.

# Issues
- Includes change from https://github.com/NeonClary/CCAI-Demo-FEAT_Config/pull/1

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->