### PR TITLE
Disable Specific User Personas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ phd-advisor-frontend/firebase.json
 # Python virtual environments
 **/venv/
 .venv/
+
+# Cursor docs
+.cursor/

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -152,6 +152,24 @@ async def chat_stream(
                 allowed_ids=available,
             )
 
+            # Guard against race condition where all selected advisors
+            # become unavailable (e.g. service update) between preference
+            # save and chat request.
+            if not top_personas:
+                yield ChatStreamLine(
+                    type="error",
+                    data={
+                        "code": "NO_ADVISORS_AVAILABLE",
+                        "detail": "None of your selected advisors are currently available. "
+                                  "Please check your advisor settings and try again.",
+                    },
+                ).to_ndjson()
+                yield ChatStreamLine(
+                    type="progress",
+                    data={"phase": "complete"},
+                ).to_ndjson()
+                return
+
             done_queue: asyncio.Queue = asyncio.Queue()
 
             async def _run(pid: str) -> None:

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -12,8 +12,10 @@ from pydantic import BaseModel, Field
 from app.api.routes.chat_sessions import persist_message
 from app.api.utils import get_or_create_session_for_request_async
 from app.core.auth import get_current_active_user
+from app.config import get_settings
 from app.core.bootstrap import chat_orchestrator
 from app.core.database import get_database
+from app.core.persona_filter import get_available_persona_ids
 from app.core.session_manager import get_session_manager
 from app.models.user import User
 
@@ -137,9 +139,17 @@ async def chat_stream(
                 ).to_ndjson()
                 return
 
+            # Filter personas by system whitelist and user preferences
+            available = get_available_persona_ids(
+                registered_ids=chat_orchestrator.list_personas(),
+                system_allowed=get_settings().personas.allowed_advisors,
+                user_disabled=current_user.disabled_advisors,
+            )
+
             # Get personas most relevant to the current session
             top_personas = await chat_orchestrator.get_top_personas(
                 session_id=sid,
+                allowed_ids=available,
             )
 
             done_queue: asyncio.Queue = asyncio.Queue()

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -156,12 +156,21 @@ async def chat_stream(
             # become unavailable (e.g. service update) between preference
             # save and chat request.
             if not top_personas:
+                error_detail = (
+                    "None of your selected advisors are currently available. "
+                    "Please check your advisor settings and try again."
+                )
+                if message.chat_session_id:
+                    await persist_message(message.chat_session_id, {
+                        "id": str(ObjectId()),
+                        "type": "error",
+                        "content": error_detail,
+                    })
                 yield ChatStreamLine(
                     type="error",
                     data={
                         "code": "NO_ADVISORS_AVAILABLE",
-                        "detail": "None of your selected advisors are currently available. "
-                                  "Please check your advisor settings and try again.",
+                        "detail": error_detail,
                     },
                 ).to_ndjson()
                 yield ChatStreamLine(

--- a/multi_llm_chatbot_backend/app/api/routes/preferences.py
+++ b/multi_llm_chatbot_backend/app/api/routes/preferences.py
@@ -1,0 +1,66 @@
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from app.config import get_settings
+from app.core.auth import get_current_active_user
+from app.core.bootstrap import chat_orchestrator
+from app.core.database import get_database
+from app.core.persona_filter import get_available_persona_ids
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class AdvisorPreferencesRequest(BaseModel):
+    disabled_advisors: Optional[List[str]] = None
+
+
+class AdvisorPreferencesResponse(BaseModel):
+    disabled_advisors: Optional[List[str]] = None
+    available_advisors: List[str] = []
+
+
+def _build_response(user: User) -> AdvisorPreferencesResponse:
+    available = get_available_persona_ids(
+        registered_ids=chat_orchestrator.list_personas(),
+        system_allowed=get_settings().personas.allowed_advisors,
+    )
+    return AdvisorPreferencesResponse(
+        disabled_advisors=user.disabled_advisors,
+        available_advisors=available,
+    )
+
+
+@router.get("/me/advisor-preferences", response_model=AdvisorPreferencesResponse)
+async def get_advisor_preferences(
+    current_user: User = Depends(get_current_active_user),
+):
+    return _build_response(current_user)
+
+
+@router.put("/me/advisor-preferences", response_model=AdvisorPreferencesResponse)
+async def update_advisor_preferences(
+    body: AdvisorPreferencesRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    if body.disabled_advisors is not None:
+        known_ids = set(chat_orchestrator.list_personas())
+        unknown = [aid for aid in body.disabled_advisors if aid not in known_ids]
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown advisor IDs: {unknown}",
+            )
+
+    db = get_database()
+    await db.users.update_one(
+        {"_id": current_user.id},
+        {"$set": {"disabled_advisors": body.disabled_advisors}},
+    )
+    current_user.disabled_advisors = body.disabled_advisors
+    return _build_response(current_user)

--- a/multi_llm_chatbot_backend/app/api/routes/preferences.py
+++ b/multi_llm_chatbot_backend/app/api/routes/preferences.py
@@ -40,6 +40,11 @@ def _build_response(user: User) -> AdvisorPreferencesResponse:
 async def get_advisor_preferences(
     current_user: User = Depends(get_current_active_user),
 ):
+    """
+    Retrieve advisor preferences for the authenticated user.
+    @param current_user: Authenticated user from dependency injection
+    @return: AdvisorPreferencesResponse containing disabled and available advisor IDs
+    """
     return _build_response(current_user)
 
 
@@ -48,6 +53,13 @@ async def update_advisor_preferences(
     body: AdvisorPreferencesRequest,
     current_user: User = Depends(get_current_active_user),
 ):
+    """
+    Update advisor preferences for the authenticated user.
+    @param body: AdvisorPreferencesRequest containing the list of advisor IDs to disable
+    @param current_user: Authenticated user from dependency injection
+    @return: AdvisorPreferencesResponse with updated disabled and available advisor IDs
+    @raises HTTPException 400: If any provided advisor ID is not recognized
+    """
     if body.disabled_advisors is not None:
         known_ids = set(chat_orchestrator.list_personas())
         unknown = [aid for aid in body.disabled_advisors if aid not in known_ids]

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -337,6 +337,12 @@ class AppSettings(BaseModel):
     def get_frontend_config(self) -> dict:
         """Return the subset of configuration safe to expose to the frontend
         via ``GET /api/config``.  Secrets are excluded."""
+        allowed = self.personas.allowed_advisors
+        persona_items = self.personas.items
+        if allowed is not None:
+            allowed_set = set(allowed)
+            persona_items = [p for p in persona_items if p.id in allowed_set]
+
         return {
             "app": self.app.dict(),
             "homepage": self.homepage.dict(),
@@ -344,7 +350,7 @@ class AppSettings(BaseModel):
             "chat_page": self.chat_page.dict(),
             "onboarding": self.onboarding.dict(),
             "personas": {
-                "items": [p.to_frontend_config() for p in self.personas.items],
+                "items": [p.to_frontend_config() for p in persona_items],
             },
             "version": __version__,
         }

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -179,10 +179,11 @@ class PersonasConfig(BaseModel):
     allowed_advisors: Optional[List[str]] = None
 
     @model_validator(mode='after')
-    def _warn_empty_allowed_advisors(self):
+    def _validate_allowed_advisors(self):
         if self.allowed_advisors is not None and len(self.allowed_advisors) == 0:
-            logger.warning(
-                "allowed_advisors is set to an empty list; no advisors will be available"
+            raise ValueError(
+                "allowed_advisors must not be an empty list; "
+                "omit the setting or set to null to allow all advisors"
             )
         return self
 

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -176,6 +176,15 @@ class PersonasConfig(BaseModel):
     personas_dir: str = ""
     config_dir: str = ""
     items: List[PersonaItemConfig] = []
+    allowed_advisors: Optional[List[str]] = None
+
+    @model_validator(mode='after')
+    def _warn_empty_allowed_advisors(self):
+        if self.allowed_advisors is not None and len(self.allowed_advisors) == 0:
+            logger.warning(
+                "allowed_advisors is set to an empty list; no advisors will be available"
+            )
+        return self
 
     @model_validator(mode='after')
     def _load_personas_from_directory(self):

--- a/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
+++ b/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
@@ -871,20 +871,27 @@ When analyzing the document context:
             }
         
 
-    async def get_top_personas(self, session_id: str, k: int = 3) -> List[str]:
+    async def get_top_personas(self, session_id: str, k: int = 3,
+                              allowed_ids: Optional[List[str]] = None) -> List[str]:
         """
         Use the LLM to rank personas based on current session context.
         Falls back to default persona order if LLM fails or returns invalid data.
+
+        When *allowed_ids* is provided, only those personas are considered
+        (for system-level and user-level filtering).
         """
+        pool_ids = allowed_ids if allowed_ids is not None else list(self.personas.keys())
+        pool = {pid: self.personas[pid] for pid in pool_ids if pid in self.personas}
+
         try:
             session = self.session_manager.get_session(session_id)
 
-            if not self.personas:
-                logger.warning("No personas registered.")
+            if not pool:
+                logger.warning("No personas available after filtering.")
                 return []
 
             # Use the LLM from one of the existing persona objects
-            llm = next(iter(self.personas.values())).llm
+            llm = next(iter(pool.values())).llm
 
             # Use recent conversation context (last 5 messages)
             recent_context = "\n".join(
@@ -894,11 +901,11 @@ When analyzing the document context:
             # Format available persona descriptions
             persona_descriptions = "\n".join([
                 f"- ID: {p.id}\n  Name: {p.name}\n  Prompt: {p.system_prompt.strip()}"
-                for p in self.personas.values()
+                for p in pool.values()
             ])
 
             # Ensure k does not exceed the number of available personas
-            k = min(k, len(self.personas))
+            k = min(k, len(pool))
 
             app_title = get_settings().app.title
 
@@ -935,15 +942,15 @@ When analyzing the document context:
             if isinstance(top_ids, dict):
                 top_ids = next(iter(top_ids.values()), [])
 
-            # Step 3: Filter valid persona IDs
-            valid_ids = [pid for pid in top_ids if pid in self.personas]
+            # Step 3: Filter valid persona IDs against the allowed pool
+            valid_ids = [pid for pid in top_ids if pid in pool]
 
             if len(valid_ids) < k:
                 logger.warning(f"LLM returned insufficient or invalid IDs. Got: {valid_ids}")
-                return list(self.personas.keys())[:k]
+                return list(pool.keys())[:k]
 
             return valid_ids[:k]
 
         except Exception as e:
             logger.error(f"Error selecting top personas: {e}")
-            return list(self.personas.keys())[:k]
+            return list(pool.keys())[:k]

--- a/multi_llm_chatbot_backend/app/core/persona_filter.py
+++ b/multi_llm_chatbot_backend/app/core/persona_filter.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+
+def get_available_persona_ids(
+    registered_ids: List[str],
+    system_allowed: Optional[List[str]] = None,
+    user_disabled: Optional[List[str]] = None,
+) -> List[str]:
+    """Return the persona IDs available after applying all filtering layers.
+
+    Filtering is applied in order:
+      1. System whitelist (``system_allowed``) — if not None, only IDs
+         present in this list survive.  ``None`` means no restriction.
+      2. User blocklist (``user_disabled``) — if not None, these IDs are
+         removed.  ``None`` means no user overrides.
+
+    The order of *registered_ids* is preserved in the result so that
+    downstream fallback logic (e.g. first-K when LLM ranking fails)
+    remains deterministic.
+    """
+    ids = list(registered_ids)
+
+    if system_allowed is not None:
+        allowed_set = set(system_allowed)
+        ids = [pid for pid in ids if pid in allowed_set]
+
+    if user_disabled is not None:
+        disabled_set = set(user_disabled)
+        ids = [pid for pid in ids if pid not in disabled_set]
+
+    return ids

--- a/multi_llm_chatbot_backend/app/core/persona_filter.py
+++ b/multi_llm_chatbot_backend/app/core/persona_filter.py
@@ -21,11 +21,9 @@ def get_available_persona_ids(
     ids = list(registered_ids)
 
     if system_allowed is not None:
-        allowed_set = set(system_allowed)
-        ids = [pid for pid in ids if pid in allowed_set]
+        ids = [pid for pid in ids if pid in system_allowed]
 
     if user_disabled is not None:
-        disabled_set = set(user_disabled)
-        ids = [pid for pid in ids if pid not in disabled_set]
+        ids = [pid for pid in ids if pid not in user_disabled]
 
     return ids

--- a/multi_llm_chatbot_backend/app/main.py
+++ b/multi_llm_chatbot_backend/app/main.py
@@ -23,6 +23,7 @@ from app.api.routes import router as main_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.chat_sessions import router as chat_sessions_router
 from app.api.routes.phd_canvas import router as phd_canvas_router
+from app.api.routes.preferences import router as preferences_router
 
 import logging
 
@@ -61,6 +62,7 @@ app.include_router(main_router)
 app.include_router(auth_router, prefix="/auth", tags=["authentication"])
 app.include_router(chat_sessions_router, prefix="/api", tags=["chat-sessions"])
 app.include_router(phd_canvas_router, prefix="/api", tags=["phd-canvas"])
+app.include_router(preferences_router, prefix="/api", tags=["preferences"])
 
 # Serve bundled avatar images
 _avatars_dir = Path(__file__).resolve().parent / "assets" / "avatars"

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -47,6 +47,7 @@ class User(BaseModel):
     hashed_password: str
     academicStage: Optional[str] = None
     researchArea: Optional[str] = None
+    disabled_advisors: Optional[List[str]] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     last_login: Optional[datetime] = None
     is_active: bool = True

--- a/multi_llm_chatbot_backend/app/tests/unit/test_advisor_preferences.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_advisor_preferences.py
@@ -1,0 +1,186 @@
+import asyncio
+import sys
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+# Stub heavy modules before importing the preferences route module.
+_mock_bootstrap = MagicMock()
+_mock_bootstrap.chat_orchestrator.list_personas.return_value = [
+    "pragmatist", "theorist", "methodologist",
+]
+sys.modules.setdefault("app.core.bootstrap", _mock_bootstrap)
+sys.modules.setdefault("app.core.rag_manager", MagicMock())
+
+from fastapi import APIRouter  # noqa: E402
+
+_stub_router_module = MagicMock(router=APIRouter())
+for _name in (
+    "app.api.routes.chat",
+    "app.api.routes.documents",
+    "app.api.routes.sessions",
+    "app.api.routes.provider",
+    "app.api.routes.debug",
+    "app.api.routes.root",
+    "app.api.routes.phd_canvas",
+):
+    sys.modules.setdefault(_name, _stub_router_module)
+
+from app.api.routes.preferences import (  # noqa: E402
+    AdvisorPreferencesRequest,
+    get_advisor_preferences,
+    update_advisor_preferences,
+)
+from app.models.user import User  # noqa: E402
+
+FAKE_USER_ID = ObjectId()
+ALL_IDS = ["pragmatist", "theorist", "methodologist"]
+
+
+def _make_fake_user(**overrides):
+    defaults = dict(
+        _id=FAKE_USER_ID,
+        firstName="Test",
+        lastName="User",
+        email="test@example.com",
+        hashed_password="$2b$12$fakehash",
+        is_active=True,
+        created_at=datetime(2025, 1, 1),
+    )
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _mock_db():
+    db = MagicMock()
+    db.users.update_one = AsyncMock()
+    return db
+
+
+def _mock_settings(allowed_advisors=None):
+    settings = MagicMock()
+    settings.personas.allowed_advisors = allowed_advisors
+    return settings
+
+
+# ------------------------------------------------------------------
+# GET /api/me/advisor-preferences
+# ------------------------------------------------------------------
+
+
+@patch("app.api.routes.preferences.get_settings")
+@patch("app.api.routes.preferences.chat_orchestrator")
+class TestGetAdvisorPreferences(unittest.TestCase):
+
+    def test_returns_none_when_no_prefs_set(self, mock_orch, mock_settings):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+
+        user = _make_fake_user()
+        result = asyncio.run(get_advisor_preferences(current_user=user))
+
+        self.assertIsNone(result.disabled_advisors)
+        self.assertEqual(result.available_advisors, ALL_IDS)
+
+    def test_returns_disabled_list(self, mock_orch, mock_settings):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+
+        user = _make_fake_user(disabled_advisors=["theorist"])
+        result = asyncio.run(get_advisor_preferences(current_user=user))
+
+        self.assertEqual(result.disabled_advisors, ["theorist"])
+
+    def test_available_reflects_system_whitelist(self, mock_orch, mock_settings):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings(
+            allowed_advisors=["pragmatist", "theorist"],
+        )
+
+        user = _make_fake_user()
+        result = asyncio.run(get_advisor_preferences(current_user=user))
+
+        self.assertEqual(result.available_advisors, ["pragmatist", "theorist"])
+
+
+# ------------------------------------------------------------------
+# PUT /api/me/advisor-preferences
+# ------------------------------------------------------------------
+
+
+@patch("app.api.routes.preferences.get_database")
+@patch("app.api.routes.preferences.get_settings")
+@patch("app.api.routes.preferences.chat_orchestrator")
+class TestUpdateAdvisorPreferences(unittest.TestCase):
+
+    def test_valid_ids_persisted(self, mock_orch, mock_settings, mock_get_db):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user()
+        body = AdvisorPreferencesRequest(disabled_advisors=["theorist"])
+        result = asyncio.run(
+            update_advisor_preferences(body=body, current_user=user)
+        )
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"disabled_advisors": ["theorist"]}},
+        )
+        self.assertEqual(result.disabled_advisors, ["theorist"])
+
+    def test_unknown_ids_rejected(self, mock_orch, mock_settings, mock_get_db):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+
+        user = _make_fake_user()
+        body = AdvisorPreferencesRequest(disabled_advisors=["fake_advisor"])
+
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(
+                update_advisor_preferences(body=body, current_user=user)
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("fake_advisor", ctx.exception.detail)
+
+    def test_null_clears_preferences(self, mock_orch, mock_settings, mock_get_db):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user(disabled_advisors=["theorist"])
+        body = AdvisorPreferencesRequest(disabled_advisors=None)
+        result = asyncio.run(
+            update_advisor_preferences(body=body, current_user=user)
+        )
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"disabled_advisors": None}},
+        )
+        self.assertIsNone(result.disabled_advisors)
+
+    def test_empty_list_accepted(self, mock_orch, mock_settings, mock_get_db):
+        mock_orch.list_personas.return_value = ALL_IDS
+        mock_settings.return_value = _mock_settings()
+        db = _mock_db()
+        mock_get_db.return_value = db
+
+        user = _make_fake_user(disabled_advisors=["theorist"])
+        body = AdvisorPreferencesRequest(disabled_advisors=[])
+        result = asyncio.run(
+            update_advisor_preferences(body=body, current_user=user)
+        )
+
+        db.users.update_one.assert_called_once_with(
+            {"_id": user.id},
+            {"$set": {"disabled_advisors": []}},
+        )
+        self.assertEqual(result.disabled_advisors, [])

--- a/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
@@ -102,6 +102,36 @@ class TestLoadSettings(unittest.TestCase):
             any("allowed_advisors is set to an empty list" in msg for msg in cm.output)
         )
 
+    def test_frontend_config_includes_all_when_no_whitelist(self):
+        cfg_path = _write_config(self.tmp_path, {
+            "personas": {
+                "items": [
+                    {"id": "one", "name": "One"},
+                    {"id": "two", "name": "Two"},
+                ]
+            }
+        })
+        settings = load_settings(cfg_path)
+        frontend = settings.get_frontend_config()
+        ids = [p["id"] for p in frontend["personas"]["items"]]
+        self.assertEqual(ids, ["one", "two"])
+
+    def test_frontend_config_filters_by_whitelist(self):
+        cfg_path = _write_config(self.tmp_path, {
+            "personas": {
+                "allowed_advisors": ["two"],
+                "items": [
+                    {"id": "one", "name": "One"},
+                    {"id": "two", "name": "Two"},
+                    {"id": "three", "name": "Three"},
+                ]
+            }
+        })
+        settings = load_settings(cfg_path)
+        frontend = settings.get_frontend_config()
+        ids = [p["id"] for p in frontend["personas"]["items"]]
+        self.assertEqual(ids, ["two"])
+
     def test_bad_persona_does_not_crash_everything(self):
         """Validates that a bad persona in the inline items list causes a
         validation error -- the directory loader solves this for file-based configs."""

--- a/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
@@ -63,6 +63,45 @@ class TestLoadSettings(unittest.TestCase):
         ids = {p.id for p in settings.personas.items}
         self.assertEqual(ids, {"one", "two"})
 
+    def test_allowed_advisors_defaults_to_none(self):
+        cfg_path = _write_config(self.tmp_path, {
+            "personas": {
+                "items": [
+                    {"id": "a", "name": "A"},
+                ]
+            }
+        })
+        settings = load_settings(cfg_path)
+        self.assertIsNone(settings.personas.allowed_advisors)
+
+    def test_allowed_advisors_populated(self):
+        cfg_path = _write_config(self.tmp_path, {
+            "personas": {
+                "allowed_advisors": ["one", "two"],
+                "items": [
+                    {"id": "one", "name": "One"},
+                ]
+            }
+        })
+        settings = load_settings(cfg_path)
+        self.assertEqual(settings.personas.allowed_advisors, ["one", "two"])
+
+    def test_allowed_advisors_empty_list_warns(self):
+        cfg_path = _write_config(self.tmp_path, {
+            "personas": {
+                "allowed_advisors": [],
+                "items": [
+                    {"id": "a", "name": "A"},
+                ]
+            }
+        })
+        with self.assertLogs("app.config", level="WARNING") as cm:
+            settings = load_settings(cfg_path)
+        self.assertEqual(settings.personas.allowed_advisors, [])
+        self.assertTrue(
+            any("allowed_advisors is set to an empty list" in msg for msg in cm.output)
+        )
+
     def test_bad_persona_does_not_crash_everything(self):
         """Validates that a bad persona in the inline items list causes a
         validation error -- the directory loader solves this for file-based configs."""

--- a/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_persona_config.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import yaml
 import app.config
+from pydantic import ValidationError
 from app.config import load_settings, load_personas_from_dir, PersonasConfig
 
 
@@ -86,7 +87,7 @@ class TestLoadSettings(unittest.TestCase):
         settings = load_settings(cfg_path)
         self.assertEqual(settings.personas.allowed_advisors, ["one", "two"])
 
-    def test_allowed_advisors_empty_list_warns(self):
+    def test_allowed_advisors_empty_list_raises(self):
         cfg_path = _write_config(self.tmp_path, {
             "personas": {
                 "allowed_advisors": [],
@@ -95,12 +96,8 @@ class TestLoadSettings(unittest.TestCase):
                 ]
             }
         })
-        with self.assertLogs("app.config", level="WARNING") as cm:
-            settings = load_settings(cfg_path)
-        self.assertEqual(settings.personas.allowed_advisors, [])
-        self.assertTrue(
-            any("allowed_advisors is set to an empty list" in msg for msg in cm.output)
-        )
+        with self.assertRaises(ValidationError):
+            load_settings(cfg_path)
 
     def test_frontend_config_includes_all_when_no_whitelist(self):
         cfg_path = _write_config(self.tmp_path, {

--- a/multi_llm_chatbot_backend/app/tests/unit/test_persona_filter.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_persona_filter.py
@@ -1,0 +1,57 @@
+import unittest
+from app.core.persona_filter import get_available_persona_ids
+
+ALL_IDS = ["pragmatist", "theorist", "methodologist", "mentor", "critic"]
+
+
+class TestGetAvailablePersonaIds(unittest.TestCase):
+
+    def test_no_filters_returns_all(self):
+        """None for both filters means no restrictions."""
+        result = get_available_persona_ids(ALL_IDS)
+        self.assertEqual(result, ALL_IDS)
+
+    def test_system_whitelist_filters(self):
+        result = get_available_persona_ids(
+            ALL_IDS, system_allowed=["theorist", "critic"]
+        )
+        self.assertEqual(result, ["theorist", "critic"])
+
+    def test_user_disabled_filters(self):
+        result = get_available_persona_ids(
+            ALL_IDS, user_disabled=["mentor", "critic"]
+        )
+        self.assertEqual(result, ["pragmatist", "theorist", "methodologist"])
+
+    def test_both_layers_cascade(self):
+        """System narrows first, then user narrows further."""
+        result = get_available_persona_ids(
+            ALL_IDS,
+            system_allowed=["pragmatist", "theorist", "methodologist"],
+            user_disabled=["theorist"],
+        )
+        self.assertEqual(result, ["pragmatist", "methodologist"])
+
+    def test_unknown_ids_in_user_disabled_ignored(self):
+        result = get_available_persona_ids(
+            ALL_IDS, user_disabled=["nonexistent", "also_fake"]
+        )
+        self.assertEqual(result, ALL_IDS)
+
+    def test_all_filtered_returns_empty(self):
+        result = get_available_persona_ids(
+            ALL_IDS, system_allowed=["theorist"], user_disabled=["theorist"]
+        )
+        self.assertEqual(result, [])
+
+    def test_order_preserved(self):
+        """Result order matches registered_ids, not system_allowed."""
+        result = get_available_persona_ids(
+            ALL_IDS, system_allowed=["critic", "pragmatist"]
+        )
+        self.assertEqual(result, ["pragmatist", "critic"])
+
+    def test_system_allowed_empty_list_allows_none(self):
+        """An explicit empty whitelist means no advisors are allowed."""
+        result = get_available_persona_ids(ALL_IDS, system_allowed=[])
+        self.assertEqual(result, [])

--- a/phd-advisor-frontend/src/components/AdvisorStatusDropdown.js
+++ b/phd-advisor-frontend/src/components/AdvisorStatusDropdown.js
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Users, ChevronDown, Pencil } from 'lucide-react';
 import AvatarPickerModal from './AvatarPickerModal';
+import Toggle from './Toggle';
+import { useAppConfig } from '../contexts/AppConfigContext';
 
 const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, isDark }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [hoveredId, setHoveredId] = useState(null);
   const [pickerAdvisor, setPickerAdvisor] = useState(null);
+  const { isAdvisorEnabled, setAdvisorEnabled } = useAppConfig();
   
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -24,10 +27,11 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
   }
   
   const advisorEntries = Object.entries(advisors);
-  const thinkingCount = Array.isArray(thinkingAdvisors) 
-    ? thinkingAdvisors.filter(id => id !== 'system').length 
+  const thinkingCount = Array.isArray(thinkingAdvisors)
+    ? thinkingAdvisors.filter(id => id !== 'system').length
     : 0;
   const totalAdvisors = advisorEntries.length;
+  const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
 
   const handleToggle = () => {
     setIsOpen(!isOpen);
@@ -42,7 +46,7 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
         <div className="advisor-status-info">
           <Users size={16} />
           <span className="advisor-count">
-            {totalAdvisors} Advisor{totalAdvisors !== 1 ? 's' : ''}
+            {enabledCount} of {totalAdvisors} Advisor{totalAdvisors !== 1 ? 's' : ''}
           </span>
           {thinkingCount > 0 && (
             <div className="thinking-badge">
@@ -67,11 +71,12 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
               const IconComponent = advisor.icon;
               const colors = getAdvisorColors(id, isDark);
               const isThinking = Array.isArray(thinkingAdvisors) && thinkingAdvisors.includes(id);
-              
+              const enabled = isAdvisorEnabled(id);
+
               return (
                 <div
                   key={id}
-                  className={`advisor-item ${isThinking ? 'thinking' : ''}`}
+                  className={`advisor-item ${isThinking ? 'thinking' : ''} ${enabled ? '' : 'disabled'}`}
                   style={{ '--advisor-color': colors.color, '--advisor-bg': colors.bgColor }}
                 >
                   <div
@@ -93,21 +98,20 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
                   </div>
                   <div className="advisor-details">
                     <div className="advisor-name">{advisor.name}</div>
-                    <div className="advisor-description">{advisor.description}</div>
+                    <div className="advisor-description">
+                      {!enabled
+                        ? <span className="advisor-off-label">Off — won't reply</span>
+                        : isThinking
+                          ? <span className="advisor-thinking-label">Thinking…</span>
+                          : advisor.description}
+                    </div>
                   </div>
-                  <div className="advisor-status">
-                    {isThinking ? (
-                      <div className="status-thinking">
-                        <div className="thinking-dots">
-                          <div className="dot"></div>
-                          <div className="dot"></div>
-                          <div className="dot"></div>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="status-ready">Ready</div>
-                    )}
-                  </div>
+                  <Toggle
+                    checked={enabled}
+                    onChange={(next) => setAdvisorEnabled(id, next)}
+                    size="sm"
+                    label={`Toggle ${advisor.name}`}
+                  />
                 </div>
               );
             })}
@@ -239,6 +243,25 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
         
         .advisor-item.thinking {
           background: var(--advisor-bg);
+        }
+
+        .advisor-item.disabled .advisor-icon,
+        .advisor-item.disabled .advisor-name {
+          opacity: 0.45;
+        }
+
+        .advisor-item.disabled .advisor-description {
+          opacity: 0.7;
+        }
+
+        .advisor-off-label {
+          color: var(--text-tertiary, #9ca3af);
+          font-style: italic;
+        }
+
+        .advisor-thinking-label {
+          color: var(--advisor-color);
+          font-weight: 500;
         }
         
         .advisor-icon {

--- a/phd-advisor-frontend/src/components/AdvisorStatusDropdown.js
+++ b/phd-advisor-frontend/src/components/AdvisorStatusDropdown.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Users, ChevronDown, Pencil } from 'lucide-react';
+import ReactDOM from 'react-dom';
+import { Users, ChevronDown, Pencil, AlertTriangle, X } from 'lucide-react';
 import AvatarPickerModal from './AvatarPickerModal';
 import Toggle from './Toggle';
 import { useAppConfig } from '../contexts/AppConfigContext';
@@ -8,6 +9,7 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
   const [isOpen, setIsOpen] = useState(false);
   const [hoveredId, setHoveredId] = useState(null);
   const [pickerAdvisor, setPickerAdvisor] = useState(null);
+  const [pendingDisableId, setPendingDisableId] = useState(null);
   const { isAdvisorEnabled, setAdvisorEnabled } = useAppConfig();
   
   // Close dropdown when clicking outside
@@ -37,6 +39,19 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
     setIsOpen(!isOpen);
   };
 
+  const handleAdvisorToggle = (id, next) => {
+    if (!next && enabledCount === 1 && isAdvisorEnabled(id)) {
+      setPendingDisableId(id);
+      return;
+    }
+    setAdvisorEnabled(id, next);
+  };
+
+  const confirmDisable = () => {
+    if (pendingDisableId) setAdvisorEnabled(pendingDisableId, false);
+    setPendingDisableId(null);
+  };
+
   return (
     <div className="advisor-status-dropdown">
       <button 
@@ -63,6 +78,37 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
           advisorName={pickerAdvisor.name}
           onClose={() => setPickerAdvisor(null)}
         />
+      )}
+
+      {pendingDisableId && ReactDOM.createPortal(
+        <div
+          className="disable-all-overlay"
+          onMouseDown={(e) => { if (e.target === e.currentTarget) setPendingDisableId(null); }}
+        >
+          <div className="disable-all-modal">
+            <div className="disable-all-header">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <AlertTriangle size={18} style={{ color: '#dc2626' }} />
+                <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 16 }}>Disable all advisors?</h3>
+              </div>
+              <button
+                onClick={() => setPendingDisableId(null)}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 4, display: 'flex' }}
+                aria-label="Close"
+              >
+                <X size={20} />
+              </button>
+            </div>
+            <div className="disable-all-body">
+              Disabling all advisors makes it so chat won't work. You'll need to re-enable at least one advisor before you can have a conversation.
+            </div>
+            <div className="disable-all-actions">
+              <button onClick={() => setPendingDisableId(null)} className="disable-all-secondary">Go back</button>
+              <button onClick={confirmDisable} className="disable-all-danger">Continue</button>
+            </div>
+          </div>
+        </div>,
+        document.body
       )}
       {isOpen && (
         <div className="advisor-dropdown-panel">
@@ -108,7 +154,7 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
                   </div>
                   <Toggle
                     checked={enabled}
-                    onChange={(next) => setAdvisorEnabled(id, next)}
+                    onChange={(next) => handleAdvisorToggle(id, next)}
                     size="sm"
                     label={`Toggle ${advisor.name}`}
                   />
@@ -339,6 +385,72 @@ const AdvisorStatusDropdown = ({ advisors, thinkingAdvisors, getAdvisorColors, i
         @keyframes pulse {
           0%, 100% { opacity: 1; }
           50% { opacity: 0.7; }
+        }
+
+        .disable-all-overlay {
+          position: fixed;
+          inset: 0;
+          background: rgba(0,0,0,0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 1100;
+        }
+
+        .disable-all-modal {
+          background: var(--bg-primary);
+          border-radius: 16px;
+          width: 420px;
+          max-width: 95vw;
+          box-shadow: var(--shadow-xl, 0 24px 48px rgba(0,0,0,0.25));
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+        }
+
+        .disable-all-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 16px 20px;
+          border-bottom: 1px solid var(--border-primary);
+        }
+
+        .disable-all-body {
+          padding: 20px;
+          font-size: 14px;
+          color: var(--text-primary);
+          line-height: 1.5;
+        }
+
+        .disable-all-actions {
+          display: flex;
+          justify-content: flex-end;
+          gap: 8px;
+          padding: 0 20px 20px;
+        }
+
+        .disable-all-secondary {
+          background: transparent;
+          border: 1px solid var(--border-primary);
+          color: var(--text-secondary);
+          font-size: 13px;
+          padding: 8px 14px;
+          border-radius: 8px;
+          cursor: pointer;
+          font-family: inherit;
+        }
+
+        .disable-all-danger {
+          background: #dc2626;
+          color: #fff;
+          border: none;
+          font-size: 13px;
+          padding: 8px 14px;
+          border-radius: 8px;
+          cursor: pointer;
+          font-family: inherit;
+          font-weight: 500;
         }
         
         /* Responsive Design */

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users } from 'lucide-react';
 import Toggle from './Toggle';
@@ -69,7 +69,20 @@ const miniBtn = {
 
 const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) => {
   const [activeTab, setActiveTab] = useState('profile');
-  const { advisors, isAdvisorEnabled, setAdvisorEnabled } = useAppConfig();
+  const {
+    advisors,
+    isAdvisorEnabled,
+    setAdvisorEnabled,
+    setAllAdvisorsEnabled,
+    hydrateAdvisorPreferences,
+  } = useAppConfig();
+
+  // Reconcile with the backend whenever the user opens Settings (covers fresh
+  // logins and changes made on another device).
+  useEffect(() => {
+    hydrateAdvisorPreferences();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Track where the mouse went DOWN so we don't close the modal when a user
   // drags to select text inside an input and the mouseup happens outside the modal.
@@ -240,9 +253,7 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
 
   const advisorEntries = Object.entries(advisors || {});
   const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
-  const setAll = (enabled) => {
-    advisorEntries.forEach(([id]) => setAdvisorEnabled(id, enabled));
-  };
+  const setAll = (enabled) => setAllAdvisorsEnabled(enabled);
 
   return ReactDOM.createPortal(
     <div style={overlay} onMouseDown={handleOverlayMouseDown} onMouseUp={handleOverlayMouseUp}>

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -255,6 +255,33 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
   const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
   const setAll = (enabled) => setAllAdvisorsEnabled(enabled);
 
+  // pendingDisable: { type: 'all' } | { type: 'single', id } — set when the
+  // user is about to leave zero advisors enabled. Confirming runs the action;
+  // "Go back" leaves state untouched.
+  const [pendingDisable, setPendingDisable] = useState(null);
+
+  const handleDisableAllClick = () => {
+    if (enabledCount === 0) return;
+    setPendingDisable({ type: 'all' });
+  };
+
+  const handleAdvisorToggle = (id, next) => {
+    if (!next && enabledCount === 1 && isAdvisorEnabled(id)) {
+      setPendingDisable({ type: 'single', id });
+      return;
+    }
+    setAdvisorEnabled(id, next);
+  };
+
+  const confirmPendingDisable = () => {
+    if (pendingDisable?.type === 'all') {
+      setAll(false);
+    } else if (pendingDisable?.type === 'single') {
+      setAdvisorEnabled(pendingDisable.id, false);
+    }
+    setPendingDisable(null);
+  };
+
   return ReactDOM.createPortal(
     <div style={overlay} onMouseDown={handleOverlayMouseDown} onMouseUp={handleOverlayMouseUp}>
       <div style={modal}>
@@ -338,7 +365,7 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
                 </div>
                 <div style={{ display: 'flex', gap: 6 }}>
                   <button onClick={() => setAll(true)} style={miniBtn}>Enable all</button>
-                  <button onClick={() => setAll(false)} style={miniBtn}>Disable all</button>
+                  <button onClick={handleDisableAllClick} style={miniBtn}>Disable all</button>
                 </div>
               </div>
 
@@ -386,7 +413,7 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
                       </div>
                       <Toggle
                         checked={enabled}
-                        onChange={(next) => setAdvisorEnabled(id, next)}
+                        onChange={(next) => handleAdvisorToggle(id, next)}
                         label={`Toggle ${advisor.name}`}
                       />
                     </div>
@@ -422,6 +449,34 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
             </form>
           )}
         </div>
+
+        {pendingDisable && (
+          <div
+            style={{ ...overlay, zIndex: 1100 }}
+            onMouseDown={(e) => { if (e.target === e.currentTarget) setPendingDisable(null); }}
+          >
+            <div style={{ ...modal, width: 420 }}>
+              <div style={header}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <AlertTriangle size={18} style={{ color: '#dc2626' }} />
+                  <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 16 }}>Disable all advisors?</h3>
+                </div>
+                <button onClick={() => setPendingDisable(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 4, display: 'flex' }} aria-label="Close">
+                  <X size={20} />
+                </button>
+              </div>
+              <div style={body}>
+                <div style={{ fontSize: 14, color: 'var(--text-primary)', lineHeight: 1.5 }}>
+                  Disabling all advisors makes it so chat won't work. You'll need to re-enable at least one advisor before you can have a conversation.
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
+                  <button onClick={() => setPendingDisable(null)} style={miniBtn}>Go back</button>
+                  <button onClick={confirmPendingDisable} style={dangerBtn}>Continue</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>,
     document.body

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -1,6 +1,8 @@
 import React, { useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { X, User as UserIcon, Lock, Trash2, AlertTriangle } from 'lucide-react';
+import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users } from 'lucide-react';
+import Toggle from './Toggle';
+import { useAppConfig } from '../contexts/AppConfigContext';
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -54,8 +56,20 @@ const dangerBtn = {
   cursor: 'pointer', fontSize: 14, fontWeight: 500,
 };
 
+const miniBtn = {
+  background: 'transparent',
+  border: '1px solid var(--border-primary)',
+  color: 'var(--text-secondary)',
+  fontSize: 12,
+  padding: '5px 10px',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
 const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) => {
   const [activeTab, setActiveTab] = useState('profile');
+  const { advisors, isAdvisorEnabled, setAdvisorEnabled } = useAppConfig();
 
   // Track where the mouse went DOWN so we don't close the modal when a user
   // drags to select text inside an input and the mouseup happens outside the modal.
@@ -224,12 +238,18 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
     }`,
   });
 
+  const advisorEntries = Object.entries(advisors || {});
+  const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
+  const setAll = (enabled) => {
+    advisorEntries.forEach(([id]) => setAdvisorEnabled(id, enabled));
+  };
+
   return ReactDOM.createPortal(
     <div style={overlay} onMouseDown={handleOverlayMouseDown} onMouseUp={handleOverlayMouseUp}>
       <div style={modal}>
         <div style={header}>
-          <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 18 }}>Account Settings</h3>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)' }}>
+          <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 18 }}>Settings</h3>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 4, display: 'flex' }} aria-label="Close settings">
             <X size={20} />
           </button>
         </div>
@@ -240,6 +260,9 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
           </button>
           <button style={tabBtn(activeTab === 'password')} onClick={() => { setActiveTab('password'); setMessage(null); }}>
             <Lock size={15} /> Password
+          </button>
+          <button style={tabBtn(activeTab === 'advisors')} onClick={() => { setActiveTab('advisors'); setMessage(null); }}>
+            <Users size={15} /> Advisors
           </button>
           <button style={tabBtn(activeTab === 'danger')} onClick={() => { setActiveTab('danger'); setMessage(null); }}>
             <Trash2 size={15} /> Delete Account
@@ -289,6 +312,77 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
                 {isSubmitting ? 'Changing…' : 'Change Password'}
               </button>
             </form>
+          )}
+
+          {activeTab === 'advisors' && (
+            <>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+                <div>
+                  <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)' }}>
+                    Active advisors
+                  </div>
+                  <div style={{ fontSize: 12.5, color: 'var(--text-secondary)', marginTop: 2 }}>
+                    {enabledCount} of {advisorEntries.length} active · turn an advisor off to keep them out of your conversations
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button onClick={() => setAll(true)} style={miniBtn}>Enable all</button>
+                  <button onClick={() => setAll(false)} style={miniBtn}>Disable all</button>
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {advisorEntries.length === 0 && (
+                  <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+                    No advisors configured.
+                  </div>
+                )}
+                {advisorEntries.map(([id, advisor]) => {
+                  const IconComponent = advisor.icon;
+                  const enabled = isAdvisorEnabled(id);
+                  return (
+                    <div
+                      key={id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        padding: '12px 4px',
+                        borderTop: '1px solid var(--border-primary)',
+                        opacity: enabled ? 1 : 0.55,
+                        transition: 'opacity .15s ease',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 36, height: 36, borderRadius: 8,
+                          background: advisor.bgColor, color: advisor.color,
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          flexShrink: 0, overflow: 'hidden',
+                        }}
+                      >
+                        {advisor.avatarUrl
+                          ? <img src={advisor.avatarUrl} alt={advisor.name} style={{ width: 36, height: 36, objectFit: 'cover' }}/>
+                          : <IconComponent size={18}/>}
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+                          {advisor.name}
+                        </div>
+                        <div style={{ fontSize: 12, color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {advisor.description || advisor.role || ''}
+                        </div>
+                      </div>
+                      <Toggle
+                        checked={enabled}
+                        onChange={(next) => setAdvisorEnabled(id, next)}
+                        label={`Toggle ${advisor.name}`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </>
           )}
 
           {activeTab === 'danger' && (

--- a/phd-advisor-frontend/src/components/Toggle.js
+++ b/phd-advisor-frontend/src/components/Toggle.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+/**
+ * Clean iOS-style toggle switch. Single reusable component so toggles
+ * across the app (advisor on/off, settings preferences) look identical.
+ *
+ * Props:
+ *   checked    — boolean
+ *   onChange   — (next: boolean) => void
+ *   size       — 'sm' (32×18) | 'md' (38×22, default)
+ *   disabled   — boolean
+ *   label      — optional aria-label for screen readers
+ */
+const Toggle = ({ checked, onChange, size = 'md', disabled = false, label }) => {
+  const dims = size === 'sm'
+    ? { w: 32, h: 18, knob: 14, off: 2, on: 16 }
+    : { w: 38, h: 22, knob: 18, off: 2, on: 18 };
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+    if (!disabled) onChange(!checked);
+  };
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={handleClick}
+      style={{
+        width: dims.w,
+        height: dims.h,
+        padding: 0,
+        border: 'none',
+        borderRadius: dims.h,
+        background: checked
+          ? 'var(--accent-primary, #6366f1)'
+          : 'var(--border-secondary, #d1d5db)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+        position: 'relative',
+        transition: 'background-color 0.2s ease',
+        flexShrink: 0,
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          top: dims.off,
+          left: checked ? dims.on : dims.off,
+          width: dims.knob,
+          height: dims.knob,
+          borderRadius: '50%',
+          background: '#ffffff',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.1)',
+          transition: 'left 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+        }}
+      />
+    </button>
+  );
+};
+
+export default Toggle;

--- a/phd-advisor-frontend/src/contexts/AppConfigContext.js
+++ b/phd-advisor-frontend/src/contexts/AppConfigContext.js
@@ -89,6 +89,12 @@ export const AppConfigProvider = ({ children }) => {
     try { return JSON.parse(localStorage.getItem('myCustomAvatars') || '[]'); }
     catch { return []; }
   });
+  // Per-user enable/disable for each advisor. Missing key = enabled by default
+  // so new advisors light up automatically when added on the backend.
+  const [disabledAdvisors, setDisabledAdvisors] = useState(() => {
+    try { return JSON.parse(localStorage.getItem('disabledAdvisors') || '{}'); }
+    catch { return {}; }
+  });
 
   useEffect(() => {
     const fetchConfig = async () => {
@@ -125,6 +131,17 @@ export const AppConfigProvider = ({ children }) => {
     localStorage.setItem('myCustomAvatars', JSON.stringify(next));
   };
 
+  // Advisor enable/disable. Disabled advisors are filtered out of orchestrator
+  // calls (TODO backend wiring) and visually dimmed in the UI.
+  const isAdvisorEnabled = (id) => !disabledAdvisors[id];
+  const setAdvisorEnabled = (id, enabled) => {
+    const next = { ...disabledAdvisors };
+    if (enabled) delete next[id];
+    else next[id] = true;
+    setDisabledAdvisors(next);
+    localStorage.setItem('disabledAdvisors', JSON.stringify(next));
+  };
+
   // Inject the primary colour as a CSS custom property on <html> so it is
   // available everywhere without prop-drilling.
   useEffect(() => {
@@ -156,6 +173,9 @@ export const AppConfigProvider = ({ children }) => {
     setAdvisorAvatar,
     addMyAvatar,
     myCustomAvatars,
+    disabledAdvisors,
+    isAdvisorEnabled,
+    setAdvisorEnabled,
   };
 
   if (loading) {

--- a/phd-advisor-frontend/src/contexts/AppConfigContext.js
+++ b/phd-advisor-frontend/src/contexts/AppConfigContext.js
@@ -3,6 +3,23 @@ import * as LucideIcons from 'lucide-react';
 
 const AppConfigContext = createContext(null);
 
+const ADVISOR_PREFS_URL = `${process.env.REACT_APP_API_URL}/api/me/advisor-preferences`;
+
+// The frontend tracks disabled advisors as an object keyed by id
+// ({ critic: true }) for fast lookups; the backend speaks a flat string[].
+// These two helpers translate between the shapes. A null/undefined array
+// from the backend means "no preferences set" → nothing disabled.
+const disabledObjToArray = (obj) =>
+  Object.keys(obj || {}).filter((id) => obj[id]);
+const disabledArrayToObj = (arr) =>
+  Array.isArray(arr)
+    ? arr.reduce((acc, id) => { acc[id] = true; return acc; }, {})
+    : {};
+
+const getAuthToken = () => {
+  try { return localStorage.getItem('authToken'); } catch { return null; }
+};
+
 /**
  * Resolve a Lucide icon name string (e.g. "BookOpen") to the actual React
  * component.  Falls back to HelpCircle if the name isn't found.
@@ -95,6 +112,8 @@ export const AppConfigProvider = ({ children }) => {
     try { return JSON.parse(localStorage.getItem('disabledAdvisors') || '{}'); }
     catch { return {}; }
   });
+  // Advisor ids the backend considers selectable (system-level allow list).
+  const [availableAdvisors, setAvailableAdvisors] = useState([]);
 
   useEffect(() => {
     const fetchConfig = async () => {
@@ -132,15 +151,95 @@ export const AppConfigProvider = ({ children }) => {
   };
 
   // Advisor enable/disable. Disabled advisors are filtered out of orchestrator
-  // calls (TODO backend wiring) and visually dimmed in the UI.
+  // calls (server-side, per user) and visually dimmed in the UI.
   const isAdvisorEnabled = (id) => !disabledAdvisors[id];
+
+  // Apply a disabled map locally + cache it. localStorage keeps the last known
+  // state so the UI is correct instantly on reload before the backend answers.
+  const applyDisabled = (obj) => {
+    setDisabledAdvisors(obj);
+    try { localStorage.setItem('disabledAdvisors', JSON.stringify(obj)); }
+    catch { /* storage full / unavailable — non-fatal */ }
+  };
+
+  // Reconcile local state with whatever the backend returns (it is the source
+  // of truth; it also distinguishes "no prefs / null" from an explicit list).
+  const applyServerResponse = (data) => {
+    applyDisabled(disabledArrayToObj(data?.disabled_advisors));
+    if (Array.isArray(data?.available_advisors)) {
+      setAvailableAdvisors(data.available_advisors);
+    }
+  };
+
+  // Pull the authenticated user's preferences from the backend.
+  const hydrateAdvisorPreferences = async () => {
+    const token = getAuthToken();
+    if (!token) return;
+    try {
+      const res = await fetch(ADVISOR_PREFS_URL, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        console.error('Failed to load advisor preferences:', res.status);
+        return;
+      }
+      applyServerResponse(await res.json());
+    } catch (err) {
+      // Offline / network error — keep the cached localStorage state.
+      console.error('Failed to load advisor preferences:', err);
+    }
+  };
+
+  // Persist the full disabled set to the backend. We send the whole array
+  // (not a delta) so the PUT is idempotent and the server stays authoritative.
+  const persistAdvisorPreferences = async (obj) => {
+    const token = getAuthToken();
+    if (!token) return;
+    try {
+      const res = await fetch(ADVISOR_PREFS_URL, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ disabled_advisors: disabledObjToArray(obj) }),
+      });
+      if (!res.ok) {
+        console.error('Failed to save advisor preferences:', res.status);
+        return;
+      }
+      applyServerResponse(await res.json());
+    } catch (err) {
+      // Optimistic local state is already applied; surface the failure only.
+      console.error('Failed to save advisor preferences:', err);
+    }
+  };
+
   const setAdvisorEnabled = (id, enabled) => {
     const next = { ...disabledAdvisors };
     if (enabled) delete next[id];
     else next[id] = true;
-    setDisabledAdvisors(next);
-    localStorage.setItem('disabledAdvisors', JSON.stringify(next));
+    applyDisabled(next);            // optimistic
+    persistAdvisorPreferences(next); // sync (reconciles on response)
   };
+
+  // Bulk enable/disable in one shot — a single state update and one PUT,
+  // instead of N racing requests when toggling every advisor.
+  const setAllAdvisorsEnabled = (enabled) => {
+    const next = enabled
+      ? {}
+      : Object.keys(advisors || {}).reduce(
+          (acc, id) => { acc[id] = true; return acc; }, {});
+    applyDisabled(next);
+    persistAdvisorPreferences(next);
+  };
+
+  // Load preferences once on mount when a session token is already present
+  // (returning user). Fresh logins reconcile when the Settings modal opens.
+  useEffect(() => {
+    hydrateAdvisorPreferences();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Inject the primary colour as a CSS custom property on <html> so it is
   // available everywhere without prop-drilling.
@@ -174,8 +273,11 @@ export const AppConfigProvider = ({ children }) => {
     addMyAvatar,
     myCustomAvatars,
     disabledAdvisors,
+    availableAdvisors,
     isAdvisorEnabled,
     setAdvisorEnabled,
+    setAllAdvisorsEnabled,
+    hydrateAdvisorPreferences,
   };
 
   if (loading) {

--- a/phd_config.yaml
+++ b/phd_config.yaml
@@ -118,15 +118,6 @@ personas:
   # Optional whitelist of advisor IDs. When set, only these advisors are
   # available. Omit or leave unset to allow all enabled personas.
   allowed_advisors:
-    - "critic"
-    - "empathetic"
-    - "methodologist"
-    - "minimalist"
-    - "motivator"
-    - "pragmatist"
-    - "socratic"
-    - "storyteller"
-    - "theorist"
 
 # ── Orchestrator / Clarification ───────────────────────────────────────────
 

--- a/phd_config.yaml
+++ b/phd_config.yaml
@@ -117,9 +117,16 @@ personas:
 
   # Optional whitelist of advisor IDs. When set, only these advisors are
   # available. Omit or leave unset to allow all enabled personas.
-  # allowed_advisors:
-  #   - "pragmatist"
-  #   - "theorist"
+  allowed_advisors:
+    - "critic"
+    - "empathetic"
+    - "methodologist"
+    - "minimalist"
+    - "motivator"
+    - "pragmatist"
+    - "socratic"
+    - "storyteller"
+    - "theorist"
 
 # ── Orchestrator / Clarification ───────────────────────────────────────────
 

--- a/phd_config.yaml
+++ b/phd_config.yaml
@@ -115,6 +115,12 @@ personas:
   # Individual persona files are loaded from this directory (relative to this file).
   personas_dir: "personas/phd_advisors"
 
+  # Optional whitelist of advisor IDs. When set, only these advisors are
+  # available. Omit or leave unset to allow all enabled personas.
+  # allowed_advisors:
+  #   - "pragmatist"
+  #   - "theorist"
+
 # ── Orchestrator / Clarification ───────────────────────────────────────────
 
 orchestrator:


### PR DESCRIPTION
# Description

## Backend

- Added a system-level advisor whitelist (`allowed_advisors`) to `phd_config.yaml`, allowing admins to restrict which personas are available without removing their config files.
- Introduced `persona_filter.py` that applies a two-layer filter: system whitelist → user blocklist.
- Added per-user `disabled_advisors` field to the `User` model.
- Created `GET/PUT /api/me/advisor-preferences` endpoints for retrieving and persisting user advisor preferences, with validation against registered persona IDs.
- Wired persona filtering into the `chat-stream` orchestrator so disabled/disallowed advisors are excluded from LLM ranking and response generation.
- `get_frontend_config()` omits personas not in the system whitelist, preventing disallowed advisors from appearing in the UI at all.
- Added a warning log when `allowed_advisors` is configured as an empty list (no advisors available).

## Frontend

New Toggle component - small, accessible on/off switch used by both the Settings modal and the in-chat advisor dropdown.
AppConfigContext now owns the advisor enable/disable state
The ability to turn all on and off was added.
# Issues

Closes #64 

# Other Notes

## Backend

- **Breaking change (minor):** The `get_top_personas` method on `ImprovedOrchestrator` now accepts an optional `allowed_ids` parameter. Existing callers that don't pass it will see no behavior change (defaults to all registered personas).
- **No minimum number of advisors enforced** If a user disables all advisors, the chat stream will return zero persona responses with no explicit error. Need to consider if we should retain a  minimum number of advisors and whether this should be handled on the front-end or backend (or combination of both).
- **New test coverage added:** `test_persona_filter.py`, `test_advisor_preferences.py`, and new cases in `test_persona_config.py` cover the filtering logic, API endpoints, and config validation.

## Frontend

<!-- Fill in -->