### PR TITLE
Feat/account management

### DIFF
--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -20,6 +20,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class MessageResponse(BaseModel):
+    message: str
+
+
 class ChangePasswordRequest(BaseModel):
     current_password: str
     new_password: str
@@ -149,13 +153,13 @@ async def get_current_user_profile(current_user: User = Depends(get_current_acti
     """
     return create_user_response(current_user)
 
-@router.post("/logout")
+@router.post("/logout", response_model=MessageResponse)
 async def logout():
     """
     Log out the current user (client should discard the token).
-    @return: dict with a confirmation message
+    @return: MessageResponse with a confirmation message
     """
-    return {"message": "Successfully logged out"}
+    return MessageResponse(message="Successfully logged out")
 
 @router.post("/verify-token", response_model=UserResponse)
 async def verify_token(current_user: User = Depends(get_current_active_user)):
@@ -166,7 +170,7 @@ async def verify_token(current_user: User = Depends(get_current_active_user)):
     """
     return create_user_response(current_user)
 
-@router.post("/me/password")
+@router.post("/me/password", response_model=MessageResponse)
 async def change_password(
     body: ChangePasswordRequest,
     current_user: User = Depends(get_current_active_user),
@@ -175,7 +179,7 @@ async def change_password(
     Change the authenticated user's password.
     @param body: ChangePasswordRequest with the current and new passwords
     @param current_user: Authenticated user from dependency injection
-    @return: dict with a confirmation message
+    @return: MessageResponse with a confirmation message
     """
     if not verify_password(body.current_password, current_user.hashed_password):
         raise HTTPException(
@@ -192,7 +196,7 @@ async def change_password(
         {"_id": current_user.id},
         {"$set": {"hashed_password": get_password_hash(body.new_password)}},
     )
-    return {"message": "Password changed successfully"}
+    return MessageResponse(message="Password changed successfully")
 
 @router.patch("/me", response_model=UserResponse)
 async def update_profile(
@@ -220,7 +224,7 @@ async def update_profile(
     updated_user = await db.users.find_one({"_id": current_user.id})
     return create_user_response(User(**updated_user))
 
-@router.delete("/me")
+@router.delete("/me", response_model=MessageResponse)
 async def delete_account(
     body: DeleteAccountRequest,
     current_user: User = Depends(get_current_active_user),
@@ -229,7 +233,7 @@ async def delete_account(
     Permanently delete the authenticated user's account and all chat sessions.
     @param body: DeleteAccountRequest with the user's password for confirmation
     @param current_user: Authenticated user from dependency injection
-    @return: dict with a confirmation message
+    @return: MessageResponse with a confirmation message
     """
     if not verify_password(body.password, current_user.hashed_password):
         raise HTTPException(
@@ -240,4 +244,4 @@ async def delete_account(
     uid = current_user.id
     await db.chat_sessions.delete_many({"user_id": uid})
     await db.users.delete_one({"_id": uid})
-    return {"message": "Account deleted"}
+    return MessageResponse(message="Account deleted")

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends, status
 from datetime import datetime, timedelta
 from app.models.user import UserCreate, UserLogin, User, Token, UserResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from typing import Optional
 from app.core.auth import (
     get_password_hash, 
@@ -27,10 +27,26 @@ class ChangePasswordRequest(BaseModel):
     current_password: str
     new_password: str
 
+    @model_validator(mode="after")
+    def passwords_must_differ(self):
+        if self.current_password == self.new_password:
+            raise ValueError("New password must be different from the current password")
+        return self
+
 
 class UpdateProfileRequest(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.first_name is not None:
+            self.first_name = self.first_name.strip() or None
+        if self.last_name is not None:
+            self.last_name = self.last_name.strip() or None
+        if self.first_name is None and self.last_name is None:
+            raise ValueError("At least one field must be provided")
+        return self
 
 
 class DeleteAccountRequest(BaseModel):
@@ -221,14 +237,9 @@ async def update_profile(
     try:
         updates = {}
         if body.first_name is not None:
-            updates["firstName"] = body.first_name.strip()
+            updates["firstName"] = body.first_name
         if body.last_name is not None:
-            updates["lastName"] = body.last_name.strip()
-        if not updates:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No fields to update",
-            )
+            updates["lastName"] = body.last_name
         db = get_database()
         await db.users.update_one({"_id": current_user.id}, {"$set": updates})
         updated_user = await db.users.find_one({"_id": current_user.id})

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -181,22 +181,32 @@ async def change_password(
     @param current_user: Authenticated user from dependency injection
     @return: MessageResponse with a confirmation message
     """
-    if not verify_password(body.current_password, current_user.hashed_password):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Current password is incorrect",
+    try:
+        if not verify_password(body.current_password, current_user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is incorrect",
+            )
+        if len(body.new_password) < 6:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="New password must be at least 6 characters",
+            )
+        db = get_database()
+        await db.users.update_one(
+            {"_id": current_user.id},
+            {"$set": {"hashed_password": get_password_hash(body.new_password)}},
         )
-    if len(body.new_password) < 6:
+        return MessageResponse(message="Password changed successfully")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error during password change: {e}")
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="New password must be at least 6 characters",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not change password"
         )
-    db = get_database()
-    await db.users.update_one(
-        {"_id": current_user.id},
-        {"$set": {"hashed_password": get_password_hash(body.new_password)}},
-    )
-    return MessageResponse(message="Password changed successfully")
 
 @router.patch("/me", response_model=UserResponse)
 async def update_profile(
@@ -209,20 +219,30 @@ async def update_profile(
     @param current_user: Authenticated user from dependency injection
     @return: UserResponse with the updated profile information
     """
-    updates = {}
-    if body.firstName is not None:
-        updates["firstName"] = body.firstName.strip()
-    if body.lastName is not None:
-        updates["lastName"] = body.lastName.strip()
-    if not updates:
+    try:
+        updates = {}
+        if body.firstName is not None:
+            updates["firstName"] = body.firstName.strip()
+        if body.lastName is not None:
+            updates["lastName"] = body.lastName.strip()
+        if not updates:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No fields to update",
+            )
+        db = get_database()
+        await db.users.update_one({"_id": current_user.id}, {"$set": updates})
+        updated_user = await db.users.find_one({"_id": current_user.id})
+        return create_user_response(User(**updated_user))
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error during profile update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="No fields to update",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not update profile"
         )
-    db = get_database()
-    await db.users.update_one({"_id": current_user.id}, {"$set": updates})
-    updated_user = await db.users.find_one({"_id": current_user.id})
-    return create_user_response(User(**updated_user))
 
 @router.delete("/me", response_model=MessageResponse)
 async def delete_account(
@@ -235,13 +255,23 @@ async def delete_account(
     @param current_user: Authenticated user from dependency injection
     @return: MessageResponse with a confirmation message
     """
-    if not verify_password(body.password, current_user.hashed_password):
+    try:
+        if not verify_password(body.password, current_user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Incorrect password",
+            )
+        db = get_database()
+        uid = current_user.id
+        await db.chat_sessions.delete_many({"user_id": uid})
+        await db.users.delete_one({"_id": uid})
+        return MessageResponse(message="Account deleted")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error during account deletion: {e}")
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Incorrect password",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not delete account"
         )
-    db = get_database()
-    uid = current_user.id
-    await db.chat_sessions.delete_many({"user_id": uid})
-    await db.users.delete_one({"_id": uid})
-    return MessageResponse(message="Account deleted")

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -220,10 +220,10 @@ async def update_profile(
     """
     try:
         updates = {}
-        if body.firstName is not None:
-            updates["firstName"] = body.firstName.strip()
-        if body.lastName is not None:
-            updates["lastName"] = body.lastName.strip()
+        if body.first_name is not None:
+            updates["firstName"] = body.first_name.strip()
+        if body.last_name is not None:
+            updates["lastName"] = body.last_name.strip()
         if not updates:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -29,8 +29,8 @@ class ChangePasswordRequest(BaseModel):
 
 
 class UpdateProfileRequest(BaseModel):
-    firstName: Optional[str] = None
-    lastName: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
 
 
 class DeleteAccountRequest(BaseModel):

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -38,7 +38,11 @@ router = APIRouter()
 
 @router.post("/signup", response_model=Token)
 async def signup(user_data: UserCreate):
-    """Create a new user account"""
+    """
+    Register a new user and return an access token.
+    @param user_data: UserCreate with name, email, password, and optional academic fields
+    @return: Token containing a JWT access token and the created UserResponse
+    """
     try:
         db = get_database()
         
@@ -91,7 +95,11 @@ async def signup(user_data: UserCreate):
 
 @router.post("/login", response_model=Token)
 async def login(user_credentials: UserLogin):
-    """Login with email and password"""
+    """
+    Authenticate a user and return an access token.
+    @param user_credentials: UserLogin with email and password
+    @return: Token containing a JWT access token and the authenticated UserResponse
+    """
     try:
         # Authenticate user
         user = await authenticate_user(user_credentials.email, user_credentials.password)
@@ -134,17 +142,28 @@ async def login(user_credentials: UserLogin):
 
 @router.get("/me", response_model=UserResponse)
 async def get_current_user_profile(current_user: User = Depends(get_current_active_user)):
-    """Get current user profile"""
+    """
+    Retrieve the profile of the currently authenticated user.
+    @param current_user: Authenticated user from dependency injection
+    @return: UserResponse with the user's profile information
+    """
     return create_user_response(current_user)
 
 @router.post("/logout")
 async def logout():
-    """Logout (client should discard token)"""
+    """
+    Log out the current user (client should discard the token).
+    @return: dict with a confirmation message
+    """
     return {"message": "Successfully logged out"}
 
 @router.post("/verify-token", response_model=UserResponse)
 async def verify_token(current_user: User = Depends(get_current_active_user)):
-    """Verify token and return user info"""
+    """
+    Validate the caller's JWT and return their profile.
+    @param current_user: Authenticated user from dependency injection
+    @return: UserResponse with the user's profile information
+    """
     return create_user_response(current_user)
 
 @router.post("/me/password")
@@ -152,6 +171,12 @@ async def change_password(
     body: ChangePasswordRequest,
     current_user: User = Depends(get_current_active_user),
 ):
+    """
+    Change the authenticated user's password.
+    @param body: ChangePasswordRequest with the current and new passwords
+    @param current_user: Authenticated user from dependency injection
+    @return: dict with a confirmation message
+    """
     if not verify_password(body.current_password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -174,6 +199,12 @@ async def update_profile(
     body: UpdateProfileRequest,
     current_user: User = Depends(get_current_active_user),
 ):
+    """
+    Update the authenticated user's profile fields.
+    @param body: UpdateProfileRequest with optional firstName and lastName
+    @param current_user: Authenticated user from dependency injection
+    @return: UserResponse with the updated profile information
+    """
     updates = {}
     if body.firstName is not None:
         updates["firstName"] = body.firstName.strip()
@@ -194,6 +225,12 @@ async def delete_account(
     body: DeleteAccountRequest,
     current_user: User = Depends(get_current_active_user),
 ):
+    """
+    Permanently delete the authenticated user's account and all chat sessions.
+    @param body: DeleteAccountRequest with the user's password for confirmation
+    @param current_user: Authenticated user from dependency injection
+    @return: dict with a confirmation message
+    """
     if not verify_password(body.password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -2,8 +2,11 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from datetime import datetime, timedelta
 from bson import ObjectId
 from app.models.user import UserCreate, UserLogin, User, Token, UserResponse
+from pydantic import BaseModel
+from typing import Optional
 from app.core.auth import (
     get_password_hash, 
+    verify_password,
     authenticate_user, 
     create_access_token, 
     get_user_by_email,
@@ -15,6 +18,21 @@ from app.core.database import get_database
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+
+class UpdateProfileRequest(BaseModel):
+    firstName: Optional[str] = None
+    lastName: Optional[str] = None
+
+
+class DeleteAccountRequest(BaseModel):
+    password: str
+
 
 router = APIRouter()
 
@@ -128,3 +146,61 @@ async def logout():
 async def verify_token(current_user: User = Depends(get_current_active_user)):
     """Verify token and return user info"""
     return create_user_response(current_user)
+
+@router.post("/me/password")
+async def change_password(
+    body: ChangePasswordRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not verify_password(body.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect",
+        )
+    if len(body.new_password) < 6:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must be at least 6 characters",
+        )
+    db = get_database()
+    await db.users.update_one(
+        {"_id": current_user.id},
+        {"$set": {"hashed_password": get_password_hash(body.new_password)}},
+    )
+    return {"message": "Password changed successfully"}
+
+@router.patch("/me", response_model=UserResponse)
+async def update_profile(
+    body: UpdateProfileRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    updates = {}
+    if body.firstName is not None:
+        updates["firstName"] = body.firstName.strip()
+    if body.lastName is not None:
+        updates["lastName"] = body.lastName.strip()
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields to update",
+        )
+    db = get_database()
+    await db.users.update_one({"_id": current_user.id}, {"$set": updates})
+    updated_user = await db.users.find_one({"_id": current_user.id})
+    return create_user_response(User(**updated_user))
+
+@router.delete("/me")
+async def delete_account(
+    body: DeleteAccountRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not verify_password(body.password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Incorrect password",
+        )
+    db = get_database()
+    uid = current_user.id
+    await db.chat_sessions.delete_many({"user_id": uid})
+    await db.users.delete_one({"_id": uid})
+    return {"message": "Account deleted"}

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -187,10 +187,10 @@ async def change_password(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is incorrect",
             )
-        if len(body.new_password) < 6:
+        if len(body.new_password) < 8:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="New password must be at least 6 characters",
+                detail="New password must be at least 8 characters",
             )
         db = get_database()
         await db.users.update_one(

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -249,7 +249,7 @@ async def delete_account(
     current_user: User = Depends(get_current_active_user),
 ):
     """
-    Permanently delete the authenticated user's account and all chat sessions.
+    Permanently delete the authenticated user's account, all chat sessions, and all PhD Canvas data.
     @param body: DeleteAccountRequest with the user's password for confirmation
     @param current_user: Authenticated user from dependency injection
     @return: MessageResponse with a confirmation message

--- a/multi_llm_chatbot_backend/app/api/routes/auth.py
+++ b/multi_llm_chatbot_backend/app/api/routes/auth.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, HTTPException, Depends, status
 from datetime import datetime, timedelta
-from bson import ObjectId
 from app.models.user import UserCreate, UserLogin, User, Token, UserResponse
 from pydantic import BaseModel
 from typing import Optional
@@ -264,6 +263,7 @@ async def delete_account(
         db = get_database()
         uid = current_user.id
         await db.chat_sessions.delete_many({"user_id": uid})
+        await db.phd_canvases.delete_many({"user_id": uid})
         await db.users.delete_one({"_id": uid})
         return MessageResponse(message="Account deleted")
 

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -153,7 +153,7 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = UpdateProfileRequest(firstName="Alice")
+        body = UpdateProfileRequest(first_name="Alice")
         result = asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
@@ -173,7 +173,7 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = UpdateProfileRequest(firstName="Alice", lastName="Smith")
+        body = UpdateProfileRequest(first_name="Alice", last_name="Smith")
         result = asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
@@ -200,7 +200,7 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = UpdateProfileRequest(firstName="  Alice  ")
+        body = UpdateProfileRequest(first_name="  Alice  ")
         asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -119,7 +119,7 @@ class TestChangePassword(unittest.TestCase):
             asyncio.run(change_password(body=body, current_user=user))
 
         self.assertEqual(ctx.exception.status_code, 400)
-        self.assertIn("6 characters", ctx.exception.detail)
+        self.assertIn("8 characters", ctx.exception.detail)
 
     def test_db_not_called_on_wrong_password(self, mock_verify, mock_hash, mock_get_db):
         mock_verify.return_value = False

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -87,7 +87,7 @@ class TestChangePassword(unittest.TestCase):
             {"_id": user.id},
             {"$set": {"hashed_password": "new_hashed"}},
         )
-        self.assertEqual(result["message"], "Password changed successfully")
+        self.assertEqual(result.message, "Password changed successfully")
 
     def test_wrong_current_password(self, mock_verify, mock_hash, mock_get_db):
         mock_verify.return_value = False
@@ -226,7 +226,7 @@ class TestDeleteAccount(unittest.TestCase):
         mock_verify.assert_called_once_with("correct", user.hashed_password)
         db.chat_sessions.delete_many.assert_called_once_with({"user_id": user.id})
         db.users.delete_one.assert_called_once_with({"_id": user.id})
-        self.assertEqual(result["message"], "Account deleted")
+        self.assertEqual(result.message, "Account deleted")
 
     def test_wrong_password(self, mock_verify, mock_get_db):
         mock_verify.return_value = False

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from bson import ObjectId
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 
 # app.api.routes.__init__ eagerly imports and wires routers from every
 # sibling route module, several of which spin up the LLM stack, NLTK
@@ -137,6 +138,14 @@ class TestChangePassword(unittest.TestCase):
 
         db.users.update_one.assert_not_called()
 
+    def test_same_password_rejected(self, mock_verify, mock_hash, mock_get_db):
+        with self.assertRaises(ValidationError) as ctx:
+            ChangePasswordRequest(
+                current_password="samepass", new_password="samepass",
+            )
+
+        self.assertIn("different", str(ctx.exception).lower())
+
 
 # ------------------------------------------------------------------
 # PATCH /auth/me
@@ -184,14 +193,10 @@ class TestUpdateProfile(unittest.TestCase):
         self.assertEqual(result.lastName, "Smith")
 
     def test_empty_body_rejected(self, mock_get_db):
-        user = _make_fake_user()
-        body = UpdateProfileRequest()
+        with self.assertRaises(ValidationError) as ctx:
+            UpdateProfileRequest()
 
-        with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(update_profile(body=body, current_user=user))
-
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertIn("No fields to update", ctx.exception.detail)
+        self.assertIn("at least one field", str(ctx.exception).lower())
 
     def test_strips_whitespace(self, mock_get_db):
         user = _make_fake_user()
@@ -201,12 +206,20 @@ class TestUpdateProfile(unittest.TestCase):
         mock_get_db.return_value = db
 
         body = UpdateProfileRequest(first_name="  Alice  ")
+        self.assertEqual(body.first_name, "Alice")
+
         asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
             {"_id": user.id},
             {"$set": {"firstName": "Alice"}},
         )
+
+    def test_whitespace_only_body_rejected(self, mock_get_db):
+        with self.assertRaises(ValidationError) as ctx:
+            UpdateProfileRequest(first_name="   ")
+
+        self.assertIn("at least one field", str(ctx.exception).lower())
 
 
 # ------------------------------------------------------------------

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -1,37 +1,41 @@
 import asyncio
-import importlib.util
-import os
 import sys
-import types
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from bson import ObjectId
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 
-from app.models.user import User
+# app.api.routes.__init__ eagerly imports and wires routers from every
+# sibling route module, several of which spin up the LLM stack, NLTK
+# downloads, and ChromaDB at import time. Stub those heavy modules with
+# harmless substitutes so the package imports cleanly and auth.py can
+# be loaded via normal import machinery.
+for _name in ("app.core.bootstrap", "app.core.rag_manager"):
+    sys.modules.setdefault(_name, MagicMock())
 
-# app.api.routes.__init__ imports sibling route modules that run heavy
-# module-level code (LLM bootstrap, etc.).  We only need auth.py, so
-# we register a thin stub for the *package* then load auth.py by file
-# path so the real __init__ is never executed.
-_pkg_name = "app.api.routes"
-if _pkg_name not in sys.modules:
-    _pkg = types.ModuleType(_pkg_name)
-    _pkg.__path__ = [
-        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "api", "routes")
-    ]
-    _pkg.__package__ = _pkg_name
-    sys.modules[_pkg_name] = _pkg
+_stub_router_module = MagicMock(router=APIRouter())
+for _name in (
+    "app.api.routes.chat",
+    "app.api.routes.documents",
+    "app.api.routes.sessions",
+    "app.api.routes.provider",
+    "app.api.routes.debug",
+    "app.api.routes.root",
+    "app.api.routes.phd_canvas",
+):
+    sys.modules.setdefault(_name, _stub_router_module)
 
-_auth_path = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "api", "routes", "auth.py")
+from app.api.routes.auth import (  # noqa: E402
+    ChangePasswordRequest,
+    DeleteAccountRequest,
+    UpdateProfileRequest,
+    change_password,
+    delete_account,
+    update_profile,
 )
-_spec = importlib.util.spec_from_file_location("app.api.routes.auth", _auth_path)
-_auth_mod = importlib.util.module_from_spec(_spec)
-sys.modules["app.api.routes.auth"] = _auth_mod
-_spec.loader.exec_module(_auth_mod)
+from app.models.user import User  # noqa: E402
 
 FAKE_USER_ID = ObjectId()
 
@@ -75,11 +79,11 @@ class TestChangePassword(unittest.TestCase):
         mock_get_db.return_value = db
 
         user = _make_fake_user()
-        body = _auth_mod.ChangePasswordRequest(
+        body = ChangePasswordRequest(
             current_password="old", new_password="newsecure",
         )
 
-        result = asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+        result = asyncio.run(change_password(body=body, current_user=user))
 
         mock_verify.assert_called_once_with("old", user.hashed_password)
         mock_hash.assert_called_once_with("newsecure")
@@ -93,12 +97,12 @@ class TestChangePassword(unittest.TestCase):
         mock_verify.return_value = False
 
         user = _make_fake_user()
-        body = _auth_mod.ChangePasswordRequest(
+        body = ChangePasswordRequest(
             current_password="wrong", new_password="newsecure",
         )
 
         with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+            asyncio.run(change_password(body=body, current_user=user))
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("incorrect", ctx.exception.detail.lower())
@@ -107,12 +111,12 @@ class TestChangePassword(unittest.TestCase):
         mock_verify.return_value = True
 
         user = _make_fake_user()
-        body = _auth_mod.ChangePasswordRequest(
+        body = ChangePasswordRequest(
             current_password="old", new_password="short",
         )
 
         with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+            asyncio.run(change_password(body=body, current_user=user))
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("6 characters", ctx.exception.detail)
@@ -123,12 +127,12 @@ class TestChangePassword(unittest.TestCase):
         mock_get_db.return_value = db
 
         user = _make_fake_user()
-        body = _auth_mod.ChangePasswordRequest(
+        body = ChangePasswordRequest(
             current_password="wrong", new_password="newsecure",
         )
 
         with self.assertRaises(HTTPException):
-            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+            asyncio.run(change_password(body=body, current_user=user))
 
         db.users.update_one.assert_not_called()
 
@@ -148,8 +152,8 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = _auth_mod.UpdateProfileRequest(firstName="Alice")
-        result = asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+        body = UpdateProfileRequest(firstName="Alice")
+        result = asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
             {"_id": user.id},
@@ -168,8 +172,8 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = _auth_mod.UpdateProfileRequest(firstName="Alice", lastName="Smith")
-        result = asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+        body = UpdateProfileRequest(firstName="Alice", lastName="Smith")
+        result = asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
             {"_id": user.id},
@@ -180,10 +184,10 @@ class TestUpdateProfile(unittest.TestCase):
 
     def test_empty_body_rejected(self, mock_get_db):
         user = _make_fake_user()
-        body = _auth_mod.UpdateProfileRequest()
+        body = UpdateProfileRequest()
 
         with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+            asyncio.run(update_profile(body=body, current_user=user))
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("No fields to update", ctx.exception.detail)
@@ -195,8 +199,8 @@ class TestUpdateProfile(unittest.TestCase):
         db.users.find_one = AsyncMock(return_value=updated_doc)
         mock_get_db.return_value = db
 
-        body = _auth_mod.UpdateProfileRequest(firstName="  Alice  ")
-        asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+        body = UpdateProfileRequest(firstName="  Alice  ")
+        asyncio.run(update_profile(body=body, current_user=user))
 
         db.users.update_one.assert_called_once_with(
             {"_id": user.id},
@@ -219,9 +223,9 @@ class TestDeleteAccount(unittest.TestCase):
         mock_get_db.return_value = db
 
         user = _make_fake_user()
-        body = _auth_mod.DeleteAccountRequest(password="correct")
+        body = DeleteAccountRequest(password="correct")
 
-        result = asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+        result = asyncio.run(delete_account(body=body, current_user=user))
 
         mock_verify.assert_called_once_with("correct", user.hashed_password)
         db.chat_sessions.delete_many.assert_called_once_with({"user_id": user.id})
@@ -234,10 +238,10 @@ class TestDeleteAccount(unittest.TestCase):
         mock_get_db.return_value = db
 
         user = _make_fake_user()
-        body = _auth_mod.DeleteAccountRequest(password="wrong")
+        body = DeleteAccountRequest(password="wrong")
 
         with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+            asyncio.run(delete_account(body=body, current_user=user))
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("Incorrect password", ctx.exception.detail)
@@ -248,10 +252,10 @@ class TestDeleteAccount(unittest.TestCase):
         mock_get_db.return_value = db
 
         user = _make_fake_user()
-        body = _auth_mod.DeleteAccountRequest(password="wrong")
+        body = DeleteAccountRequest(password="wrong")
 
         with self.assertRaises(HTTPException):
-            asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+            asyncio.run(delete_account(body=body, current_user=user))
 
         db.users.delete_one.assert_not_called()
         db.chat_sessions.delete_many.assert_not_called()

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -1,0 +1,257 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from app.models.user import User
+
+# app.api.routes.__init__ imports sibling route modules that run heavy
+# module-level code (LLM bootstrap, etc.).  We only need auth.py, so
+# we register a thin stub for the *package* then load auth.py by file
+# path so the real __init__ is never executed.
+_pkg_name = "app.api.routes"
+if _pkg_name not in sys.modules:
+    _pkg = types.ModuleType(_pkg_name)
+    _pkg.__path__ = [
+        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "api", "routes")
+    ]
+    _pkg.__package__ = _pkg_name
+    sys.modules[_pkg_name] = _pkg
+
+_auth_path = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "api", "routes", "auth.py")
+)
+_spec = importlib.util.spec_from_file_location("app.api.routes.auth", _auth_path)
+_auth_mod = importlib.util.module_from_spec(_spec)
+sys.modules["app.api.routes.auth"] = _auth_mod
+_spec.loader.exec_module(_auth_mod)
+
+FAKE_USER_ID = ObjectId()
+
+
+def _make_fake_user(**overrides):
+    defaults = dict(
+        _id=FAKE_USER_ID,
+        firstName="Test",
+        lastName="User",
+        email="test@example.com",
+        hashed_password="$2b$12$fakehash",
+        is_active=True,
+        created_at=datetime(2025, 1, 1),
+    )
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _mock_db():
+    db = MagicMock()
+    db.users.update_one = AsyncMock()
+    db.users.delete_one = AsyncMock()
+    db.users.find_one = AsyncMock()
+    db.chat_sessions.delete_many = AsyncMock()
+    return db
+
+
+# ------------------------------------------------------------------
+# POST /auth/me/password
+# ------------------------------------------------------------------
+
+
+@patch("app.api.routes.auth.get_database")
+@patch("app.api.routes.auth.get_password_hash", return_value="new_hashed")
+@patch("app.api.routes.auth.verify_password")
+class TestChangePassword(unittest.TestCase):
+
+    def test_success(self, mock_verify, mock_hash, mock_get_db):
+        mock_verify.return_value = True
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = _auth_mod.ChangePasswordRequest(
+            current_password="old", new_password="newsecure",
+        )
+
+        result = asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+
+        mock_verify.assert_called_once_with("old", user.hashed_password)
+        mock_hash.assert_called_once_with("newsecure")
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"hashed_password": "new_hashed"}},
+        )
+        self.assertEqual(result["message"], "Password changed successfully")
+
+    def test_wrong_current_password(self, mock_verify, mock_hash, mock_get_db):
+        mock_verify.return_value = False
+
+        user = _make_fake_user()
+        body = _auth_mod.ChangePasswordRequest(
+            current_password="wrong", new_password="newsecure",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("incorrect", ctx.exception.detail.lower())
+
+    def test_new_password_too_short(self, mock_verify, mock_hash, mock_get_db):
+        mock_verify.return_value = True
+
+        user = _make_fake_user()
+        body = _auth_mod.ChangePasswordRequest(
+            current_password="old", new_password="short",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("6 characters", ctx.exception.detail)
+
+    def test_db_not_called_on_wrong_password(self, mock_verify, mock_hash, mock_get_db):
+        mock_verify.return_value = False
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = _auth_mod.ChangePasswordRequest(
+            current_password="wrong", new_password="newsecure",
+        )
+
+        with self.assertRaises(HTTPException):
+            asyncio.run(_auth_mod.change_password(body=body, current_user=user))
+
+        db.users.update_one.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# PATCH /auth/me
+# ------------------------------------------------------------------
+
+
+@patch("app.api.routes.auth.get_database")
+class TestUpdateProfile(unittest.TestCase):
+
+    def test_update_first_name(self, mock_get_db):
+        user = _make_fake_user()
+        updated_doc = {**user.model_dump(by_alias=True), "firstName": "Alice"}
+        db = _mock_db()
+        db.users.find_one = AsyncMock(return_value=updated_doc)
+        mock_get_db.return_value = db
+
+        body = _auth_mod.UpdateProfileRequest(firstName="Alice")
+        result = asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"firstName": "Alice"}},
+        )
+        self.assertEqual(result.firstName, "Alice")
+
+    def test_update_both_names(self, mock_get_db):
+        user = _make_fake_user()
+        updated_doc = {
+            **user.model_dump(by_alias=True),
+            "firstName": "Alice",
+            "lastName": "Smith",
+        }
+        db = _mock_db()
+        db.users.find_one = AsyncMock(return_value=updated_doc)
+        mock_get_db.return_value = db
+
+        body = _auth_mod.UpdateProfileRequest(firstName="Alice", lastName="Smith")
+        result = asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"firstName": "Alice", "lastName": "Smith"}},
+        )
+        self.assertEqual(result.firstName, "Alice")
+        self.assertEqual(result.lastName, "Smith")
+
+    def test_empty_body_rejected(self, mock_get_db):
+        user = _make_fake_user()
+        body = _auth_mod.UpdateProfileRequest()
+
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("No fields to update", ctx.exception.detail)
+
+    def test_strips_whitespace(self, mock_get_db):
+        user = _make_fake_user()
+        updated_doc = {**user.model_dump(by_alias=True), "firstName": "Alice"}
+        db = _mock_db()
+        db.users.find_one = AsyncMock(return_value=updated_doc)
+        mock_get_db.return_value = db
+
+        body = _auth_mod.UpdateProfileRequest(firstName="  Alice  ")
+        asyncio.run(_auth_mod.update_profile(body=body, current_user=user))
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"firstName": "Alice"}},
+        )
+
+
+# ------------------------------------------------------------------
+# DELETE /auth/me
+# ------------------------------------------------------------------
+
+
+@patch("app.api.routes.auth.get_database")
+@patch("app.api.routes.auth.verify_password")
+class TestDeleteAccount(unittest.TestCase):
+
+    def test_success(self, mock_verify, mock_get_db):
+        mock_verify.return_value = True
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = _auth_mod.DeleteAccountRequest(password="correct")
+
+        result = asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+
+        mock_verify.assert_called_once_with("correct", user.hashed_password)
+        db.chat_sessions.delete_many.assert_called_once_with({"user_id": user.id})
+        db.users.delete_one.assert_called_once_with({"_id": user.id})
+        self.assertEqual(result["message"], "Account deleted")
+
+    def test_wrong_password(self, mock_verify, mock_get_db):
+        mock_verify.return_value = False
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = _auth_mod.DeleteAccountRequest(password="wrong")
+
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("Incorrect password", ctx.exception.detail)
+
+    def test_no_deletion_on_wrong_password(self, mock_verify, mock_get_db):
+        mock_verify.return_value = False
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = _auth_mod.DeleteAccountRequest(password="wrong")
+
+        with self.assertRaises(HTTPException):
+            asyncio.run(_auth_mod.delete_account(body=body, current_user=user))
+
+        db.users.delete_one.assert_not_called()
+        db.chat_sessions.delete_many.assert_not_called()

--- a/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_account_management.py
@@ -60,6 +60,7 @@ def _mock_db():
     db.users.delete_one = AsyncMock()
     db.users.find_one = AsyncMock()
     db.chat_sessions.delete_many = AsyncMock()
+    db.phd_canvases.delete_many = AsyncMock()
     return db
 
 
@@ -229,6 +230,7 @@ class TestDeleteAccount(unittest.TestCase):
 
         mock_verify.assert_called_once_with("correct", user.hashed_password)
         db.chat_sessions.delete_many.assert_called_once_with({"user_id": user.id})
+        db.phd_canvases.delete_many.assert_called_once_with({"user_id": user.id})
         db.users.delete_one.assert_called_once_with({"_id": user.id})
         self.assertEqual(result.message, "Account deleted")
 
@@ -259,3 +261,4 @@ class TestDeleteAccount(unittest.TestCase):
 
         db.users.delete_one.assert_not_called()
         db.chat_sessions.delete_many.assert_not_called()
+        db.phd_canvases.delete_many.assert_not_called()


### PR DESCRIPTION
# Description

Adds backend support for self-service account management on the `/auth` router.

**New endpoints:**
- `POST /auth/me/password` — change password.
- `PATCH /auth/me` — update profile (`firstName`, `lastName`).
- `DELETE /auth/me` — permanently delete the account (requires password).

**Summary of changes:**
- Consistent Pydantic response models (`MessageResponse`) and `@param`/`@return` docstrings across all `auth` endpoints.
- Account deletion includes `chat_sessions` and `phd_canvases`.
- Minimum password length on change-password set to 8 to match the frontend `Signup.js` rule.

# Issues

Relates to Issue #26. 

# Other Notes

- This PR only implements the backend endpoints. Front-end UI needs to be implemented to close the issue. 

## Test flow
Start the app with Docker and create a dummy account that you are ok deleting, then run the following commands from another terminal:

```bash
# Log in to your dummy account
curl -s -X POST http://localhost:8000/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"test@example.com","password":"yourpassword"}' | python3 -m json.tool

# Grab the access token and set it as a variable
TOKEN="paste_your_token_here"

# Test change password
curl -s -X POST http://localhost:8000/auth/me/password \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"current_password":"yourpassword","new_password":"newpassword123"}' | python3 -m json.tool

# Test wrong current password
curl -s -X POST http://localhost:8000/auth/me/password \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"current_password":"wrong","new_password":"newpassword123"}' | python3 -m json.tool

# Test new password too short
curl -s -X POST http://localhost:8000/auth/me/password \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"current_password":"yourpassword","new_password":"short"}' | python3 -m json.tool

# Test update profile
curl -s -X PATCH http://localhost:8000/auth/me \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"firstName":"NewFirst","lastName":"NewLast"}' | python3 -m json.tool

# Test deleting your dummy account
curl -s -X DELETE http://localhost:8000/auth/me \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"password":"newpassword123"}' | python3 -m json.tool

# Verify the account is gone
curl -s http://localhost:8000/auth/me \
  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
```