### PR TITLE
UI Improvements

### DIFF
--- a/phd-advisor-frontend/src/App.js
+++ b/phd-advisor-frontend/src/App.js
@@ -89,7 +89,7 @@ function App() {
             />
           )}
           {currentView === 'chat' && isAuthenticated && (
-            <ChatPage 
+            <ChatPage
               user={user}
               authToken={authToken}
               onNavigateToHome={navigateToHome}

--- a/phd-advisor-frontend/src/components/Sidebar.js
+++ b/phd-advisor-frontend/src/components/Sidebar.js
@@ -1,16 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  MessageSquare, 
-  Plus, 
-  Search, 
-  MoreVertical, 
-  Trash2, 
+import {
+  MessageSquare,
+  Plus,
+  SquarePen,
+  Search,
+  MoreVertical,
+  Trash2,
   Edit3,
   LogOut,
   User,
   Settings,
-  ChevronLeft,
-  ChevronRight,
+  PanelLeft,
   FileText
 } from 'lucide-react';
 import { useAppConfig } from '../contexts/AppConfigContext';
@@ -191,7 +191,7 @@ const Sidebar = ({
                     onClick={toggleSidebar} 
                     title="Collapse sidebar"
                   >
-                    <ChevronLeft size={16} />
+                    <PanelLeft size={18} />
                   </button>
                   
                   <div className="user-menu-container">
@@ -218,21 +218,12 @@ const Sidebar = ({
                 </div>
               </div>
 
-              <button 
-                className="new-chat-button" 
-                onClick={handleNewChat}
-                disabled={isCreatingNewChat}
-              >
-                <Plus size={16} />
-                <span>{isCreatingNewChat ? 'Creating...' : 'New Chat'}</span>
-              </button>
-
-              <button 
+              <button
                 className="sidebar-canvas-btn"
                 onClick={onNavigateToCanvas}
                 title={canvasLabel}
               >
-                <FileText size={20} />
+                <FileText size={18} />
                 {!isCollapsed && <span>{canvasLabel}</span>}
               </button>
             </>
@@ -246,15 +237,15 @@ const Sidebar = ({
                 onClick={toggleSidebar} 
                 title="Expand sidebar"
               >
-                <ChevronRight size={20} />
+                <PanelLeft size={20} />
               </button>
-              <button 
-                className="collapsed-new-chat" 
-                onClick={handleNewChat} 
+              <button
+                className="collapsed-new-chat"
+                onClick={handleNewChat}
                 title="New Chat"
                 disabled={isCreatingNewChat}
               >
-                <Plus size={20} />
+                <SquarePen size={20} />
               </button>
               <button 
                 className="sidebar-canvas-btn"
@@ -268,7 +259,7 @@ const Sidebar = ({
           )}
         </div>
 
-        {/* Search - only show when expanded */}
+        {/* Search + New Chat - only show when expanded */}
         {!isCollapsed && (
           <div className="sidebar-search">
             <div className="search-container">
@@ -281,6 +272,14 @@ const Sidebar = ({
                 className="search-input"
               />
             </div>
+            <button
+              className="new-chat-icon-btn"
+              onClick={handleNewChat}
+              disabled={isCreatingNewChat}
+              title={isCreatingNewChat ? 'Creating...' : 'New Chat'}
+            >
+              <SquarePen size={18} />
+            </button>
           </div>
         )}
 

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Home, MessageCircle, Reply, X, Sparkles, Users, Settings2, FileText , LogOut, Menu} from 'lucide-react';
+import { Home, MessageCircle, Reply, X, Sparkles, Users, Settings2, FileText, Menu } from 'lucide-react';
 import EnhancedChatInput from '../components/EnhancedChatInput';
 import MessageBubble from '../components/MessageBubble';
 import ThinkingIndicator from '../components/ThinkingIndicator';
@@ -796,29 +796,20 @@ const handleNewChat = async (sessionId = null) => {
                   </div>
                 )}
                 
-                {/* Optional: Add header sign out button */}
-                <button 
-                  className="header-signout-btn"
-                  onClick={onSignOut}
-                  title="Sign Out"
-                >
-                  <LogOut size={16} />
-                </button>
-                
                 {/* Export Button */}
-                <ExportButton 
-                  hasMessages={hasConversationMessages} 
+                <ExportButton
+                  hasMessages={hasConversationMessages}
                   currentSessionId={currentSessionId}
                   authToken={authToken}
                 />
-                
+
                 {/* Provider Dropdown */}
-                <ProviderDropdown 
+                <ProviderDropdown
                   currentProvider={currentProvider}
                   onProviderChange={handleProviderSwitch}
                   isLoading={isProviderSwitching}
                 />
-                
+
                 {/* Theme Toggle */}
                 <ThemeToggle />
               </div>

--- a/phd-advisor-frontend/src/styles/Sidebar.css
+++ b/phd-advisor-frontend/src/styles/Sidebar.css
@@ -27,16 +27,18 @@
 
 /* Toggle Button - Matches User Menu Style */
 .sidebar-toggle {
-  padding: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: none;
   background: none;
   border-radius: 6px;
   cursor: pointer;
   color: var(--text-secondary, #6b7280);
   transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .sidebar-toggle:hover {
@@ -188,7 +190,12 @@
 }
 
 .user-menu-button {
-  padding: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: none;
   background: none;
   border-radius: 6px;
@@ -289,10 +296,43 @@
 
 /* Search Section */
 .sidebar-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-light, #e5e7eb);
   flex-shrink: 0;
   transition: all 0.3s ease;
+}
+
+.sidebar-search .search-container {
+  flex: 1;
+}
+
+.new-chat-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 8px;
+  background: #2663EB;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.new-chat-icon-btn:hover {
+  background: #1d4fc4;
+  transform: translateY(-1px);
+}
+
+.new-chat-icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .dark .sidebar-search {
@@ -637,26 +677,83 @@
 }
 
 .sidebar-canvas-btn {
+  position: relative;
+  overflow: hidden;
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: center;
+  gap: 10px;
   width: 100%;
-  padding: 12px 16px;
-  background: var(--feature-bg);
-  border: 1px solid var(--accent-primary);
-  border-radius: 8px;
-  color: var(--accent-primary);
+  padding: 13px 20px;
+  background: linear-gradient(180deg, #7B7BF0 0%, #5957E8 100%);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: #ffffff;
   cursor: pointer;
-  transition: all 0.2s ease;
-  margin-bottom: 8px;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  margin-top: 14px;
+  margin-bottom: 8px;
+  box-shadow:
+    0 0 32px -10px rgba(99, 102, 241, 0.45),
+    0 4px 14px -4px rgba(89, 87, 232, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  transition:
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.25s ease;
+}
+
+/* Sliding shimmer that sweeps across on hover */
+.sidebar-canvas-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.25) 50%,
+    transparent 100%
+  );
+  transition: left 0.6s ease;
+  pointer-events: none;
+}
+
+.sidebar-canvas-btn > * {
+  position: relative;
+  z-index: 1;
+}
+
+.sidebar-canvas-btn svg {
+  color: #ffffff;
+  flex-shrink: 0;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .sidebar-canvas-btn:hover {
-  background: var(--accent-primary);
-  color: white;
-  transform: translateY(-1px);
+  transform: translateY(-2px) scale(1.015);
+  background: linear-gradient(180deg, #8C8CF7 0%, #6663EE 100%);
+  box-shadow:
+    0 0 80px -8px rgba(124, 124, 240, 0.85),
+    0 12px 28px -6px rgba(89, 87, 232, 0.7),
+    inset 0 1px 0 rgba(255, 255, 255, 0.32);
+}
+
+.sidebar-canvas-btn:hover::before {
+  left: 100%;
+}
+
+.sidebar-canvas-btn:hover svg {
+  transform: rotate(-8deg) scale(1.1);
+}
+
+.sidebar-canvas-btn:active {
+  transform: translateY(0) scale(1);
+  transition-duration: 0.1s;
 }
 
 .sidebar.collapsed .sidebar-canvas-btn span {


### PR DESCRIPTION
# Description
- Sidebar: swap chevron toggle for PanelLeft, swap Plus for SquarePen on collapsed-state new-chat button.
- Sidebar: move "New Chat" out of the main column to an icon button next to search.
- Sidebar: restyle canvas button as a gradient pill with hover shimmer.
- Sidebar: tighten toggle/menu button sizing (32x32) for visual consistency.
- ChatPage header: remove the standalone sign-out button; sign-out lives in the sidebar user menu.

# Issues
- UI Changes from PR #53

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->