### PR TITLE
Fix bug around chat deletion

### DIFF
--- a/phd-advisor-frontend/src/components/Sidebar.js
+++ b/phd-advisor-frontend/src/components/Sidebar.js
@@ -27,7 +27,8 @@ const Sidebar = ({
   isMobileOpen = false,
   onMobileToggle,
   onNavigateToCanvas,
-  refreshTrigger
+  refreshTrigger,
+  onCurrentSessionDeleted
 }) => {
   const { config } = useAppConfig();
   const canvasLabel = config?.app?.title ? `${config.app.title} Canvas` : 'Canvas';
@@ -141,7 +142,7 @@ const Sidebar = ({
         if (response.ok) {
           setChatSessions(prev => prev.filter(session => session.id !== sessionId));
           if (currentSessionId === sessionId) {
-            onNewChat(); // Create new session if current one was deleted
+            onCurrentSessionDeleted?.();
           }
         }
       } catch (error) {

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -261,6 +261,17 @@ const handleSelectSession = async (sessionId) => {
   await loadChatSession(sessionId);
 };
 
+// Sidebar deleted the currently-active chat. Clear local state without
+// creating a replacement session.
+const handleCurrentSessionDeleted = () => {
+  setCurrentSessionId(null);
+  setCurrentSessionTitle('');
+  setMessages([]);
+  setReplyingTo(null);
+  setThinkingAdvisors([]);
+  setUploadedDocuments([]);
+};
+
 // Handle creating new chat from sidebar
 const handleNewChat = async (sessionId = null) => {
   if (sessionId) {
@@ -746,6 +757,7 @@ const handleNewChat = async (sessionId = null) => {
         currentSessionId={currentSessionId}
         onSelectSession={handleSelectSession}
         onNewChat={handleNewChat}
+        onCurrentSessionDeleted={handleCurrentSessionDeleted}
         onSignOut={onSignOut}
         authToken={authToken}
         onSidebarToggle={handleSidebarToggle}


### PR DESCRIPTION
# Description
The bug was that the frontend was making an extra call (onNewChat() → POST /new-chat → createNewSession()) immediately after the delete succeeded. That's what spawned the new MongoDB session.

# Issues
- Closes #45 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->