### PR TITLE
Fix/json output

### DIFF
--- a/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
+++ b/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
@@ -226,6 +226,7 @@ class ImprovedChatOrchestrator:
                 context=[{"role": "user", "content": user_prompt}],
                 temperature=0.4,
                 max_tokens=1024,
+                response_mime_type="application/json"
             )
 
             cleaned = raw.strip()

--- a/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
+++ b/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
@@ -794,7 +794,8 @@ When analyzing the document context:
                 system_prompt=f"You are an assistant that selects the best advisors for a user of {app_title}.",
                 context=[{"role": "user", "content": prompt}],
                 temperature=0.4,
-                max_tokens=150
+                max_tokens=150,
+                response_mime_type="application/json"
             )
 
             # Step 1: Try direct JSON load
@@ -804,6 +805,10 @@ When analyzing the document context:
                 # Step 2: Fallback: try extracting list of quoted strings
                 top_ids = re.findall(r'"(.*?)"', llm_response)
                 logger.warning(f"Fallback JSON extraction used: {top_ids}")
+
+            # Handle models that wrap the list in an object (e.g. {"advisor_ids": [...]})
+            if isinstance(top_ids, dict):
+                top_ids = next(iter(top_ids.values()), [])
 
             # Step 3: Filter valid persona IDs
             valid_ids = [pid for pid in top_ids if pid in self.personas]

--- a/multi_llm_chatbot_backend/app/llm/improved_vllm_client.py
+++ b/multi_llm_chatbot_backend/app/llm/improved_vllm_client.py
@@ -42,12 +42,17 @@ class ImprovedVllmClient(LLMClient):
             if not self.model_name:
                 await self.refresh_model()
 
-            response = await self.client.chat.completions.create(
+            create_kwargs = dict(
                 model=self.model_name,
                 messages=context_window.messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
+
+            if response_mime_type == "application/json":
+                create_kwargs["response_format"] = {"type": "json_object"}
+
+            response = await self.client.chat.completions.create(**create_kwargs)
 
             text = response.choices[0].message.content.strip()
             return self._clean_response(text)

--- a/multi_llm_chatbot_backend/app/tests/unit/test_vllm_client.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_vllm_client.py
@@ -161,6 +161,47 @@ class TestImprovedVllmClient(unittest.TestCase):
         self.assertIsNone(client.model_name)
 
     # ------------------------------------------------------------------
+    # generate – response_format for JSON
+    # ------------------------------------------------------------------
+
+    def test_generate_passes_response_format_for_json(self, MockAsyncOpenAI, mock_get_ctx):
+        client = ImprovedVllmClient(
+            api_url=FAKE_URL, api_key=FAKE_KEY, model_name="test-model",
+        )
+        client.client.chat.completions.create = AsyncMock(
+            return_value=_make_completion_mock('{"key": "value"}')
+        )
+
+        asyncio.run(client.generate(
+            system_prompt="Return JSON",
+            context=[{"role": "user", "content": "Hi"}],
+            temperature=0.3,
+            max_tokens=100,
+            response_mime_type="application/json",
+        ))
+
+        call_kwargs = client.client.chat.completions.create.call_args.kwargs
+        self.assertEqual(call_kwargs["response_format"], {"type": "json_object"})
+
+    def test_generate_omits_response_format_when_no_mime_type(self, MockAsyncOpenAI, mock_get_ctx):
+        client = ImprovedVllmClient(
+            api_url=FAKE_URL, api_key=FAKE_KEY, model_name="test-model",
+        )
+        client.client.chat.completions.create = AsyncMock(
+            return_value=_make_completion_mock("plain text response")
+        )
+
+        asyncio.run(client.generate(
+            system_prompt="You are helpful.",
+            context=[{"role": "user", "content": "Hello"}],
+            temperature=0.7,
+            max_tokens=100,
+        ))
+
+        call_kwargs = client.client.chat.completions.create.call_args.kwargs
+        self.assertNotIn("response_format", call_kwargs)
+
+    # ------------------------------------------------------------------
     # _clean_response
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
# Description
Added structured JSON output (`response_mime_type="application/json"`) support across the backend:
- **vLLM client**: Map `response_mime_type` to OpenAI's `response_format: {"type": "json_object"}` in `ImprovedVllmClient.generate()`.
- **Orchestrator**: Add `response_mime_type` to `generate_contextual_clarification` and `get_top_personas` LLM calls.
- **Parsing**: Handle dict-wrapped JSON responses (e.g. `{"advisor_ids": [...]}`) that vLLM model returned instead of bare array. (Note: this output quirk may be specific to vLLM endpoint model and subject to change.)
- **Tests**: Add unit tests verifying `response_format` is passed by vLLM client. 

# Issues
Closes #13 

# Other Notes
- Existing JSON cleanup logic in `generate_contextual_clarification` is intentionally kept as a safety net in case the vLLM endpoint changes to a model that doesn't support JSON output.