### PR TITLE
Canvas PR: 3 Documents Page Created

### DIFF
--- a/phd-advisor-frontend/package-lock.json
+++ b/phd-advisor-frontend/package-lock.json
@@ -8,16 +8,22 @@
       "name": "phd-advisor-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/legacy-modes": "^6.5.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "@uiw/react-codemirror": "^4.25.9",
+        "katex": "^0.16.45",
+        "latex.js": "^0.12.6",
         "lucide-react": "^0.544.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "react-scripts": "5.0.1",
+        "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -2068,6 +2074,108 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.42.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
+      "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -2966,6 +3074,36 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3031,6 +3169,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3438,6 +3582,15 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -3797,6 +3950,12 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3865,16 +4024,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
-      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -4207,6 +4356,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
+      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
+      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -4377,6 +4579,15 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -5227,6 +5438,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5363,6 +5594,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -5746,6 +5986,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5839,6 +6088,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -5974,6 +6238,16 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -6087,6 +6361,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6486,13 +6766,6 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "license": "MIT"
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6773,6 +7046,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -6972,6 +7251,57 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8394,6 +8724,23 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -9017,6 +9364,125 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -9044,6 +9510,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -9051,6 +9533,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9341,6 +9840,28 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenation.de": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/hyphenation.de/-/hyphenation.de-0.2.1.tgz",
+      "integrity": "sha512-s6Y4TFA8xWjRLneOPI6HV/+wzfm2c2yurTvFaXlznmsbeI6waZhMpxu94fSXGNGsrPxrzI1zTtYDEWeEeaANnw==",
+      "dependencies": {
+        "hypher": "*"
+      }
+    },
+    "node_modules/hyphenation.en-us": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/hyphenation.en-us/-/hyphenation.en-us-0.2.1.tgz",
+      "integrity": "sha512-ItXYgvIpfN8rfXl/GTBQC7DsSb5PPsKh9gGzViK/iWzCS5mvjDebFJ6xCcIYo8dal+nSp2rUzvTT7BosrKlL8A==",
+      "dependencies": {
+        "hypher": "*"
+      }
+    },
+    "node_modules/hypher": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/hypher/-/hypher-0.2.5.tgz",
+      "integrity": "sha512-kUTpuyzBWWDO2VakmjHC/cxesg4lKQP+Fdc+7lrK4yvjNjkV9vm5UTZMDAwOyyHTOpbkYrAMlNZHG61NnE9vYQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -9390,6 +9911,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/immer": {
@@ -11134,6 +11670,71 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.14.11",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.11.tgz",
+      "integrity": "sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.3",
+        "glob": "^10.3.3",
+        "nopt": "^7.2.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11312,6 +11913,22 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11364,6 +11981,27 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/latex.js": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/latex.js/-/latex.js-0.12.6.tgz",
+      "integrity": "sha512-spMTeSq9cP4vidMQuPgoYGKmsQTMElZhDtNF3NyLIRc03XkuuPvMA0tzb0ShS/otaIJrB7DIHDk0GL3knCisEw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "8.x",
+        "fs-extra": "10.x",
+        "hyphenation.de": "*",
+        "hyphenation.en-us": "*",
+        "js-beautify": "1.14.x",
+        "stdin": "*",
+        "svgdom": "^0.1.8"
+      },
+      "bin": {
+        "latex.js": "bin/latex.js"
+      },
+      "engines": {
+        "node": ">= 14.0"
       }
     },
     "node_modules/launch-editor": {
@@ -11756,6 +12394,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -12125,6 +12782,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -12746,6 +13422,21 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13107,6 +13798,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -14810,6 +15507,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14884,6 +15587,15 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -15451,6 +16163,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -15471,6 +16202,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -15678,6 +16425,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -16620,6 +17373,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stdin": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
+      "integrity": "sha512-2bacd1TXzqOEsqRa+eEWkRdOSznwptrs4gqFcpMq5tOtmJUGPZd10W5Lam6wQ4YQ/+qjQt4e9u35yXCF6mrlfQ=="
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -16929,6 +17687,12 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.17",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
@@ -17080,6 +17844,30 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "license": "MIT"
+    },
+    "node_modules/svgdom": {
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/svgdom/-/svgdom-0.1.23.tgz",
+      "integrity": "sha512-zTT8cz8rf07OCvRhTipJv+bt/MgL5Zm2ZF3IttK9zr/MKVDTrgo+usbDQMOK1PGzqDT7GA1SshnYlXvtafK7Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkit": "^2.0.4",
+        "image-size": "^1.2.1",
+        "sax": "^1.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Fuzzyma"
+      }
+    },
+    "node_modules/svgdom/node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/svgo": {
       "version": "1.3.2",
@@ -17420,6 +18208,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -17704,20 +18498,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -17779,6 +18559,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -17786,6 +18576,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unified": {
@@ -17831,6 +18631,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
@@ -17851,6 +18665,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -18070,6 +18898,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -18093,6 +18935,12 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -18135,6 +18983,16 @@
       "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-vitals": {

--- a/phd-advisor-frontend/package.json
+++ b/phd-advisor-frontend/package.json
@@ -3,16 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@codemirror/legacy-modes": "^6.5.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "@uiw/react-codemirror": "^4.25.9",
+    "katex": "^0.16.45",
+    "latex.js": "^0.12.6",
     "lucide-react": "^0.544.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-scripts": "5.0.1",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/phd-advisor-frontend/src/App.js
+++ b/phd-advisor-frontend/src/App.js
@@ -38,7 +38,10 @@ function App() {
     setCurrentView('auth');
   };
 
-  const navigateToCanvas = () => {
+  const navigateToCanvas = (canvasView) => {
+    if (['insights', 'workspace', 'deliverables'].includes(canvasView)) {
+      localStorage.setItem('canvas-view-v2', canvasView);
+    }
     setCurrentView('canvas');
   };
 
@@ -74,7 +77,9 @@ function App() {
         <div className="App">
           {currentView === 'home' && (
             <HomePage
+              onNavigateToHome={navigateToHome}
               onNavigateToChat={isAuthenticated ? navigateToChat : navigateToAuth}
+              onNavigateToCanvas={isAuthenticated ? navigateToCanvas : navigateToAuth}
               isAuthenticated={isAuthenticated}
             />
           )}
@@ -82,9 +87,10 @@ function App() {
             <AuthPage onAuthSuccess={handleAuthSuccess} />
           )}
           {currentView === 'canvas' && isAuthenticated && (
-            <CanvasPage 
+            <CanvasPage
               user={user}
               authToken={authToken}
+              onNavigateToHome={navigateToHome}
               onNavigateToChat={navigateToChat}
               onSignOut={handleSignOut}
             />

--- a/phd-advisor-frontend/src/components/AppHeader.js
+++ b/phd-advisor-frontend/src/components/AppHeader.js
@@ -70,6 +70,8 @@ const AppHeader = ({
         <div className="canvas-tabs chat-view-tabs">
           <button className={`tab ${isOnChat ? 'active' : ''}`} onClick={onNavigateToChat}>Chat</button>
           <button className={`tab ${tabActive('insights') ? 'active' : ''}`} onClick={() => goToCanvas('insights')}>Insights</button>
+          <button className={`tab ${tabActive('workspace') ? 'active' : ''}`} onClick={() => goToCanvas('workspace')}>Workspace</button>
+          <button className={`tab ${tabActive('deliverables') ? 'active' : ''}`} onClick={() => goToCanvas('deliverables')}>Documents</button>
         </div>
       )}
 
@@ -77,7 +79,7 @@ const AppHeader = ({
       {!isOnHome && (
         <select
           className="canvas-tabs-mobile"
-          value={isOnChat ? 'chat' : (canvasSub || 'insights')}
+          value={isOnChat ? 'chat' : (canvasSub || 'workspace')}
           onChange={(e) => {
             const v = e.target.value;
             if (v === 'chat') onNavigateToChat();
@@ -86,6 +88,8 @@ const AppHeader = ({
         >
           <option value="chat">Chat</option>
           <option value="insights">Insights</option>
+          <option value="workspace">Workspace</option>
+          <option value="deliverables">Documents</option>
         </select>
       )}
 

--- a/phd-advisor-frontend/src/components/AppHeader.js
+++ b/phd-advisor-frontend/src/components/AppHeader.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Home, Menu, Users } from 'lucide-react';
+import ThemeToggle from './ThemeToggle';
+import { useAppConfig } from '../contexts/AppConfigContext';
+
+/**
+ * Shared floating header used on every page so the app feels like one surface.
+ *
+ * Props:
+ *   currentPage: 'home' | 'chat' | 'canvas'
+ *   onNavigateToHome, onNavigateToChat, onNavigateToCanvas: navigation callbacks
+ *     (onNavigateToCanvas may receive 'insights' | 'workspace' to deep-link a view)
+ *   onMobileMenu?: () => void  — when present, shows the mobile menu button
+ *   children?: ReactNode        — extra controls slotted between the tabs and the theme toggle
+ */
+const AppHeader = ({
+  currentPage = 'home',
+  onNavigateToHome,
+  onNavigateToChat,
+  onNavigateToCanvas,
+  onMobileMenu,
+  children,
+}) => {
+  const { config, resolveIcon } = useAppConfig();
+  const BrandIcon = resolveIcon ? resolveIcon('Users') : Users;
+
+  const goToCanvas = (view) => {
+    if (onNavigateToCanvas) onNavigateToCanvas(view);
+  };
+
+  // Accept either 'canvas' (all canvas tabs highlight equally) or a more specific
+  // 'canvas-<subview>' from CanvasPage so only the active one highlights.
+  const isOnHome = currentPage === 'home';
+  const isOnChat = currentPage === 'chat';
+  const isOnCanvas = currentPage === 'canvas' || currentPage.startsWith('canvas-');
+  const canvasSub = currentPage.startsWith('canvas-') ? currentPage.slice(7) : null;
+  const tabActive = (sub) => isOnCanvas && (canvasSub === null ? false : canvasSub === sub);
+
+  return (
+    <header className="floating-header app-header">
+      <div className="header-left">
+        {onMobileMenu && (
+          <button className="mobile-menu-button" onClick={onMobileMenu}>
+            <Menu size={20} />
+          </button>
+        )}
+        <button
+          className="modern-home-btn"
+          onClick={onNavigateToHome}
+          title="Home"
+          disabled={isOnHome}
+          aria-disabled={isOnHome}
+        >
+          <Home size={20} />
+        </button>
+        <div className="header-brand">
+          <div className="brand-icon">
+            <BrandIcon size={24} />
+          </div>
+          <div className="brand-text">
+            <h1>{config?.app?.title || 'Advisory'}</h1>
+            <p>{config?.app?.subtitle || 'AI-Powered Guidance'}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Hide the view pill bar on the home page — home is a landing page,
+          not part of the chat ↔ canvas surface. */}
+      {!isOnHome && (
+        <div className="canvas-tabs chat-view-tabs">
+          <button className={`tab ${isOnChat ? 'active' : ''}`} onClick={onNavigateToChat}>Chat</button>
+          <button className={`tab ${tabActive('insights') ? 'active' : ''}`} onClick={() => goToCanvas('insights')}>Insights</button>
+        </div>
+      )}
+
+      {/* Compact mobile dropdown — appears in place of the pill bar at narrow widths */}
+      {!isOnHome && (
+        <select
+          className="canvas-tabs-mobile"
+          value={isOnChat ? 'chat' : (canvasSub || 'insights')}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === 'chat') onNavigateToChat();
+            else goToCanvas(v);
+          }}
+        >
+          <option value="chat">Chat</option>
+          <option value="insights">Insights</option>
+        </select>
+      )}
+
+      <div className="header-right">
+        {children}
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+};
+
+export default AppHeader;

--- a/phd-advisor-frontend/src/components/canvas/CanvasCriticWidgets.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasCriticWidgets.js
@@ -1,0 +1,430 @@
+import React, { useState } from 'react';
+import Icon from './CanvasIcon';
+
+const fireToast = (msg, kind = 'success') =>
+  window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg, kind } }));
+
+// Critic widgets are scripted in canvas; the *real* critique should happen in
+// the main chat so message history lives in one place (per Daniel's review).
+// "Open in chat" stashes a draft prompt + persona hint then asks CanvasPage to
+// navigate to chat — the chat page can read `canvas-chat-handoff` from localStorage.
+const handoffToChat = (persona, prompt, context = {}) => {
+  try {
+    localStorage.setItem('canvas-chat-handoff', JSON.stringify({
+      at: Date.now(), persona, prompt, ...context,
+    }));
+  } catch { /* ignore */ }
+  window.dispatchEvent(new CustomEvent('canvas-open-in-chat', { detail: { persona, prompt } }));
+  fireToast(`Opening ${persona} in chat — full history will be there.`);
+};
+
+// ---------- Reviewer 2 widget ----------
+export function Reviewer2Widget({ state, setState, openModal }) {
+  return (
+    <>
+      <div className="critic-prompt">
+        "Paste a draft paragraph, abstract, or section. I'll respond as the most uncharitable but technically competent reviewer your work will ever see."
+      </div>
+      {state.lastReview ? (
+        <div className="review">
+          <span className="review-tag">Last critique · {state.lastReview.severity}/10 severity</span>
+          <div style={{ marginBottom: 6 }}><strong>Major:</strong> {state.lastReview.major}</div>
+          <div style={{ color: 'var(--canvas-text-2)', fontSize: 12 }}>+{state.lastReview.minorCount} minor issues, {state.lastReview.suggestionCount} suggestions</div>
+        </div>
+      ) : (
+        <div style={{ fontSize: 11.5, color: 'var(--canvas-text-3)', fontStyle: 'italic', padding: '4px 2px' }}>
+          No drafts reviewed yet.
+        </div>
+      )}
+      <div className="critic-meter">
+        <span>tone</span>
+        <div className="bar"><i style={{ width: '92%' }}/></div>
+        <span style={{ color: 'var(--canvas-critic)' }}>harsh</span>
+      </div>
+      <div style={{ display: 'flex', gap: 6, alignSelf: 'flex-start' }}>
+        <button
+          className="btn btn-critic"
+          onClick={() => openModal('reviewer-2', {
+            initial: state.lastDraft,
+            onComplete: (review) => setState({ ...state, lastDraft: review.draft, lastReview: review }),
+          })}
+        >
+          <Icon name="gavel" size={13}/>Get critique
+        </button>
+        <button
+          className="btn"
+          title="Open Reviewer 2 in the main chat (history lives there)"
+          onClick={() => handoffToChat('Reviewer 2', state.lastDraft
+            ? `Critique this draft as Reviewer 2: "${state.lastDraft}"`
+            : 'Open Reviewer 2 and ready a critique.')}
+        >
+          <Icon name="message" size={13}/>Open in chat
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ---------- Devil's Advocate widget ----------
+export function DevilsAdvocateWidget({ state, setState, openModal }) {
+  return (
+    <>
+      <div style={{ fontSize: 11, color: 'var(--canvas-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600 }}>Your claim</div>
+      <div style={{ fontSize: 13, color: 'var(--canvas-text)', fontWeight: 500, lineHeight: 1.4, padding: '4px 0' }}>"{state.claim}"</div>
+      <div style={{ fontSize: 11, color: 'var(--canvas-critic)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginTop: 4 }}>
+        Strongest counters · {state.counters.length}
+      </div>
+      <div className="devil-list">
+        {state.counters.slice(0, 3).map((c, i) => (
+          <div key={i} className="devil-item">
+            <div className="lbl">{c.lbl}</div>
+            <div>{c.text}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 6, alignSelf: 'flex-start' }}>
+        <button
+          className="btn btn-critic"
+          onClick={() => openModal('devils-advocate', {
+            claim: state.claim,
+            counters: state.counters,
+            onUpdate: (next) => setState({ ...state, ...next }),
+          })}
+        >
+          <Icon name="scale" size={13}/>Push harder
+        </button>
+        <button
+          className="btn"
+          title="Open Devil's Advocate in the main chat (history lives there)"
+          onClick={() => handoffToChat("Devil's Advocate",
+            `Take the position of devil's advocate on my claim: "${state.claim || 'my current hypothesis'}". Be ruthless.`)}
+        >
+          <Icon name="message" size={13}/>Open in chat
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ---------- Scope realism widget ----------
+export function ScopeRealismWidget({ state, openModal }) {
+  return (
+    <div className="realism">
+      <div className="realism-verdict">
+        <div className="verdict-head">
+          <div className="verdict-score">{state.score.toFixed(1)}</div>
+          <div>
+            <div className="verdict-label">Feasibility</div>
+            <div style={{ fontSize: 12, color: 'var(--canvas-text-2)', marginTop: 2 }}>{state.label}</div>
+          </div>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--canvas-text-3)', fontFamily: 'var(--canvas-mono)' }}>
+          target: {state.target}
+        </div>
+      </div>
+      <div>
+        {state.factors.map(f => (
+          <div key={f.label} className="realism-row">
+            <span className="label-cell">{f.label}</span>
+            <span className="gauge"><i style={{ width: f.val + '%' }}/></span>
+            <span className="val">{f.val}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 6, alignSelf: 'flex-start' }}>
+        <button
+          className="btn btn-critic"
+          onClick={() => openModal('scope-realism', { state })}
+        >
+          <Icon name="bullseye" size={13}/>Read full verdict
+        </button>
+        <button
+          className="btn"
+          title="Open Scope Realism in the main chat (history lives there)"
+          onClick={() => handoffToChat('Scope Realism',
+            `Run a brutal feasibility check on my goal: "${state.target || 'my current research scope'}". Be specific about what's at risk.`)}
+        >
+          <Icon name="message" size={13}/>Open in chat
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ===================================================================
+// Critic modals
+// ===================================================================
+
+const REVIEW_TEMPLATES = [
+  {
+    severity: 8,
+    major: 'The hypothesis is presented before its operationalization. You write that L2/3 spiking "encodes" prediction error without specifying what spike-pattern feature you will measure (rate? latency? variance?), what range of values would count as "encoding," or what would falsify the claim.',
+    minor: [
+      'Sample size of n=4 animals is described as "preliminary" without a power calculation or a stopping rule.',
+      'GLM with history kernel is presented as the analysis but no mention of how its outputs map to the proposed predictive-coding interpretation.',
+      'No engagement with adaptation as a confound — the obvious alternative explanation for any oddball-driven decrease in firing.',
+      'Reference to "predictive coding" is loose. Rao & Ballard, Bastos, and Friston make different commitments. Which one are you testing?',
+    ],
+    suggestions: [
+      'Add a single sentence specifying the measurable signature you predict, with directionality.',
+      'Either control for arousal/pupil or acknowledge it as a limit upfront.',
+      'Add a stopping rule and target effect size before scaling beyond n=4.',
+    ],
+  },
+  {
+    severity: 7,
+    major: 'You claim the GLM analyses are "consistent with" the hypothesis. This phrase is doing too much work. Consistency with PE encoding is also consistency with at least three alternative explanations (adaptation, arousal, attention). Without a positive test that PE encoding predicts but the alternatives do not, "consistent with" is unfalsifiable.',
+    minor: [
+      'Mouse V1 is justified by convention rather than by what makes it the right model for this question.',
+      'No statement of what would change your mind.',
+      'Figure-free abstract for an empirical claim is a red flag for reviewers.',
+    ],
+    suggestions: [
+      'Replace "consistent with" with a specific signed prediction the data either matches or doesn\'t.',
+      'List 1-2 results that, if observed, would refute the hypothesis.',
+    ],
+  },
+  {
+    severity: 9,
+    major: 'This reads like an introduction, not an abstract. There is no result. There is no number. The strongest claim is that your "preliminary analyses are consistent" with your hypothesis — which is the lowest possible bar in empirical neuroscience. If the actual finding is interesting, lead with the finding, not with the framing.',
+    minor: [
+      'Word "preliminary" appears three times in three sentences. Cut two.',
+      '"Oddball stimulus paradigm" is jargon-without-citation; one sentence of definition or one citation, not zero.',
+      'No mention of layer-specificity, despite L2/3 being the core claim.',
+    ],
+    suggestions: [
+      'Lead sentence: "We find that <effect>" — even if the effect is small, name it.',
+      'Cut "we hypothesize that" entirely. Hypotheses go in the intro of the paper, not the abstract.',
+    ],
+  },
+];
+
+export function ReviewerModal({ data, onClose }) {
+  const [draft, setDraft] = useState(data.initial || '');
+  const [running, setRunning] = useState(false);
+  const [review, setReview] = useState(null);
+
+  const run = () => {
+    if (!draft.trim()) return;
+    setRunning(true);
+    setReview(null);
+    setTimeout(() => {
+      const idx = (draft.length + draft.split(' ').length) % REVIEW_TEMPLATES.length;
+      const r = REVIEW_TEMPLATES[idx];
+      setReview(r);
+      setRunning(false);
+    }, 900);
+  };
+
+  const accept = () => {
+    if (!review) return;
+    data.onComplete({
+      draft,
+      severity: review.severity,
+      major: review.major,
+      minorCount: review.minor.length,
+      suggestionCount: review.suggestions.length,
+    });
+    fireToast('Critique saved · severity ' + review.severity + '/10', 'critic');
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal huge" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon critic"><Icon name="gavel" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Reviewer 2 Simulator</div>
+          <div className="modal-sub">Paste a draft. Get the harshest competent peer review you'll ever read — before a real reviewer does.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-row">
+          <label className="label">Your draft</label>
+          <textarea
+            className="textarea"
+            style={{ minHeight: 120, fontFamily: 'var(--canvas-mono)', fontSize: 12.5 }}
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            placeholder="Paste an abstract, a claim, a paragraph…"
+          />
+          <div style={{ fontSize: 11, color: 'var(--canvas-text-3)', fontFamily: 'var(--canvas-mono)', textAlign: 'right' }}>{draft.length} chars · {draft.trim().split(/\s+/).filter(Boolean).length} words</div>
+        </div>
+
+        {!review && !running && (
+          <div style={{ marginTop: 16, padding: '12px 14px', background: 'var(--canvas-bg-2)', border: '1px dashed var(--canvas-border-2)', borderRadius: 8, fontSize: 12, color: 'var(--canvas-text-3)', lineHeight: 1.5 }}>
+            <strong style={{ color: 'var(--canvas-text-2)' }}>What this is:</strong> a simulated peer review tuned to push back hard. It will name unstated operationalizations, rival explanations, and weak phrasings. <span style={{ color: 'var(--canvas-text-4)' }}>It will not flatter you. That's the point.</span>
+          </div>
+        )}
+
+        {running && (
+          <div style={{ marginTop: 20, display: 'flex', alignItems: 'center', gap: 10, color: 'var(--canvas-text-2)' }}>
+            <div className="spinner critic"/>
+            <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 12 }}>parsing claims · finding rival hypotheses · drafting…</span>
+          </div>
+        )}
+
+        {review && (
+          <div style={{ marginTop: 18, display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div style={{
+                fontFamily: 'var(--canvas-mono)', fontSize: 22, fontWeight: 600,
+                color: 'var(--canvas-critic)', letterSpacing: '-0.02em',
+              }}>{review.severity}/10</div>
+              <div style={{ fontSize: 11, color: 'var(--canvas-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600 }}>severity</div>
+              <div style={{ flex: 1 }}/>
+              <div style={{ fontSize: 11, fontFamily: 'var(--canvas-mono)', color: 'var(--canvas-text-3)' }}>{review.minor.length} minor · {review.suggestions.length} suggestions</div>
+            </div>
+            <div className="review">
+              <span className="review-tag">Major issue</span>
+              {review.major}
+            </div>
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--canvas-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 6 }}>Minor issues</div>
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12.5, color: 'var(--canvas-text-2)', lineHeight: 1.55 }}>
+                {review.minor.map((m, i) => <li key={i} style={{ marginBottom: 4 }}>{m}</li>)}
+              </ul>
+            </div>
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--canvas-accent)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 6 }}>Suggestions</div>
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12.5, color: 'var(--canvas-text-2)', lineHeight: 1.55 }}>
+                {review.suggestions.map((s, i) => <li key={i} style={{ marginBottom: 4 }}>{s}</li>)}
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Close</button>
+        {review ? (
+          <>
+            <button className="btn" onClick={() => { setReview(null); }}>New critique</button>
+            <button className="btn btn-critic" onClick={accept}><Icon name="check" size={13}/>Save to widget</button>
+          </>
+        ) : (
+          <button className="btn btn-critic" onClick={run} disabled={!draft.trim() || running}>
+            <Icon name="gavel" size={13}/>{running ? 'Reviewing…' : 'Critique my draft'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const HARDER_COUNTERS = [
+  { lbl: 'Reverse causation', text: 'You assume PE drives spike changes. The opposite mapping — that some intrinsic cortical state drives both the spike pattern and the perceived "surprise" — is observationally indistinguishable in your design.' },
+  { lbl: 'Definition shift', text: 'You will be tempted, when results don\'t fit, to redefine "prediction error" until they do. Pre-register your operationalization or you cannot honestly claim to have tested PC.' },
+  { lbl: 'Wrong layer', text: 'Most predictive-coding accounts place PE signaling in L4 or L5b, not L2/3. Your prior for finding PE in L2/3 should be lower than you\'re writing.' },
+  { lbl: 'Mouse vs. theory', text: 'Predictive coding theories were built on primate visual hierarchies with rich top-down attention. Mouse V1 lacks several of the assumed circuits. You may be testing the theory on a substrate it doesn\'t apply to.' },
+];
+
+export function DevilsModal({ data, onClose }) {
+  const [counters, setCounters] = useState(data.counters);
+  const [pushing, setPushing] = useState(false);
+
+  const pushHarder = () => {
+    setPushing(true);
+    setTimeout(() => {
+      const next = HARDER_COUNTERS.find(c => !counters.find(x => x.lbl === c.lbl));
+      if (next) {
+        const nc = [...counters, next];
+        setCounters(nc);
+        data.onUpdate({ counters: nc });
+        fireToast('Stronger counter added: "' + next.lbl + '"', 'critic');
+      } else {
+        fireToast('No more counters — your hypothesis is more robust than I thought.');
+      }
+      setPushing(false);
+    }, 800);
+  };
+
+  return (
+    <div className="canvas-modal wide" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon critic"><Icon name="scale" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Devil's Advocate</div>
+          <div className="modal-sub">The strongest counter-arguments to your hypothesis, ranked by how much they should worry you.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div style={{ background: 'var(--canvas-bg-2)', border: '1px solid var(--canvas-border-2)', borderRadius: 9, padding: '12px 14px', marginBottom: 16 }}>
+          <div style={{ fontSize: 10.5, color: 'var(--canvas-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 4 }}>Your claim</div>
+          <div style={{ fontSize: 14, color: 'var(--canvas-text)', fontWeight: 500 }}>"{data.claim}"</div>
+        </div>
+        <div className="devil-list">
+          {counters.map((c, i) => (
+            <div key={i} className="devil-item" style={{ padding: '12px 14px 12px 36px' }}>
+              <div className="lbl">{c.lbl}</div>
+              <div style={{ fontSize: 13, lineHeight: 1.55 }}>{c.text}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Close</button>
+        <button className="btn btn-critic" onClick={pushHarder} disabled={pushing}>
+          {pushing ? <><div className="spinner critic"/>Thinking…</> : <><Icon name="zap" size={13}/>Push harder</>}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ScopeModal({ data, onClose }) {
+  const s = data.state;
+  return (
+    <div className="canvas-modal wide" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon critic"><Icon name="bullseye" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Scope Realism Check</div>
+          <div className="modal-sub">A brutal feasibility verdict on "{s.target}" given your current pace.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '14px 16px', background: 'var(--canvas-bg-2)', border: '1px solid rgba(232,100,184,0.3)', borderRadius: 10, marginBottom: 18 }}>
+          <div style={{ fontFamily: 'var(--canvas-mono)', fontSize: 36, fontWeight: 600, color: 'var(--canvas-critic)', letterSpacing: '-0.02em', lineHeight: 1 }}>{s.score.toFixed(1)}</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 10.5, color: 'var(--canvas-text-3)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600 }}>Verdict</div>
+            <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--canvas-text)', marginTop: 2 }}>{s.label}</div>
+            <div style={{ fontSize: 12, color: 'var(--canvas-text-3)', marginTop: 4 }}>5.0 = neither feasible nor infeasible · &lt;3 = unrealistic · &gt;7 = comfortable</div>
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          <div className="label" style={{ marginBottom: 8 }}>Factor breakdown</div>
+          {s.factors.map(f => (
+            <div key={f.label} className="realism-row" style={{ padding: '7px 0' }}>
+              <span className="label-cell" style={{ width: 140, fontSize: 12.5 }}>{f.label}</span>
+              <span className="gauge" style={{ height: 6 }}><i style={{ width: f.val + '%' }}/></span>
+              <span className="val" style={{ width: 36 }}>{f.val}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="review">
+          <span className="review-tag">The actual problem</span>
+          {s.notes}
+        </div>
+
+        <div style={{ marginTop: 16 }}>
+          <div className="label" style={{ marginBottom: 8 }}>Recommended actions</div>
+          <ul style={{ margin: 0, paddingLeft: 18, fontSize: 13, color: 'var(--canvas-text-2)', lineHeight: 1.6 }}>
+            <li><strong style={{ color: 'var(--canvas-text)' }}>Commit to a PC formulation by May 31.</strong> Theory clarity is your bottleneck, not data.</li>
+            <li>Build a writing buffer. Your 9-day streak is great; 90 days is the minimum to absorb the inevitable lab/family/health setbacks.</li>
+            <li>Cut a chapter. A 5-chapter dissertation that ships beats a 6-chapter one that doesn't.</li>
+            <li>Calibrate against your cohort: median time-to-defense in your program is 5.8 years. You are projecting 5.2.</li>
+          </ul>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Close</button>
+        <button className="btn btn-critic"><Icon name="zap" size={13}/>Re-run with new estimates</button>
+      </div>
+    </div>
+  );
+}

--- a/phd-advisor-frontend/src/components/canvas/CanvasDeliverables.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasDeliverables.js
@@ -1,0 +1,1328 @@
+// Deliverables view — multi-project PhD deliverable center.
+// Each "project" is a draft of a template (paper, slides, poster, CV, etc.).
+// You can keep many projects in flight, switch between them, version-rollback,
+// drag in citations from your Bibliography or arXiv, embed images, render math,
+// and export to Markdown / LaTeX / HTML / Print.
+// AI passes are stubbed (need LLM endpoint) but every static signal works today.
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import 'katex/dist/katex.min.css';
+import Icon from './CanvasIcon';
+import { MOD } from './platform';
+import LatexEditor from './CanvasLatexEditor';
+
+// Markdown plugins shared across all rendered blocks. remark-math + rehype-katex
+// give us real LaTeX math (`$...$` inline, `$$...$$` block) inside any preview.
+const REMARK_PLUGINS = [remarkGfm, remarkMath];
+const REHYPE_PLUGINS = [rehypeKatex];
+
+const fireToast = (msg, kind = 'success') =>
+  window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg, kind } }));
+
+const STORE_KEY = 'canvas-deliverables-v2';
+const MAX_VERSIONS = 10;
+const newId = (p) => p + Math.random().toString(36).slice(2, 8);
+
+// ============================================================================
+// Templates
+// ============================================================================
+export const TEMPLATES = [
+  {
+    id: 'research-paper',
+    name: 'Research Paper',
+    desc: 'Abstract → Introduction → Methods → Results → Discussion → References',
+    icon: 'book',
+    mode: 'paper',
+    sections: [
+      { id: 'abstract', name: 'Abstract', target: 250, hint: 'One paragraph: question, method, finding, implication.', checks: ['hasNumber', 'hasFinding'] },
+      { id: 'intro', name: 'Introduction', target: 1000, hint: 'Frame the problem, state the gap, name your contribution.', checks: ['hasGap', 'hasCitation'] },
+      { id: 'methods', name: 'Methods', target: 800, hint: 'Reproducibility-first: subjects, materials, procedure, analysis.', checks: ['hasCitation', 'hasNumber'] },
+      { id: 'results', name: 'Results', target: 800, hint: 'Lead with the effect. Numbers + figure refs. No interpretation here.', checks: ['hasNumber', 'hasFigure'] },
+      { id: 'discussion', name: 'Discussion', target: 1000, hint: 'What it means, what it doesn\'t, limits, future work.', checks: ['hasLimit', 'hasCitation'] },
+      { id: 'refs', name: 'References', target: 0, hint: 'Bibliography list. Drop @keys here from the Bibliography widget.', checks: [] },
+    ],
+  },
+  {
+    id: 'thesis-chapter',
+    name: 'Thesis Chapter',
+    desc: 'Standard chapter scaffolding for a dissertation.',
+    icon: 'book',
+    mode: 'paper',
+    sections: [
+      { id: 'overview', name: 'Overview', target: 200, hint: 'What this chapter does and why it\'s here.', checks: [] },
+      { id: 'background', name: 'Background', target: 1500, hint: 'Lit review focused on this chapter\'s question.', checks: ['hasCitation'] },
+      { id: 'methods', name: 'Methods', target: 1500, hint: 'Reproducibility-first.', checks: ['hasCitation', 'hasNumber'] },
+      { id: 'results', name: 'Results', target: 2000, hint: 'Findings + figures.', checks: ['hasFigure', 'hasNumber'] },
+      { id: 'discussion', name: 'Discussion', target: 1500, hint: 'How it fits the larger thesis.', checks: ['hasLimit'] },
+    ],
+  },
+  {
+    id: 'nsf-grfp',
+    name: 'NSF GRFP',
+    desc: 'Personal Statement (3 pages) + Research Plan (2 pages).',
+    icon: 'award',
+    mode: 'document',
+    sections: [
+      { id: 'personal', name: 'Personal Statement', target: 1500, hint: 'Background, experiences, broader impacts. Write as a story.', checks: ['hasBroaderImpacts'] },
+      { id: 'research', name: 'Research Plan', target: 1000, hint: 'Question, hypothesis, approach, intellectual merit.', checks: ['hasHypothesis', 'hasMerit'] },
+    ],
+  },
+  {
+    id: 'conference-abstract',
+    name: 'Conference Abstract',
+    desc: 'Single section, 250 words. Lead with the result.',
+    icon: 'send',
+    mode: 'document',
+    sections: [
+      { id: 'abs', name: 'Abstract', target: 250, hint: 'One paragraph. Lead with finding, end with implication.', checks: ['hasFinding', 'hasNumber'] },
+    ],
+  },
+  {
+    id: 'defense-slides',
+    name: 'Defense Slides',
+    desc: 'Title → Outline → Background → Question → Methods → Results → Discussion → Q&A',
+    icon: 'kanban',
+    mode: 'slides',
+    sections: [
+      { id: 'title', name: 'Title slide', target: 30, hint: 'Title, your name, advisor, date.', checks: [] },
+      { id: 'outline', name: 'Outline', target: 60, hint: '5–7 bullet points covering the talk arc.', checks: [] },
+      { id: 'background', name: 'Background', target: 200, hint: 'Just enough context to follow the question.', checks: ['hasCitation'] },
+      { id: 'question', name: 'Question', target: 80, hint: 'Single sentence, falsifiable.', checks: [] },
+      { id: 'methods', name: 'Methods', target: 200, hint: 'High-level. Save details for backup slides.', checks: ['hasNumber'] },
+      { id: 'results', name: 'Results', target: 300, hint: 'One slide per finding. Lead with the headline.', checks: ['hasFigure', 'hasNumber'] },
+      { id: 'discussion', name: 'Discussion', target: 200, hint: 'Implications + limits + next steps.', checks: ['hasLimit'] },
+      { id: 'qa', name: 'Anticipated Q&A', target: 300, hint: 'Hardest 5 questions and your answers.', checks: [] },
+    ],
+  },
+  {
+    id: 'poster',
+    name: 'Conference Poster',
+    desc: '4-quadrant scientific poster: Intro · Methods · Results · Discussion.',
+    icon: 'layout',
+    mode: 'poster',
+    sections: [
+      { id: 'title', name: 'Title & Authors', target: 30, hint: 'Title, your name, advisor, affiliation.', checks: [] },
+      { id: 'intro', name: 'Introduction', target: 200, hint: 'Question, gap, why-care.', checks: ['hasGap'] },
+      { id: 'methods', name: 'Methods', target: 200, hint: 'High-level: subjects, design, analysis.', checks: ['hasNumber'] },
+      { id: 'results', name: 'Results', target: 250, hint: 'Headline finding + 1–2 figures.', checks: ['hasFigure', 'hasNumber'] },
+      { id: 'discussion', name: 'Discussion', target: 200, hint: 'What it means + next steps.', checks: ['hasLimit'] },
+      { id: 'refs', name: 'References / Acks', target: 80, hint: '5–10 citations + funding + contact.', checks: ['hasCitation'] },
+    ],
+  },
+  {
+    id: 'cv',
+    name: 'Academic CV',
+    desc: 'Standard sections: Education · Pubs · Talks · Awards · Service · Skills.',
+    icon: 'user',
+    mode: 'document',
+    sections: [
+      { id: 'header', name: 'Header', target: 40, hint: 'Name, position, affiliation, contact.', checks: [] },
+      { id: 'education', name: 'Education', target: 100, hint: 'Most recent first. Degree · Year · Institution.', checks: [] },
+      { id: 'publications', name: 'Publications', target: 300, hint: 'Drop @keys from Bibliography. Group by type if needed.', checks: ['hasCitation'] },
+      { id: 'talks', name: 'Invited talks & posters', target: 150, hint: 'Title · Venue · Year.', checks: [] },
+      { id: 'awards', name: 'Awards & funding', target: 100, hint: 'Most recent first. Amount + year if applicable.', checks: [] },
+      { id: 'service', name: 'Service & teaching', target: 100, hint: 'Reviewing, mentorship, TA roles.', checks: [] },
+      { id: 'skills', name: 'Skills', target: 60, hint: 'Methods, languages, software.', checks: [] },
+    ],
+  },
+  {
+    id: 'cover-letter',
+    name: 'Cover Letter',
+    desc: 'For job applications, journal submissions, or postdoc inquiries.',
+    icon: 'send',
+    mode: 'document',
+    sections: [
+      { id: 'header', name: 'Header', target: 40, hint: 'Date, recipient, salutation.', checks: [] },
+      { id: 'opener', name: 'Opening paragraph', target: 100, hint: 'Why you\'re writing + the position/journal.', checks: [] },
+      { id: 'body', name: 'Why me', target: 250, hint: 'Specific achievements that match the call. Numbers > adjectives.', checks: ['hasNumber'] },
+      { id: 'fit', name: 'Why this place', target: 150, hint: 'What about this group / journal makes it the right fit.', checks: [] },
+      { id: 'close', name: 'Close', target: 60, hint: 'Thanks + next step + signature.', checks: [] },
+    ],
+  },
+  {
+    id: 'irb-protocol',
+    name: 'IRB Protocol',
+    desc: 'Standard sections for human-subjects research approval.',
+    icon: 'shield',
+    mode: 'document',
+    sections: [
+      { id: 'overview', name: 'Study overview', target: 200, hint: 'One-paragraph summary of purpose and procedures.', checks: [] },
+      { id: 'background', name: 'Background & significance', target: 400, hint: 'Why this study? What gap does it close?', checks: ['hasGap', 'hasCitation'] },
+      { id: 'aims', name: 'Specific aims & hypotheses', target: 250, hint: '2–3 aims. Each falsifiable.', checks: ['hasHypothesis'] },
+      { id: 'participants', name: 'Participants & recruitment', target: 300, hint: 'Inclusion/exclusion criteria, sample size, recruitment plan.', checks: ['hasNumber'] },
+      { id: 'procedures', name: 'Procedures', target: 500, hint: 'Step-by-step what subjects experience. Time burden in minutes.', checks: ['hasNumber'] },
+      { id: 'risks', name: 'Risks & mitigation', target: 200, hint: 'Anticipated risks (physical, psychological, privacy) + mitigations.', checks: ['hasLimit'] },
+      { id: 'benefits', name: 'Benefits', target: 100, hint: 'Direct + societal benefits. Be honest about minimal direct benefits.', checks: [] },
+      { id: 'consent', name: 'Consent process', target: 200, hint: 'Who consents, when, written or verbal, capacity considerations.', checks: [] },
+      { id: 'data', name: 'Data handling & confidentiality', target: 200, hint: 'Storage, access, identifiers, retention period.', checks: [] },
+    ],
+  },
+  {
+    id: 'meeting-prep',
+    name: 'Advisor Meeting Prep',
+    desc: 'Bring this to your 1:1 — agenda, updates, decisions needed, follow-ups.',
+    icon: 'message',
+    mode: 'document',
+    sections: [
+      { id: 'agenda', name: 'Agenda', target: 80, hint: '3–5 bullets ranked by priority.', checks: [] },
+      { id: 'progress', name: 'Progress since last meeting', target: 200, hint: 'What you actually did, with numbers when possible.', checks: ['hasNumber'] },
+      { id: 'blockers', name: 'Blockers', target: 150, hint: 'What you need from them to move forward.', checks: ['hasLimit'] },
+      { id: 'decisions', name: 'Decisions needed', target: 200, hint: 'Frame as A/B options with your recommendation.', checks: [] },
+      { id: 'questions', name: 'Questions', target: 150, hint: 'Open questions you genuinely want their take on.', checks: [] },
+      { id: 'followup', name: 'Action items (post-meeting)', target: 100, hint: 'Fill in during/after. Owner + due date for each.', checks: [] },
+    ],
+  },
+  {
+    id: 'dissertation-formatting',
+    name: 'Dissertation Formatting Checklist',
+    desc: 'Catch-everything pass before ProQuest submission.',
+    icon: 'shield',
+    mode: 'document',
+    sections: [
+      { id: 'frontmatter', name: 'Front matter', target: 0, hint: 'Title page, copyright, abstract, dedication, acknowledgements, ToC, list of figures/tables.', checks: [] },
+      { id: 'margins', name: 'Margins & spacing', target: 0, hint: 'Verify school requirements. Most: 1" margins, double-spaced body, single-spaced quotes/captions.', checks: ['hasNumber'] },
+      { id: 'fonts', name: 'Fonts & typography', target: 0, hint: 'One body font (Times/Garamond/Cambria) at 12pt. Captions 10–11pt. Headings consistent.', checks: ['hasNumber'] },
+      { id: 'pagenumbers', name: 'Page numbering', target: 0, hint: 'Roman for front matter, Arabic from Intro onward. Check section breaks.', checks: [] },
+      { id: 'figures', name: 'Figures & tables', target: 0, hint: 'Captions below figures, above tables. Numbered. Cited in text before they appear.', checks: ['hasFigure'] },
+      { id: 'citations', name: 'Citations & references', target: 0, hint: 'Consistent style throughout. Every cite has a reference; every reference is cited.', checks: ['hasCitation'] },
+      { id: 'appendices', name: 'Appendices', target: 0, hint: 'Lettered (A, B, C). Each cited in the body at least once.', checks: [] },
+      { id: 'proquest', name: 'ProQuest submission', target: 0, hint: 'PDF/A format, embedded fonts, no broken links, abstract under word limit.', checks: [] },
+    ],
+  },
+  {
+    id: 'faculty-hunt',
+    name: 'Faculty / Advisor Hunt',
+    desc: 'For prospective PhDs or finding committee members — research the people.',
+    icon: 'user',
+    mode: 'document',
+    sections: [
+      { id: 'criteria', name: 'What you\'re looking for', target: 150, hint: 'Research area, methodology, working style, mentorship reputation.', checks: [] },
+      { id: 'shortlist', name: 'Shortlist (5–10 names)', target: 400, hint: 'For each: name, institution, 2–3 representative papers, why they fit.', checks: ['hasCitation'] },
+      { id: 'pubs', name: 'Recent publications', target: 300, hint: 'What have they published in the last 2 years? Drop @keys from Bibliography.', checks: ['hasCitation'] },
+      { id: 'students', name: 'Current/recent students', target: 200, hint: 'Lab size, time-to-defense, where students go after.', checks: ['hasNumber'] },
+      { id: 'reachout', name: 'Outreach plan', target: 200, hint: 'When to email, what to send, who to mention.', checks: [] },
+      { id: 'notes', name: 'Conversation notes', target: 0, hint: 'After meetings/emails — vibes, fit signals, red flags.', checks: [] },
+    ],
+  },
+  {
+    id: 'research-statement',
+    name: 'Research Statement',
+    desc: 'For faculty applications: past work, current direction, future arc.',
+    icon: 'sparkles',
+    mode: 'document',
+    sections: [
+      { id: 'overview', name: 'Overview', target: 200, hint: 'One paragraph: your research identity in 2–3 sentences.', checks: [] },
+      { id: 'past', name: 'Past work', target: 600, hint: 'What you\'ve done. Lead with results, cite your own papers.', checks: ['hasCitation', 'hasFinding'] },
+      { id: 'current', name: 'Current direction', target: 400, hint: 'What you\'re working on now and why it matters.', checks: ['hasGap'] },
+      { id: 'future', name: 'Future research', target: 600, hint: '3–5 year arc. 1–2 funding-ready specific aims.', checks: ['hasHypothesis'] },
+      { id: 'broader', name: 'Broader impacts', target: 200, hint: 'Outreach, mentorship, what your group will look like.', checks: ['hasBroaderImpacts'] },
+    ],
+  },
+];
+
+// ============================================================================
+// Slash command catalog — typed at the start of a line in any section editor.
+// ============================================================================
+const SLASH_COMMANDS = [
+  { id: 'h2', label: 'Heading', kind: 'block', icon: 'list', insert: () => '## Heading\n' },
+  { id: 'h3', label: 'Subheading', kind: 'block', icon: 'list', insert: () => '### Subheading\n' },
+  { id: 'list', label: 'Bullet list', kind: 'block', icon: 'list', insert: () => '- ' },
+  { id: 'todo', label: 'To-do', kind: 'block', icon: 'task', insert: () => '- [ ] ' },
+  { id: 'numbered', label: 'Numbered list', kind: 'block', icon: 'list', insert: () => '1. ' },
+  { id: 'quote', label: 'Quote', kind: 'block', icon: 'cite', insert: () => '> ' },
+  { id: 'callout', label: 'Callout', kind: 'block', icon: 'sparkles', insert: () => '> [!note]\n> ' },
+  { id: 'divider', label: 'Divider', kind: 'block', icon: 'list', insert: () => '\n---\n\n' },
+  { id: 'code', label: 'Code block', kind: 'block', icon: 'flask', insert: () => '```\n\n```\n' },
+  { id: 'math', label: 'Equation', kind: 'block', icon: 'flask', insert: () => '$$\nE = mc^2\n$$\n' },
+  { id: 'inline-math', label: 'Inline equation', kind: 'inline', icon: 'flask', insert: () => '$x^2$' },
+  { id: 'image', label: 'Image (paste URL)', kind: 'block', icon: 'download', insert: () => '![caption](https://)' },
+  { id: 'cite', label: 'Citation @key', kind: 'inline', icon: 'book', insert: () => '(@key)' },
+  { id: 'bold', label: 'Bold', kind: 'inline', icon: 'pencil', insert: () => '**bold**' },
+  { id: 'italic', label: 'Italic', kind: 'inline', icon: 'pencil', insert: () => '*italic*' },
+];
+
+// ============================================================================
+// Static "missing" checks
+// ============================================================================
+const CHECKS = {
+  hasNumber: { test: (s) => /\d/.test(s), label: 'Mentions at least one number' },
+  hasCitation: { test: (s) => /@\w+/.test(s), label: 'Cites at least one source (@key)' },
+  hasFinding: { test: (s) => /\b(we (find|show|report|demonstrate)|finding|result)/i.test(s), label: 'States a finding' },
+  hasGap: { test: (s) => /\b(gap|lack|missing|unknown|unclear|despite)/i.test(s), label: 'Names a gap' },
+  hasFigure: { test: (s) => /\b(fig(ure)?|table)\.?\s*\d/i.test(s), label: 'References a figure or table' },
+  hasLimit: { test: (s) => /\b(limit|caveat|however|future work|did not|cannot)/i.test(s), label: 'Acknowledges a limit' },
+  hasBroaderImpacts: { test: (s) => /\b(broader impact|outreach|community|underrepresented|access|teaching)/i.test(s), label: 'Addresses broader impacts' },
+  hasHypothesis: { test: (s) => /\b(hypothes|predict|aim ?\d)/i.test(s), label: 'States a hypothesis or aim' },
+  hasMerit: { test: (s) => /\b(intellectual merit|novel|advances|contribut)/i.test(s), label: 'Frames intellectual merit' },
+};
+
+const wordCount = (s) => (s || '').trim().split(/\s+/).filter(Boolean).length;
+const readingMinutes = (n) => Math.max(1, Math.round(n / 220));
+
+// ============================================================================
+// Exporters
+// ============================================================================
+const exportMarkdown = (template, sections) => [
+  `# ${template.name}\n`,
+  ...template.sections.map(s => `## ${s.name}\n\n${sections[s.id] || ''}\n`),
+].join('\n');
+const exportLatex = (template, sections) => [
+  '\\documentclass{article}',
+  `\\title{${template.name}}`,
+  '\\begin{document}',
+  '\\maketitle',
+  ...template.sections.map(s => `\n\\section{${s.name}}\n${sections[s.id] || ''}\n`),
+  '\\end{document}',
+].join('\n');
+const exportHtml = (template, sections) => [
+  '<!doctype html>',
+  `<html><head><title>${template.name}</title></head><body>`,
+  `<h1>${template.name}</h1>`,
+  ...template.sections.map(s => `<section><h2>${s.name}</h2><p>${(sections[s.id] || '').replace(/\n/g, '<br>')}</p></section>`),
+  '</body></html>',
+].join('\n');
+const downloadFile = (filename, mime, contents) => {
+  const blob = new Blob([contents], { type: mime });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+};
+
+// ============================================================================
+// Project store — multi-project (was: single-template). Migrates v1 if found.
+// ============================================================================
+const loadStore = () => {
+  try {
+    const v2 = JSON.parse(localStorage.getItem(STORE_KEY) || 'null');
+    if (v2) return v2;
+    // Migrate v1: turn each templateId entry into a project.
+    const v1 = JSON.parse(localStorage.getItem('canvas-deliverables-v1') || '{}');
+    if (v1 && v1.templates) {
+      const projects = {};
+      let activeId;
+      Object.entries(v1.templates).forEach(([tid, sec]) => {
+        const id = newId('p-');
+        const { _aiNotes, ...rest } = sec;
+        projects[id] = {
+          id,
+          name: TEMPLATES.find(t => t.id === tid)?.name || tid,
+          templateId: tid,
+          sections: rest,
+          versions: [],
+          aiNotes: _aiNotes || null,
+          createdAt: Date.now(),
+        };
+        if (tid === v1.activeTemplateId) activeId = id;
+      });
+      return { activeProjectId: activeId, projects };
+    }
+  } catch { /* fallthrough */ }
+  return { activeProjectId: null, projects: {} };
+};
+
+// ============================================================================
+// Main view
+// ============================================================================
+const DeliverablesView = ({ allStates }) => {
+  const [store, setStore] = useState(loadStore);
+  useEffect(() => { localStorage.setItem(STORE_KEY, JSON.stringify(store)); }, [store]);
+
+  const project = store.projects[store.activeProjectId] || null;
+  const template = project ? TEMPLATES.find(t => t.id === project.templateId) : null;
+  const sections = project?.sections || {};
+  const [activeSectionId, setActiveSectionId] = useState(template?.sections[0]?.id);
+  const [generatingAi, setGeneratingAi] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Normalize active section when project/template changes
+  useEffect(() => {
+    if (!template) return;
+    const valid = template.sections.some(s => s.id === activeSectionId);
+    if (!valid) setActiveSectionId(template.sections[0].id);
+  }, [project?.id, template, activeSectionId]);
+
+  // ---------- Project ops ----------
+  const createProject = (templateId, name) => {
+    const id = newId('p-');
+    const t = TEMPLATES.find(x => x.id === templateId);
+    setStore(s => ({
+      activeProjectId: id,
+      projects: {
+        ...s.projects,
+        [id]: { id, name: name || `${t.name} draft`, templateId, sections: {}, versions: [], aiNotes: null, createdAt: Date.now() },
+      },
+    }));
+    fireToast(`New ${t.name} draft created`);
+  };
+  const switchProject = (id) => setStore(s => ({ ...s, activeProjectId: id }));
+  const renameProject = (name) => {
+    if (!project) return;
+    setStore(s => ({ ...s, projects: { ...s.projects, [project.id]: { ...s.projects[project.id], name } } }));
+  };
+  const deleteProject = () => {
+    if (!project) return;
+    if (!window.confirm(`Delete "${project.name}"? This can't be undone.`)) return;
+    setStore(s => {
+      const { [project.id]: _, ...rest } = s.projects;
+      const nextActive = Object.keys(rest)[0] || null;
+      return { activeProjectId: nextActive, projects: rest };
+    });
+  };
+  const closeProject = () => setStore(s => ({ ...s, activeProjectId: null }));
+
+  // ---------- Section ops + auto-versioning ----------
+  const updateSection = (id, value) => {
+    setStore(s => {
+      const proj = s.projects[project.id];
+      const oldText = proj.sections[id] || '';
+      // Snapshot a version every time a section gains/loses ≥80 chars (rough save cadence)
+      const shouldSnap = Math.abs(value.length - oldText.length) >= 80;
+      const newVersions = shouldSnap
+        ? [{ at: Date.now(), sectionId: id, snapshot: { ...proj.sections } }, ...proj.versions].slice(0, MAX_VERSIONS)
+        : proj.versions;
+      return {
+        ...s,
+        projects: {
+          ...s.projects,
+          [project.id]: { ...proj, sections: { ...proj.sections, [id]: value }, versions: newVersions },
+        },
+      };
+    });
+  };
+
+  const restoreVersion = (v) => {
+    if (!window.confirm('Restore this version? Current text will be replaced.')) return;
+    setStore(s => ({
+      ...s,
+      projects: { ...s.projects, [project.id]: { ...s.projects[project.id], sections: v.snapshot } },
+    }));
+    fireToast('Restored');
+  };
+
+  // ---------- AI pass (stub) ----------
+  // TODO(LLM): POST {project, sections, canvas} → {notes:[{sectionId,msg}]}
+  const runAiPass = () => {
+    setGeneratingAi(true);
+    setTimeout(() => {
+      const notes = template.sections.map(s => {
+        const text = sections[s.id] || '';
+        const wc = wordCount(text);
+        if (wc === 0) return { sectionId: s.id, msg: `Empty — start with: "${s.hint}"` };
+        if (wc < s.target * 0.3) return { sectionId: s.id, msg: `Thin (${wc} words). Target ${s.target}.` };
+        return { sectionId: s.id, msg: `Looks reasonable for length (${wc} words). LLM-pass would suggest specifics here.` };
+      });
+      setStore(s => ({ ...s, projects: { ...s.projects, [project.id]: { ...s.projects[project.id], aiNotes: notes } } }));
+      setGeneratingAi(false);
+      fireToast('AI pass complete (stub)');
+    }, 700);
+  };
+
+  // ---------- Insertables: Bibliography + Highlights + Outline + Drafts + arXiv search ----------
+  const localInsertables = useMemo(() => {
+    const items = [];
+    (allStates?.bibliography?.entries || []).forEach(e =>
+      items.push({ kind: 'cite', label: e.title, snippet: ` (${e.authors}, ${e.year}; @${e.key})` }));
+    (allStates?.highlights?.items || []).forEach(h =>
+      items.push({ kind: 'quote', label: h.text.slice(0, 60), snippet: `"${h.text}"${h.citeKey ? ` (@${h.citeKey})` : ''}` }));
+    (allStates?.outline?.items || []).forEach(o =>
+      items.push({ kind: 'outline', label: o.text || '(empty)', snippet: '\n' + '  '.repeat(o.depth) + '- ' + (o.text || '') }));
+    (allStates?.writing?.chapters || []).forEach(c =>
+      items.push({ kind: 'draft', label: c.name, snippet: c.draft || '' }));
+    return items;
+  }, [allStates]);
+
+  const insertIntoActive = (snippet) => {
+    if (!activeSectionId) return;
+    const cur = sections[activeSectionId] || '';
+    updateSection(activeSectionId, cur + (cur && !cur.endsWith('\n') ? ' ' : '') + snippet);
+    fireToast('Inserted into ' + template.sections.find(s => s.id === activeSectionId)?.name);
+  };
+
+  // ---------- Export ----------
+  const exportAs = (format) => {
+    const filename = `${project.name.replace(/\s+/g, '_')}.${format === 'latex' ? 'tex' : format === 'markdown' ? 'md' : 'html'}`;
+    const mime = format === 'html' ? 'text/html' : 'text/plain';
+    const contents = format === 'markdown' ? exportMarkdown(template, sections)
+      : format === 'latex' ? exportLatex(template, sections)
+      : exportHtml(template, sections);
+    downloadFile(filename, mime, contents);
+    fireToast(`Exported ${filename}`);
+  };
+
+  // ---------- Aggregates ----------
+  const totalWords = template ? template.sections.reduce((sum, s) => sum + wordCount(sections[s.id]), 0) : 0;
+  const totalTarget = template ? template.sections.reduce((sum, s) => sum + s.target, 0) : 0;
+  const projectList = Object.values(store.projects).sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+
+  // ---------- Empty state: project picker / template picker ----------
+  if (!project) {
+    return (
+      <>
+        <div className="page-header">
+          <div>
+            <h1 className="page-title">Documents</h1>
+            <div className="page-sub">
+              Your one-stop deliverable center. Drafts auto-save. Versions kept for rollback.
+              {projectList.length > 0 && ` · ${projectList.length} draft${projectList.length === 1 ? '' : 's'} in flight.`}
+            </div>
+          </div>
+        </div>
+
+        {/* Existing projects, if any */}
+        {projectList.length > 0 && (
+          <div className="canvas-presets" style={{ marginBottom: 24 }}>
+            <div className="canvas-presets-head">
+              <div className="canvas-presets-title">Continue working</div>
+              <div className="canvas-presets-sub">Drafts you've started.</div>
+            </div>
+            <div className="canvas-presets-grid">
+              {projectList.map(p => {
+                const t = TEMPLATES.find(t => t.id === p.templateId);
+                if (!t) return null;
+                const wc = t.sections.reduce((sum, s) => sum + wordCount(p.sections[s.id]), 0);
+                const target = t.sections.reduce((sum, s) => sum + s.target, 0);
+                return (
+                  <button key={p.id} className="canvas-preset-card" onClick={() => switchProject(p.id)}>
+                    <div className="canvas-preset-icon"><Icon name={t.icon} size={18}/></div>
+                    <div className="canvas-preset-content">
+                      <div className="canvas-preset-name">{p.name}</div>
+                      <div className="canvas-preset-desc">{t.name} · {wc}/{target} words</div>
+                      <div className="canvas-preset-meta">opened {new Date(p.createdAt).toLocaleDateString()}</div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Templates */}
+        <div className="canvas-presets">
+          <div className="canvas-presets-head">
+            <div className="canvas-presets-title">{projectList.length > 0 ? 'Or start a new draft' : 'Pick a template'}</div>
+            <div className="canvas-presets-sub">9 templates · paper, slides, poster, CV, cover letter, and more.</div>
+          </div>
+          <div className="canvas-presets-grid">
+            {TEMPLATES.map(t => (
+              <button key={t.id} className="canvas-preset-card" onClick={() => createProject(t.id)}>
+                <div className="canvas-preset-icon"><Icon name={t.icon} size={18}/></div>
+                <div className="canvas-preset-content">
+                  <div className="canvas-preset-name">{t.name}</div>
+                  <div className="canvas-preset-desc">{t.desc}</div>
+                  <div className="canvas-preset-meta">{t.sections.length} sections · {t.mode}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* TODO(LLM): "Upload project brief → AI generates a custom outline" */}
+        <div className="canvas-presets" style={{ marginTop: 18 }}>
+          <div className="canvas-presets-head">
+            <div className="canvas-presets-title">From a project brief</div>
+            <div className="canvas-presets-sub">Upload your brief and the AI will draft a custom outline. <em>(Needs LLM endpoint — coming soon.)</em></div>
+          </div>
+          <button className="btn" disabled title="Needs LLM endpoint">
+            <Icon name="download" size={13} style={{ transform: 'rotate(180deg)' }}/>Upload project brief
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  // ============================================================================
+  // Editor: project tabs + header + per-mode editor
+  // ============================================================================
+  const aiNotes = project.aiNotes;
+
+  const ProjectTabs = (
+    <div className="deliverable-projects">
+      {projectList.map(p => {
+        const t = TEMPLATES.find(x => x.id === p.templateId);
+        return (
+          <button
+            key={p.id}
+            className={`deliverable-project-tab ${p.id === project.id ? 'active' : ''}`}
+            onClick={() => switchProject(p.id)}
+            title={`${t?.name || ''} · ${wordCount(Object.values(p.sections || {}).join(' '))} words`}
+          >
+            <Icon name={t?.icon || 'book'} size={12}/>
+            <span>{p.name}</span>
+          </button>
+        );
+      })}
+      <details className="canvas-export-menu deliverable-new-project">
+        <summary className="deliverable-project-tab"><Icon name="plus" size={12}/>New</summary>
+        <div className="canvas-export-menu-list">
+          {TEMPLATES.map(t => (
+            <button key={t.id} onClick={() => createProject(t.id)}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                <Icon name={t.icon} size={12}/>{t.name}
+              </span>
+            </button>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+
+  const Header = (
+    <div className="page-header">
+      <div>
+        <button className="btn btn-ghost" style={{ padding: '4px 8px', fontSize: 12, marginBottom: 4, color: 'var(--canvas-text-3)' }} onClick={closeProject}>
+          <Icon name="back" size={12}/>All drafts
+        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <input
+            className="page-title page-title-editable"
+            value={project.name}
+            onChange={(e) => renameProject(e.target.value)}
+          />
+          <SaveIndicator project={project}/>
+        </div>
+        <div className="page-sub">
+          {template.name} · {totalWords} / {totalTarget} words · ~{readingMinutes(totalWords)} min read · {template.sections.length} {template.mode === 'slides' ? 'slides' : 'sections'}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        <button className="btn btn-ghost" onClick={() => setHistoryOpen(o => !o)} title="Version history">
+          <Icon name="reset" size={13}/>History · {project.versions.length}
+        </button>
+        <button className="btn btn-ghost" onClick={runAiPass} disabled={generatingAi} title="AI check (stub)">
+          {generatingAi ? <><div className="spinner"/></> : <Icon name="sparkles" size={13}/>}
+          AI check
+        </button>
+        <details className="canvas-export-menu">
+          <summary className="btn btn-primary"><Icon name="download" size={13}/>Export</summary>
+          <div className="canvas-export-menu-list">
+            <button onClick={() => exportAs('markdown')}>Markdown (.md)</button>
+            <button onClick={() => exportAs('latex')}>LaTeX (.tex)</button>
+            <button onClick={() => exportAs('html')}>HTML (.html)</button>
+            <button onClick={() => window.print()}>Print / Save as PDF</button>
+          </div>
+        </details>
+        <button className="btn btn-ghost" onClick={deleteProject} title="Delete this draft" style={{ color: 'var(--canvas-danger)' }}>
+          <Icon name="trash" size={13}/>
+        </button>
+      </div>
+    </div>
+  );
+
+  const HistoryPanel = historyOpen && (
+    <div className="deliverable-history">
+      <div className="deliverable-history-head">
+        <span>Version history · {project.versions.length}</span>
+        <button className="icon-btn" onClick={() => setHistoryOpen(false)}><Icon name="x" size={13}/></button>
+      </div>
+      {project.versions.length === 0 ? (
+        <div style={{ padding: 14, color: 'var(--canvas-text-3)', fontSize: 12 }}>
+          Snapshots auto-save every ~80 characters of edits.
+        </div>
+      ) : (
+        project.versions.map((v, i) => {
+          const sec = template.sections.find(s => s.id === v.sectionId);
+          return (
+            <button key={i} className="deliverable-history-row" onClick={() => restoreVersion(v)}>
+              <span className="tag-pill">{sec?.name || v.sectionId}</span>
+              <span style={{ flex: 1 }}>{new Date(v.at).toLocaleString()}</span>
+              <Icon name="reset" size={11} style={{ color: 'var(--canvas-text-3)' }}/>
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+
+  const InsertPanel = (
+    <div className="deliverable-insertables">
+      <ArxivSearch onPick={insertIntoActive}/>
+      <div style={{ fontSize: 11, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginTop: 14, marginBottom: 6 }}>
+        From canvas · {localInsertables.length}
+      </div>
+      {localInsertables.length === 0 && (
+        <div style={{ padding: 12, fontSize: 11.5, color: 'var(--canvas-text-3)', background: 'var(--canvas-surface)', border: '1px dashed var(--canvas-border-2)', borderRadius: 7 }}>
+          Add a Bibliography, Highlights, Outline, or Writing widget to your canvas to surface its content here.
+        </div>
+      )}
+      {localInsertables.map((it, i) => (
+        <button key={i} onClick={() => insertIntoActive(it.snippet)} className="canvas-insert-row">
+          <span className="tag-pill">{it.kind}</span>
+          <span style={{ flex: 1, fontSize: 11.5, color: 'var(--canvas-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{it.label}</span>
+          <Icon name="plus" size={12} style={{ color: 'var(--canvas-text-3)' }}/>
+        </button>
+      ))}
+    </div>
+  );
+
+  // ---------- POSTER MODE — 4-quadrant + 2 banner sections ----------
+  if (template.mode === 'poster') {
+    const layout = template.sections;
+    return (
+      <>
+        {ProjectTabs}
+        {Header}
+        {HistoryPanel}
+        <div className="poster-grid">
+          <div className="poster-banner">
+            <PosterPanel section={layout[0]} sections={sections} updateSection={updateSection}/>
+          </div>
+          <PosterPanel section={layout[1]} sections={sections} updateSection={updateSection}/>
+          <PosterPanel section={layout[2]} sections={sections} updateSection={updateSection}/>
+          <PosterPanel section={layout[3]} sections={sections} updateSection={updateSection}/>
+          <PosterPanel section={layout[4]} sections={sections} updateSection={updateSection}/>
+          <div className="poster-banner">
+            <PosterPanel section={layout[5]} sections={sections} updateSection={updateSection}/>
+          </div>
+        </div>
+        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
+          {InsertPanel}
+        </div>
+      </>
+    );
+  }
+
+  // ---------- SLIDES MODE — Google Slides feel ----------
+  if (template.mode === 'slides') {
+    const activeIdx = template.sections.findIndex(s => s.id === activeSectionId);
+    const active = template.sections[activeIdx] || template.sections[0];
+    const text = sections[active.id] || '';
+    const aiForSlide = aiNotes && aiNotes.find(n => n.sectionId === active.id);
+    const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
+
+    return (
+      <>
+        {ProjectTabs}
+        {Header}
+        {HistoryPanel}
+        <div className="deliverable-slides-grid">
+          <div className="slide-thumbs">
+            <div style={{ fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, padding: '0 4px 6px' }}>
+              {template.sections.length} slides
+            </div>
+            {template.sections.map((s, i) => {
+              const t = sections[s.id] || '';
+              const tLines = t.split(/\n+/).map(l => l.trim()).filter(Boolean);
+              return (
+                <button key={s.id}
+                  className={`slide-thumb ${s.id === active.id ? 'active' : ''}`}
+                  onClick={() => setActiveSectionId(s.id)}
+                  title={s.name}>
+                  <div className="slide-thumb-num">{i + 1}</div>
+                  <div className="slide-thumb-canvas">
+                    <div className="slide-thumb-title">{s.name}</div>
+                    <div className="slide-thumb-body">
+                      {tLines.slice(0, 3).map((l, j) => <div key={j}>• {l.slice(0, 30)}</div>)}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <div>
+            <div className="slide-canvas-wrap">
+              <div className="slide-canvas">
+                <div className="slide-canvas-title">{active.name}</div>
+                <div className="slide-canvas-body">
+                  {lines.length === 0 ? (
+                    <div className="slide-placeholder">{active.hint}</div>
+                  ) : lines.length === 1 ? (
+                    <div className="slide-paragraph">{lines[0]}</div>
+                  ) : (
+                    <ul>{lines.map((l, j) => <li key={j}>{l}</li>)}</ul>
+                  )}
+                </div>
+                <div className="slide-canvas-footer">{activeIdx + 1} / {template.sections.length}</div>
+              </div>
+            </div>
+            <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 11, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600 }}>
+                  Slide content
+                </span>
+                <span style={{ fontSize: 11, color: 'var(--canvas-text-3)' }}>· One bullet per line</span>
+                <span style={{ flex: 1 }}/>
+                <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 10, color: 'var(--canvas-text-3)' }}>
+                  {wordCount(text)}{active.target ? `/${active.target}` : ''} words
+                </span>
+              </div>
+              <SlashTextarea
+                value={text}
+                onChange={(v) => updateSection(active.id, v)}
+                placeholder={active.hint}
+                rows={6}
+              />
+              {(active.checks || []).length > 0 && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                  {active.checks.map(c => {
+                    const check = CHECKS[c];
+                    if (!check) return null;
+                    const passed = check.test(text);
+                    return (
+                      <span key={c} className="check-pill" data-passed={passed}>
+                        {passed ? <Icon name="check" size={10}/> : <span style={{ width: 10, height: 10, borderRadius: 2, border: '1px solid currentColor' }}/>}
+                        {check.label}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+              {aiForSlide && (
+                <div className="notion-callout">
+                  <Icon name="sparkles" size={14}/>
+                  <div>
+                    <div className="notion-callout-label">AI suggestion · stub</div>
+                    <div>{aiForSlide.msg}</div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          {InsertPanel}
+        </div>
+      </>
+    );
+  }
+
+  // ---------- PAPER / DOCUMENT MODE — Notion single-surface page ----------
+  const paperLike = template.mode === 'paper';
+
+  // For paper-mode projects: optional LaTeX editor (CodeMirror + LaTeX.js preview).
+  // Source stored as a single string at project.latexSource.
+  const editorMode = (paperLike && project.editorMode) || 'rich';
+  const setEditorMode = (next) => {
+    setStore(s => {
+      const proj = s.projects[project.id];
+      // First time switching to LaTeX, seed the source from current sections.
+      let nextLatex = proj.latexSource;
+      if (next === 'latex' && (!nextLatex || nextLatex.trim() === '')) {
+        nextLatex = template.sections.map(sec =>
+          `\\section{${sec.name}}\n${proj.sections[sec.id] || ''}\n`
+        ).join('\n');
+      }
+      return {
+        ...s,
+        projects: {
+          ...s.projects,
+          [project.id]: { ...proj, editorMode: next, latexSource: nextLatex },
+        },
+      };
+    });
+  };
+  const updateLatexSource = (src) => {
+    setStore(s => ({
+      ...s,
+      projects: { ...s.projects, [project.id]: { ...s.projects[project.id], latexSource: src } },
+    }));
+  };
+
+  if (paperLike && editorMode === 'latex') {
+    return (
+      <>
+        {ProjectTabs}
+        {Header}
+        {HistoryPanel}
+        <div className="paper-editor-toggle">
+          <span className="paper-editor-toggle-label">Editor</span>
+          <button className="active" onClick={() => setEditorMode('rich')} title="Switch to Notion-style rich editor">
+            LaTeX
+          </button>
+          <button onClick={() => setEditorMode('rich')}>Rich</button>
+        </div>
+        <LatexEditor
+          value={project.latexSource || ''}
+          onChange={updateLatexSource}
+          title={project.name}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {ProjectTabs}
+      {Header}
+      {HistoryPanel}
+      {paperLike && (
+        <div className="paper-editor-toggle">
+          <span className="paper-editor-toggle-label">Editor</span>
+          <button onClick={() => setEditorMode('latex')}>LaTeX</button>
+          <button className="active" onClick={() => setEditorMode('rich')}>Rich</button>
+        </div>
+      )}
+      <div className="notion-deliverable-grid">
+        <div className="notion-toc">
+          <div className="notion-toc-label">On this page</div>
+          {template.sections.map(s => {
+            const wc = wordCount(sections[s.id]);
+            return (
+              <button key={s.id}
+                className={`notion-toc-link ${activeSectionId === s.id ? 'active' : ''}`}
+                onClick={() => {
+                  setActiveSectionId(s.id);
+                  const el = document.getElementById(`notion-section-${s.id}`);
+                  if (el) el.scrollIntoView({ block: 'start', behavior: 'smooth' });
+                }}>
+                <span className="notion-toc-link-text">{s.name}</span>
+                {wc > 0 && <span className="notion-toc-link-count">{wc}</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className={`notion-page-wrap ${paperLike ? 'paper' : ''}`}>
+          <div className={`notion-page ${paperLike ? 'serif' : ''}`}>
+            <h1 className="notion-page-title">{project.name}</h1>
+            <div className="notion-page-meta">
+              {totalWords} words · ~{readingMinutes(totalWords)} min read · {template.sections.length} sections{paperLike ? ' · academic paper' : ''}
+            </div>
+            {template.sections.map(s => {
+              const text = sections[s.id] || '';
+              const aiForSection = aiNotes ? aiNotes.find(n => n.sectionId === s.id) : null;
+              return (
+                <div key={s.id} id={`notion-section-${s.id}`} className="notion-block">
+                  <h2 className={`notion-h2 ${paperLike ? 'serif' : ''}`}>{s.name}</h2>
+                  <RichBlock
+                    value={text}
+                    onChange={(v) => updateSection(s.id, v)}
+                    placeholder={`Start writing ${s.name.toLowerCase()}…`}
+                    hint={s.hint}
+                    serif={paperLike}
+                  />
+                  {(s.checks || []).length > 0 && (
+                    <div className="notion-block-meta">
+                      {s.checks.map(c => {
+                        const check = CHECKS[c];
+                        if (!check) return null;
+                        const passed = check.test(text);
+                        return (
+                          <span key={c} className="check-pill" data-passed={passed}>
+                            {passed ? <Icon name="check" size={10}/> : <span style={{ width: 10, height: 10, borderRadius: 2, border: '1px solid currentColor' }}/>}
+                            {check.label}
+                          </span>
+                        );
+                      })}
+                      {s.target > 0 && (
+                        <span className="check-pill" data-passed={wordCount(text) >= s.target * 0.7}>
+                          {wordCount(text)} / {s.target} words
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {aiForSection && (
+                    <div className="notion-callout">
+                      <Icon name="sparkles" size={14}/>
+                      <div>
+                        <div className="notion-callout-label">AI suggestion · stub</div>
+                        <div>{aiForSection.msg}</div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {InsertPanel}
+      </div>
+    </>
+  );
+};
+
+// ============================================================================
+// Auto-save indicator. Drafts persist to localStorage on every keystroke,
+// so we show a transient "Saving…" pill when the project changes, settling
+// to "Saved · Xs ago" while idle.
+// ============================================================================
+function SaveIndicator({ project }) {
+  const [savedAt, setSavedAt] = useState(Date.now());
+  const [pulse, setPulse] = useState(false);
+  const sectionsKey = JSON.stringify(project?.sections || {});
+  useEffect(() => {
+    setPulse(true);
+    const t1 = setTimeout(() => setPulse(false), 300);
+    const t2 = setTimeout(() => setSavedAt(Date.now()), 350);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, [sectionsKey]);
+
+  // Tick the relative-time string
+  const [, force] = useState(0);
+  useEffect(() => {
+    const i = setInterval(() => force(n => n + 1), 5000);
+    return () => clearInterval(i);
+  }, []);
+
+  const ago = (() => {
+    const d = Math.floor((Date.now() - savedAt) / 1000);
+    if (d < 5) return 'just now';
+    if (d < 60) return `${d}s ago`;
+    if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+    return `${Math.floor(d / 3600)}h ago`;
+  })();
+
+  return (
+    <span className={`save-indicator ${pulse ? 'saving' : ''}`}>
+      <span className="save-indicator-dot"/>
+      {pulse ? 'Saving…' : `Saved · ${ago}`}
+    </span>
+  );
+}
+
+// ============================================================================
+// RichBlock — Notion-style click-to-edit + Docs-style floating toolbar.
+//   • Idle: shows rendered markdown (with KaTeX math) — looks like a real doc
+//   • Click: switches to a textarea source view
+//   • While editing: floating toolbar above with Bold / Italic / H2 / list / link / cite / math
+//   • Slash commands still work via the underlying textarea
+// ============================================================================
+const wrap = (text, l, r = l) => `${l}${text || 'text'}${r}`;
+const lineWrap = (text, prefix) =>
+  (text ? text.split('\n').map(line => line ? `${prefix}${line}` : line).join('\n') : `${prefix}`);
+
+const TOOLBAR = [
+  { id: 'bold',     icon: 'pencil', label: `Bold (${MOD}+B)`,   run: (sel) => wrap(sel, '**') },
+  { id: 'italic',   icon: 'pencil', label: `Italic (${MOD}+I)`, run: (sel) => wrap(sel, '*') },
+  { id: 'code',     icon: 'flask',  label: 'Inline code',      run: (sel) => wrap(sel, '`') },
+  { id: 'h2',       icon: 'list',   label: 'Heading',          run: (sel) => `## ${sel || 'Heading'}` },
+  { id: 'h3',       icon: 'list',   label: 'Subheading',       run: (sel) => `### ${sel || 'Subheading'}` },
+  { id: 'list',     icon: 'list',   label: 'Bullet list',      run: (sel) => lineWrap(sel, '- ') },
+  { id: 'numbered', icon: 'list',   label: 'Numbered list',    run: (sel) => lineWrap(sel, '1. ') },
+  { id: 'quote',    icon: 'cite',   label: 'Block quote',      run: (sel) => lineWrap(sel, '> ') },
+  { id: 'link',     icon: 'link',   label: 'Link',             run: (sel) => `[${sel || 'link text'}](https://)` },
+  { id: 'cite',     icon: 'book',   label: 'Citation @key',    run: (sel) => `(@${sel || 'key'})` },
+  { id: 'math',     icon: 'flask',  label: 'Inline math (LaTeX)', run: (sel) => `$${sel || 'x^2'}$` },
+  { id: 'math-block', icon: 'flask', label: 'Math block',       run: (sel) => `\n$$\n${sel || 'E = mc^2'}\n$$\n` },
+];
+
+function RichBlock({ value, onChange, placeholder, serif, hint }) {
+  const [editing, setEditing] = useState(false);
+  const [slash, setSlash] = useState(null);
+  const taRef = useRef(null);
+  const containerRef = useRef(null);
+
+  // Auto-grow when editing
+  useEffect(() => {
+    if (!editing || !taRef.current) return;
+    taRef.current.style.height = 'auto';
+    taRef.current.style.height = taRef.current.scrollHeight + 'px';
+  }, [value, editing]);
+
+  // Click outside to leave edit mode
+  useEffect(() => {
+    if (!editing) return;
+    const onDocClick = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setEditing(false);
+        setSlash(null);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [editing]);
+
+  const applyToolbar = (cmd) => {
+    const ta = taRef.current;
+    if (!ta) return;
+    const { selectionStart: s, selectionEnd: e } = ta;
+    const before = value.slice(0, s);
+    const sel = value.slice(s, e);
+    const after = value.slice(e);
+    const replacement = cmd.run(sel);
+    const next = before + replacement + after;
+    onChange(next);
+    // Reposition cursor at end of inserted text
+    setTimeout(() => {
+      if (taRef.current) {
+        const pos = before.length + replacement.length;
+        taRef.current.setSelectionRange(pos, pos);
+        taRef.current.focus();
+      }
+    }, 0);
+  };
+
+  const onTextChange = (e) => {
+    const val = e.target.value;
+    const cursor = e.target.selectionStart;
+    onChange(val);
+    const before = val.slice(0, cursor);
+    const m = before.match(/(?:^|\n)(\/[\w-]*)$/);
+    if (m) {
+      const q = m[1].slice(1).toLowerCase();
+      const choices = SLASH_COMMANDS.filter(c => c.label.toLowerCase().includes(q) || c.id.includes(q)).slice(0, 8);
+      setSlash({ start: cursor - m[1].length, query: q, choices, idx: 0 });
+    } else {
+      setSlash(null);
+    }
+  };
+
+  const insertSlash = (cmd) => {
+    if (!slash) return;
+    const before = value.slice(0, slash.start);
+    const after = value.slice(slash.start + 1 + slash.query.length);
+    const inserted = cmd.insert();
+    onChange(before + inserted + after);
+    setSlash(null);
+    setTimeout(() => {
+      if (taRef.current) {
+        const pos = before.length + inserted.length;
+        taRef.current.setSelectionRange(pos, pos);
+        taRef.current.focus();
+      }
+    }, 0);
+  };
+
+  const onKeyDown = (e) => {
+    // ⌘B / ⌘I keyboard shortcuts (Word/Docs convention)
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey) {
+      if (e.key.toLowerCase() === 'b') { e.preventDefault(); applyToolbar(TOOLBAR.find(t => t.id === 'bold')); return; }
+      if (e.key.toLowerCase() === 'i') { e.preventDefault(); applyToolbar(TOOLBAR.find(t => t.id === 'italic')); return; }
+    }
+    if (slash && slash.choices.length > 0) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSlash(s => ({ ...s, idx: Math.min(s.choices.length - 1, s.idx + 1) })); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); setSlash(s => ({ ...s, idx: Math.max(0, s.idx - 1) })); }
+      else if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); insertSlash(slash.choices[slash.idx]); }
+      else if (e.key === 'Escape') setSlash(null);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="rich-block">
+      {/* Floating toolbar — only when actively editing */}
+      {editing && (
+        <div className="rich-toolbar" onMouseDown={(e) => e.preventDefault() /* keep textarea focused */}>
+          {TOOLBAR.map(t => (
+            <button key={t.id} title={t.label} onClick={() => applyToolbar(t)}>
+              {t.id === 'bold' && <strong>B</strong>}
+              {t.id === 'italic' && <em>I</em>}
+              {t.id === 'code' && <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11 }}>{'<>'}</span>}
+              {t.id === 'h2' && <span style={{ fontWeight: 700 }}>H2</span>}
+              {t.id === 'h3' && <span style={{ fontWeight: 700, fontSize: 11 }}>H3</span>}
+              {t.id === 'list' && '•'}
+              {t.id === 'numbered' && <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11 }}>1.</span>}
+              {t.id === 'quote' && '"'}
+              {t.id === 'link' && <Icon name="link" size={12}/>}
+              {t.id === 'cite' && '@'}
+              {t.id === 'math' && <span style={{ fontFamily: 'serif', fontStyle: 'italic' }}>x</span>}
+              {t.id === 'math-block' && <span style={{ fontFamily: 'serif' }}>∑</span>}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {editing ? (
+        <div style={{ position: 'relative' }}>
+          <textarea
+            ref={taRef}
+            className={`notion-text ${serif ? 'serif' : ''}`}
+            value={value}
+            onChange={onTextChange}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+            autoFocus
+            rows={1}
+          />
+          {slash && slash.choices.length > 0 && (
+            <div className="slash-menu">
+              <div className="slash-menu-head">Insert block</div>
+              {slash.choices.map((c, i) => (
+                <button key={c.id}
+                  onMouseEnter={() => setSlash(s => ({ ...s, idx: i }))}
+                  onClick={() => insertSlash(c)}
+                  className={i === slash.idx ? 'active' : ''}>
+                  <Icon name={c.icon} size={13}/>
+                  <span style={{ flex: 1 }}>{c.label}</span>
+                  <span className="slash-menu-kind">{c.kind}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          className={`rich-rendered ${serif ? 'serif' : ''}`}
+          onClick={() => setEditing(true)}
+          onFocus={() => setEditing(true)}
+          tabIndex={0}
+        >
+          {value ? (
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>{value}</ReactMarkdown>
+          ) : (
+            <span className="rich-placeholder">{hint || placeholder || 'Click to edit'}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// SlashTextarea — auto-grows; `/` opens a block-insert popover.
+// ============================================================================
+function SlashTextarea({ value, onChange, placeholder, serif, notion, rows = 1 }) {
+  const ref = useRef(null);
+  const [slash, setSlash] = useState(null); // { start, query, choices, idx }
+
+  useEffect(() => {
+    if (!ref.current || !notion) return;
+    ref.current.style.height = 'auto';
+    ref.current.style.height = ref.current.scrollHeight + 'px';
+  }, [value, notion]);
+
+  const onTextChange = (e) => {
+    const val = e.target.value;
+    const cursor = e.target.selectionStart;
+    onChange(val);
+    const before = val.slice(0, cursor);
+    const m = before.match(/(?:^|\n)(\/[\w-]*)$/);
+    if (m) {
+      const q = m[1].slice(1).toLowerCase();
+      const choices = SLASH_COMMANDS.filter(c => c.label.toLowerCase().includes(q) || c.id.includes(q)).slice(0, 8);
+      setSlash({ start: cursor - m[1].length, query: q, choices, idx: 0 });
+    } else {
+      setSlash(null);
+    }
+  };
+
+  const insertCmd = (cmd) => {
+    if (!slash) return;
+    const before = value.slice(0, slash.start);
+    const after = value.slice(slash.start + 1 + slash.query.length);
+    const inserted = cmd.insert();
+    onChange(before + inserted + after);
+    setSlash(null);
+    setTimeout(() => {
+      if (ref.current) {
+        const pos = before.length + inserted.length;
+        ref.current.setSelectionRange(pos, pos);
+        ref.current.focus();
+      }
+    }, 0);
+  };
+
+  const onKeyDown = (e) => {
+    if (!slash || slash.choices.length === 0) return;
+    if (e.key === 'ArrowDown') { e.preventDefault(); setSlash(s => ({ ...s, idx: Math.min(s.choices.length - 1, s.idx + 1) })); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setSlash(s => ({ ...s, idx: Math.max(0, s.idx - 1) })); }
+    if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); insertCmd(slash.choices[slash.idx]); }
+    if (e.key === 'Escape') setSlash(null);
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <textarea
+        ref={ref}
+        className={notion ? `notion-text ${serif ? 'serif' : ''}` : 'textarea'}
+        value={value}
+        onChange={onTextChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        style={notion ? undefined : { minHeight: 110, fontFamily: 'var(--canvas-sans)', fontSize: 13, lineHeight: 1.6 }}
+      />
+      {slash && slash.choices.length > 0 && (
+        <div className="slash-menu">
+          <div className="slash-menu-head">Insert block</div>
+          {slash.choices.map((c, i) => (
+            <button key={c.id}
+              onMouseEnter={() => setSlash(s => ({ ...s, idx: i }))}
+              onClick={() => insertCmd(c)}
+              className={i === slash.idx ? 'active' : ''}>
+              <Icon name={c.icon} size={13}/>
+              <span style={{ flex: 1 }}>{c.label}</span>
+              <span className="slash-menu-kind">{c.kind}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Poster panel — single-section block in the poster layout
+// ============================================================================
+function PosterPanel({ section, sections, updateSection }) {
+  if (!section) return null;
+  const text = sections[section.id] || '';
+  return (
+    <div className="poster-panel">
+      <div className="poster-panel-head">{section.name}</div>
+      <RichBlock
+        value={text}
+        onChange={(v) => updateSection(section.id, v)}
+        placeholder={section.hint}
+        hint={section.hint}
+      />
+    </div>
+  );
+}
+
+// ============================================================================
+// arXiv search — public ATOM API, CORS-enabled.
+// ============================================================================
+function ArxivSearch({ onPick }) {
+  const [q, setQ] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [results, setResults] = useState([]);
+
+  const search = async () => {
+    if (!q.trim()) return;
+    setBusy(true);
+    try {
+      const url = `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(q)}&max_results=5`;
+      const res = await fetch(url);
+      const xml = await res.text();
+      const doc = new DOMParser().parseFromString(xml, 'text/xml');
+      const entries = Array.from(doc.getElementsByTagName('entry')).map(e => {
+        const id = e.getElementsByTagName('id')[0]?.textContent?.split('/').pop() || '';
+        const title = e.getElementsByTagName('title')[0]?.textContent?.trim() || '';
+        const authors = Array.from(e.getElementsByTagName('author')).map(a => a.getElementsByTagName('name')[0]?.textContent?.trim()).filter(Boolean);
+        const year = (e.getElementsByTagName('published')[0]?.textContent || '').slice(0, 4);
+        return { id, title, authors, year };
+      });
+      setResults(entries);
+    } catch (e) {
+      fireToast('arXiv search failed', 'danger');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 6 }}>
+        Search arXiv
+      </div>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <input className="input" placeholder="Predictive coding…" value={q}
+          onChange={e => setQ(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') search(); }}
+          style={{ fontSize: 12, padding: '5px 8px' }}/>
+        <button className="icon-btn" onClick={search} disabled={!q.trim() || busy} title="Search arXiv">
+          {busy ? <div className="spinner"/> : <Icon name="search" size={13}/>}
+        </button>
+      </div>
+      {results.length > 0 && (
+        <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {results.map(r => {
+            const a = r.authors[0] ? r.authors[0].split(' ').pop() : 'Unknown';
+            const snippet = ` (${a}, ${r.year}; arXiv:${r.id})`;
+            return (
+              <button key={r.id} className="canvas-insert-row" onClick={() => onPick(snippet)}>
+                <span className="tag-pill">arXiv</span>
+                <span style={{ flex: 1, fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.title}>{r.title}</span>
+                <Icon name="plus" size={12} style={{ color: 'var(--canvas-text-3)' }}/>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DeliverablesView;

--- a/phd-advisor-frontend/src/components/canvas/CanvasIcon.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasIcon.js
@@ -1,0 +1,90 @@
+import React from 'react';
+
+const ICONS = {
+  sparkles: <><path d="M12 3l1.8 4.5L18 9l-4.2 1.5L12 15l-1.8-4.5L6 9l4.2-1.5z"/><path d="M19 14l.9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9z"/></>,
+  layout: <><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></>,
+  insights: <><path d="M3 3v18h18"/><path d="M7 14l3-3 3 3 5-5"/></>,
+  search: <><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></>,
+  bell: <><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></>,
+  settings: <><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></>,
+  plus: <path d="M12 5v14M5 12h14"/>,
+  x: <path d="M18 6L6 18M6 6l12 12"/>,
+  check: <path d="M20 6L9 17l-5-5"/>,
+  refresh: <><path d="M21 12a9 9 0 0 0-15-6.7L3 8"/><path d="M3 4v4h4"/><path d="M3 12a9 9 0 0 0 15 6.7l3-2.7"/><path d="M21 20v-4h-4"/></>,
+  trash: <><path d="M3 6h18"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></>,
+  grip: <><circle cx="9" cy="6" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="18" r="1"/></>,
+  more: <><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></>,
+  pin: <><path d="M12 17v5"/><path d="M9 11V3h6v8l3 3v2H6v-2l3-3z"/></>,
+  link: <><path d="M10 14a5 5 0 0 0 7 0l3-3a5 5 0 1 0-7-7l-1 1"/><path d="M14 10a5 5 0 0 0-7 0l-3 3a5 5 0 1 0 7 7l1-1"/></>,
+  message: <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>,
+  task: <><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M9 9h6M9 13h4"/></>,
+  book: <><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></>,
+  kanban: <><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 7v10M15 7v6"/></>,
+  timer: <><circle cx="12" cy="13" r="8"/><path d="M9 2h6M12 8v5l3 2"/></>,
+  pencil: <><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 1 1 3 3L7 19l-4 1 1-4z"/></>,
+  calendar: <><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></>,
+  wallet: <><path d="M21 12V7a2 2 0 0 0-2-2H5a2 2 0 0 0 0 4h14a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7"/><circle cx="17" cy="13" r="1"/></>,
+  flag: <><path d="M4 22V4"/><path d="M4 4h13l-2 5 2 5H4"/></>,
+  gavel: <><path d="M14.5 12.5L18 16M11 9l3.5 3.5M5 13l5-5 6 6-5 5z"/><path d="M3 21h10"/></>,
+  scale: <><path d="M12 3v18"/><path d="M3 7h18"/><path d="M5 7l-2 6a4 4 0 0 0 8 0l-2-6"/><path d="M19 7l-2 6a4 4 0 0 0 8 0l-2-6"/></>,
+  brain: <><path d="M9 3a3 3 0 0 0-3 3v.5A3 3 0 0 0 4 9a3 3 0 0 0 1 5.5V15a3 3 0 0 0 4 3v-3"/><path d="M15 3a3 3 0 0 1 3 3v.5A3 3 0 0 1 20 9a3 3 0 0 1-1 5.5V15a3 3 0 0 1-4 3"/><path d="M9 18v3M9 14h6"/></>,
+  alert: <><path d="M10.3 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4M12 17h.01"/></>,
+  notes: <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M8 13h8M8 17h6"/></>,
+  list: <><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></>,
+  zap: <path d="M13 2L3 14h8l-1 8 10-12h-8l1-8z"/>,
+  flame: <><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></>,
+  heart: <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>,
+  graph: <><circle cx="12" cy="5" r="3"/><circle cx="6" cy="19" r="3"/><circle cx="18" cy="19" r="3"/><path d="M6.7 16.7L10 8M14 8l3.3 8.7"/></>,
+  award: <><circle cx="12" cy="8" r="6"/><path d="M15.5 12.5L17 22l-5-3-5 3 1.5-9.5"/></>,
+  network: <><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M7.5 7.5L11 16.5M16.5 7.5L13 16.5"/></>,
+  database: <><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6"/></>,
+  flask: <><path d="M9 3h6M10 3v7L4.5 19A2 2 0 0 0 6.3 22h11.4a2 2 0 0 0 1.8-3L14 10V3"/></>,
+  shield: <path d="M12 2L4 5v6.09c0 5.05 3.41 9.76 8 10.91 4.59-1.15 8-5.86 8-10.91V5l-8-3z"/>,
+  music: <><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></>,
+  bullseye: <><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1.5"/></>,
+  arrow: <><path d="M5 12h14M12 5l7 7-7 7"/></>,
+  copy: <><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>,
+  download: <><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></>,
+  play: <path d="M5 3l14 9-14 9z"/>,
+  pause: <><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></>,
+  reset: <><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></>,
+  star: <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>,
+  shuffle: <><path d="M16 3h5v5M4 20l16.5-16.5"/><path d="M21 16v5h-5M15 15l5.5 5.5M4 4l5 5"/></>,
+  expand: <><path d="M3 8V4h4M21 8V4h-4M3 16v4h4M21 16v4h-4"/></>,
+  resize: <><path d="M21 11V3h-8M3 13v8h8"/></>,
+  smile: <><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2M9 9h.01M15 9h.01"/></>,
+  send: <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"/>,
+  chevron: <path d="M9 18l6-6-6-6"/>,
+  user: <><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>,
+  cite: <><path d="M3 21c0-3 2-6 6-6"/><path d="M9 15v-2c0-3-2-5-5-5"/><path d="M14 21c0-3 2-6 6-6"/><path d="M20 15v-2c0-3-2-5-5-5"/></>,
+  pinned: <><path d="M9 4v5l-3 4h12l-3-4V4M12 13v8M9 4h6"/></>,
+  microscope: <><path d="M6 18h8M3 22h18"/><path d="M14 22a7 7 0 1 0 0-14h-1"/><path d="M9 14h2M9 12a2 2 0 0 1-2-2V6h4v4a2 2 0 0 1-2 2zM12 6V3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3"/></>,
+  sun: <><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></>,
+  moon: <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>,
+  back: <><path d="M19 12H5M12 19l-7-7 7-7"/></>,
+};
+
+const Icon = ({ name, size = 16, className = '', style }) => {
+  const paths = ICONS[name];
+  if (!paths) return null;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      {paths}
+    </svg>
+  );
+};
+
+export default Icon;

--- a/phd-advisor-frontend/src/components/canvas/CanvasLatexEditor.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasLatexEditor.js
@@ -1,0 +1,225 @@
+// Real LaTeX editor for paper-mode Documents.
+// Left: CodeMirror 6 editor with LaTeX (stex) syntax highlighting.
+// Right: live LaTeX.js HTML preview (handles \section, \textbf, \emph, lists,
+// citations, math via KaTeX — most thesis-shaped documents work).
+// Plus a "Compile PDF" action that POSTs to LaTeX-Online (latex.ytotech.com)
+// for real pdflatex output in an iframe.
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { StreamLanguage } from '@codemirror/language';
+import { stex } from '@codemirror/legacy-modes/mode/stex';
+import Icon from './CanvasIcon';
+
+const fireToast = (msg, kind = 'success') =>
+  window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg, kind } }));
+
+// Wrap a section body as a full standalone .tex document so both LaTeX.js (HTML)
+// and LaTeX-Online (PDF) can render it. The user's section content is the body.
+const wrapLatexDoc = (body, title = 'Document') => `\\documentclass[11pt]{article}
+\\usepackage[utf8]{inputenc}
+\\usepackage{amsmath,amssymb}
+\\usepackage{graphicx}
+\\usepackage{hyperref}
+\\title{${title}}
+\\begin{document}
+${body}
+\\end{document}`;
+
+// Render LaTeX source to HTML using latex.js, returned as a sandboxed iframe
+// (latex.js renders to a shadow DOM-style document via createGenerator()).
+function LatexPreview({ source, title }) {
+  const containerRef = useRef(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let cancelled = false;
+    setError(null);
+    (async () => {
+      try {
+        // Dynamic import — latex.js is heavy, we only pay the cost when used.
+        const latexJs = await import('latex.js');
+        if (cancelled) return;
+        const { HtmlGenerator, parse } = latexJs;
+        const generator = new HtmlGenerator({ hyphenate: false });
+        const doc = parse(wrapLatexDoc(source || '', title), { generator });
+        if (cancelled || !containerRef.current) return;
+        containerRef.current.innerHTML = '';
+        const fragment = doc.htmlDocument().body;
+        containerRef.current.appendChild(fragment);
+      } catch (e) {
+        if (!cancelled) setError(e.message || String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [source, title]);
+
+  return (
+    <div className="latex-preview-pane">
+      {error && (
+        <div className="latex-preview-error">
+          <Icon name="alert" size={14}/>
+          <div>
+            <div style={{ fontWeight: 600, marginBottom: 2 }}>LaTeX parse error</div>
+            <div style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11.5 }}>{error}</div>
+          </div>
+        </div>
+      )}
+      <div ref={containerRef} className="latex-preview-body"/>
+    </div>
+  );
+}
+
+// PDF compile via LaTeX-Online API. POST the wrapped doc, get a PDF blob back.
+function PdfPanel({ source, title, onClose }) {
+  const [busy, setBusy] = useState(true);
+  const [pdfUrl, setPdfUrl] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let blobUrl = null;
+    (async () => {
+      setBusy(true);
+      setError(null);
+      try {
+        // YtoTech LaTeX-Online accepts JSON with the .tex source.
+        // CORS-enabled. Returns PDF binary on success.
+        const res = await fetch('https://latex.ytotech.com/builds/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            compiler: 'pdflatex',
+            resources: [{ main: true, content: wrapLatexDoc(source, title) }],
+          }),
+        });
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new Error(text || `HTTP ${res.status}`);
+        }
+        const blob = await res.blob();
+        if (cancelled) return;
+        blobUrl = URL.createObjectURL(blob);
+        setPdfUrl(blobUrl);
+      } catch (e) {
+        if (!cancelled) setError(e.message || String(e));
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [source, title]);
+
+  return (
+    <div className="canvas-modal-backdrop" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="canvas-modal huge" style={{ maxWidth: 980, height: '85vh', display: 'flex', flexDirection: 'column' }} onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <div className="modal-icon"><Icon name="flask" size={18}/></div>
+          <div style={{ flex: 1 }}>
+            <div className="modal-title">PDF preview · pdflatex</div>
+            <div className="modal-sub">
+              Compiled via{' '}
+              <a href="https://github.com/YtoTech/latex-on-http" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--canvas-accent)' }}>
+                latex-on-http
+              </a>
+              {' '}— a free open-source service. CORS-enabled.
+            </div>
+          </div>
+          {pdfUrl && (
+            <a className="btn btn-primary" href={pdfUrl} download={`${(title || 'document').replace(/\s+/g, '_')}.pdf`}>
+              <Icon name="download" size={13}/>Save PDF
+            </a>
+          )}
+          <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+        </div>
+        <div className="modal-body" style={{ flex: 1, padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          {busy && (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12, color: 'var(--canvas-text-3)' }}>
+              <div className="spinner" style={{ width: 28, height: 28 }}/>
+              <div style={{ fontFamily: 'var(--canvas-mono)', fontSize: 12 }}>Running pdflatex…</div>
+            </div>
+          )}
+          {error && (
+            <div style={{ padding: 20, color: 'var(--canvas-danger)', fontFamily: 'var(--canvas-mono)', fontSize: 12 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--canvas-text)', marginBottom: 6 }}>Compile failed</div>
+              {error}
+              <div style={{ marginTop: 10, color: 'var(--canvas-text-3)', fontSize: 11.5, fontFamily: 'var(--canvas-sans)' }}>
+                The free latex-online service can be flaky and doesn't support every package. The HTML preview to the left should still work for most thesis-shaped documents.
+              </div>
+            </div>
+          )}
+          {pdfUrl && !busy && !error && (
+            <iframe
+              src={pdfUrl}
+              title="PDF preview"
+              style={{ width: '100%', height: '100%', border: 'none', background: '#525659' }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// LatexEditor — split-pane editor + preview, with PDF compile button
+// ============================================================================
+export default function LatexEditor({ value, onChange, title, theme = 'dark' }) {
+  const [mode, setMode] = useState('split'); // 'split' | 'source' | 'preview'
+  const [pdfOpen, setPdfOpen] = useState(false);
+
+  const extensions = useMemo(() => [
+    StreamLanguage.define(stex),
+  ], []);
+
+  const cmTheme = theme === 'light' ? 'light' : 'dark';
+
+  return (
+    <div className="latex-editor">
+      <div className="latex-editor-toolbar">
+        <div className="latex-editor-mode">
+          <button className={mode === 'split' ? 'active' : ''} onClick={() => setMode('split')} title="Editor + preview side by side">
+            <Icon name="layout" size={11}/>Split
+          </button>
+          <button className={mode === 'source' ? 'active' : ''} onClick={() => setMode('source')} title="Just the LaTeX source">
+            <Icon name="flask" size={11}/>Source
+          </button>
+          <button className={mode === 'preview' ? 'active' : ''} onClick={() => setMode('preview')} title="Just the rendered HTML">
+            <Icon name="book" size={11}/>Preview
+          </button>
+        </div>
+        <span style={{ flex: 1 }}/>
+        <button className="btn btn-ghost" onClick={() => setPdfOpen(true)} title="Compile to PDF with real pdflatex">
+          <Icon name="download" size={13}/>Compile PDF
+        </button>
+      </div>
+      <div className={`latex-editor-panes mode-${mode}`}>
+        {(mode === 'split' || mode === 'source') && (
+          <div className="latex-source-pane">
+            <CodeMirror
+              value={value}
+              onChange={onChange}
+              theme={cmTheme}
+              extensions={extensions}
+              basicSetup={{
+                lineNumbers: true,
+                foldGutter: true,
+                highlightActiveLine: false,
+                bracketMatching: true,
+                closeBrackets: true,
+              }}
+              placeholder="Write LaTeX here — \\section, \\textbf, $\\frac{a}{b}$, etc."
+            />
+          </div>
+        )}
+        {(mode === 'split' || mode === 'preview') && (
+          <LatexPreview source={value} title={title}/>
+        )}
+      </div>
+      {pdfOpen && <PdfPanel source={value} title={title} onClose={() => setPdfOpen(false)}/>}
+    </div>
+  );
+}

--- a/phd-advisor-frontend/src/components/canvas/CanvasModals.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasModals.js
@@ -1,0 +1,1096 @@
+import React, { useState, useMemo, useRef } from 'react';
+import Icon from './CanvasIcon';
+import { WIDGET_CATALOG, CATEGORIES } from './canvasData';
+
+const fireToast = (msg, kind = 'success') =>
+  window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg, kind } }));
+
+// ---------- Add citation (with DOI lookup via CrossRef) ----------
+export function AddCitationModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [authors, setA] = useState(init.authors || '');
+  const [title, setT] = useState(init.title || '');
+  const [journal, setJ] = useState(init.journal || '');
+  const [year, setY] = useState(init.year || new Date().getFullYear());
+  const [doi, setDoi] = useState(init.doi || '');
+  const [lookingUp, setLookingUp] = useState(false);
+  const [bibtexInput, setBibtexInput] = useState('');
+  const [showBibtex, setShowBibtex] = useState(false);
+  const valid = authors && title && journal;
+  const editing = !!init.key;
+
+  const lookupDoi = async () => {
+    const cleaned = doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//, '');
+    if (!cleaned) return;
+    setLookingUp(true);
+    try {
+      const res = await fetch(`https://api.crossref.org/works/${encodeURIComponent(cleaned)}`);
+      if (!res.ok) throw new Error('Not found');
+      const json = await res.json();
+      const w = json.message;
+      const authorList = (w.author || []).map(a => `${a.family || ''}, ${(a.given || '').charAt(0)}.`).join('; ');
+      setA(authorList || 'Unknown');
+      setT((w.title && w.title[0]) || 'Untitled');
+      setJ((w['container-title'] && w['container-title'][0]) || '');
+      setY((w.issued && w.issued['date-parts'] && w.issued['date-parts'][0][0]) || new Date().getFullYear());
+      fireToast('DOI resolved · fields filled');
+    } catch (e) {
+      fireToast(`DOI lookup failed: ${e.message}`, 'danger');
+    } finally {
+      setLookingUp(false);
+    }
+  };
+
+  const importBibtex = () => {
+    // Minimal BibTeX parser: pull author/title/journal/year out of the first @entry block.
+    const get = (field) => {
+      const m = bibtexInput.match(new RegExp(`${field}\\s*=\\s*[{"]([^}"]+)`, 'i'));
+      return m ? m[1].trim() : '';
+    };
+    const a = get('author');
+    const t = get('title');
+    const j = get('journal') || get('booktitle');
+    const y = get('year');
+    if (!t) { fireToast('Could not parse BibTeX', 'danger'); return; }
+    setA(a); setT(t); setJ(j); setY(y || new Date().getFullYear());
+    setShowBibtex(false);
+    fireToast('BibTeX imported');
+  };
+
+  const submit = () => {
+    if (!valid) return;
+    const key = init.key || (authors.split(',')[0] || 'cite').toLowerCase().replace(/[^a-z]/g, '') + year;
+    data.onAdd({ key, authors, title, journal, year: +year, cited: init.cited || 0, doi: doi || init.doi });
+    fireToast(`${editing ? 'Updated' : 'Added'} @${key}`);
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="book" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit citation' : 'Add citation'}</div>
+          <div className="modal-sub">{editing ? `@${init.key}` : 'Paste a DOI or BibTeX, or fill in manually.'}</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">DOI</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input className="input" placeholder="10.1038/nn0199_79  or  https://doi.org/…"
+                value={doi} onChange={e => setDoi(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') lookupDoi(); }}/>
+              <button className="btn" onClick={lookupDoi} disabled={!doi.trim() || lookingUp}>
+                {lookingUp ? <><div className="spinner"/>Looking up</> : <><Icon name="search" size={13}/>Resolve</>}
+              </button>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8, fontSize: 11, color: 'var(--canvas-text-3)' }}>
+            <button className="btn btn-ghost" onClick={() => setShowBibtex(s => !s)} style={{ padding: '4px 8px', fontSize: 11 }}>
+              <Icon name="copy" size={12}/>{showBibtex ? 'Hide BibTeX' : 'Import BibTeX'}
+            </button>
+          </div>
+          {showBibtex && (
+            <div className="form-row">
+              <label className="label">Paste a BibTeX entry</label>
+              <textarea className="textarea" rows={5} style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11.5 }}
+                value={bibtexInput} onChange={e => setBibtexInput(e.target.value)}
+                placeholder="@article{key, author={...}, title={...}, journal={...}, year={...}}"/>
+              <button className="btn" onClick={importBibtex} disabled={!bibtexInput.trim()} style={{ alignSelf: 'flex-start' }}>
+                <Icon name="check" size={13}/>Parse and fill
+              </button>
+            </div>
+          )}
+          <div className="form-row">
+            <label className="label">Authors</label>
+            <input className="input" value={authors} onChange={e => setA(e.target.value)} placeholder="Smith, J., & Doe, A."/>
+          </div>
+          <div className="form-row">
+            <label className="label">Title</label>
+            <input className="input" value={title} onChange={e => setT(e.target.value)} placeholder="A study of …"/>
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Journal</label>
+              <input className="input" value={journal} onChange={e => setJ(e.target.value)} placeholder="Nature Neuroscience"/>
+            </div>
+            <div className="form-row">
+              <label className="label">Year</label>
+              <input className="input" type="number" value={year} onChange={e => setY(e.target.value)}/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!valid}>
+          <Icon name={editing ? 'check' : 'plus'} size={13}/>{editing ? 'Save changes' : 'Add citation'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Add task ----------
+export function AddTaskModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [title, setT] = useState(init.title || '');
+  const [priority, setP] = useState(init.priority || 'med');
+  const [meta, setM] = useState(init.meta || '');
+  const editing = !!init.id;
+
+  const submit = () => {
+    if (!title) return;
+    data.onAdd({ title, priority, meta: meta || '—' });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="kanban" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit task' : 'Add task'}</div>
+          <div className="modal-sub">{editing ? '' : 'It\'ll be added to the column.'}</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">Task</label>
+            <input className="input" autoFocus value={title} onChange={e => setT(e.target.value)} placeholder="What needs doing?"/>
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Priority</label>
+              <div style={{ display: 'flex', gap: 4 }}>
+                {[['high', 'High'], ['med', 'Med'], ['low', 'Low']].map(([v, l]) => (
+                  <button key={v} className="btn"
+                    style={{ flex: 1, padding: '7px 8px', justifyContent: 'center',
+                      background: priority === v ? 'var(--canvas-surface-3)' : 'var(--canvas-surface-2)',
+                      borderColor: priority === v ? 'var(--canvas-border-2)' : 'var(--canvas-border)',
+                      color: priority === v ? 'var(--canvas-text)' : 'var(--canvas-text-2)' }}
+                    onClick={() => setP(v)}>{l}</button>
+                ))}
+              </div>
+            </div>
+            <div className="form-row">
+              <label className="label">Note / due</label>
+              <input className="input" value={meta} onChange={e => setM(e.target.value)} placeholder="May 22 · 2h"/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!title}>
+          <Icon name={editing ? 'check' : 'plus'} size={13}/>{editing ? 'Save changes' : 'Add task'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Add deadline ----------
+export function AddDeadlineModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [title, setT] = useState(init.title || '');
+  const [date, setD] = useState(init.date || '');
+  const [tag, setG] = useState(init.tag || 'writing');
+  const editing = !!init.id;
+
+  const submit = () => {
+    if (!title || !date) return;
+    data.onAdd({ title, date, tag });
+    fireToast(`${editing ? 'Updated' : 'Added'} · ${title}`);
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="calendar" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit deadline' : 'Add deadline'}</div>
+          <div className="modal-sub">Will appear sorted by urgency.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">What's due</label>
+            <input className="input" autoFocus value={title} onChange={e => setT(e.target.value)} placeholder="NSF report, COSYNE abstract…"/>
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Date</label>
+              <input className="input" type="date" value={date} onChange={e => setD(e.target.value)}/>
+            </div>
+            <div className="form-row">
+              <label className="label">Category</label>
+              <select className="select" value={tag} onChange={e => setG(e.target.value)}>
+                <option value="writing">Writing</option>
+                <option value="lab">Lab</option>
+                <option value="conf">Conference</option>
+                <option value="NSF">Funding</option>
+                <option value="milestone">Milestone</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!title || !date}>
+          <Icon name={editing ? 'check' : 'plus'} size={13}/>{editing ? 'Save' : 'Add deadline'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Log words ----------
+export function LogWordsModal({ data, onClose }) {
+  const [n, setN] = useState(data.today);
+  const submit = () => {
+    data.onLog(+n || 0);
+    fireToast(`Logged ${n} words today.`);
+    onClose();
+  };
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="pencil" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Log today's words</div>
+          <div className="modal-sub">Total written today, including edits to existing chapters.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-row">
+          <label className="label">Words written</label>
+          <input className="input" type="number" autoFocus value={n} onChange={e => setN(e.target.value)} style={{ fontFamily: 'var(--canvas-mono)', fontSize: 18, padding: '12px 14px' }}/>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 12, flexWrap: 'wrap' }}>
+          {[0, 100, 250, 500, 750, 1000].map(v => (
+            <button key={v} className="chip" onClick={() => setN(v)}>{v}</button>
+          ))}
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit}><Icon name="check" size={13}/>Log words</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Confirm remove ----------
+export function ConfirmRemoveModal({ data, onClose }) {
+  return (
+    <div className="canvas-modal" style={{ maxWidth: 420 }} onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon" style={{ background: 'rgba(240,106,106,0.12)', color: 'var(--canvas-danger)' }}>
+          <Icon name="trash" size={18}/>
+        </div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Remove "{data.label}"?</div>
+          <div className="modal-sub">Widget state stays in your project — you can add it back from the palette.</div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-danger" style={{ background: 'rgba(240,106,106,0.12)', borderColor: 'rgba(240,106,106,0.3)', color: 'var(--canvas-danger)' }} onClick={() => { data.onConfirm(); onClose(); }}>
+          <Icon name="trash" size={13}/>Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Reading paper (with CrossRef search/DOI lookup) ----------
+export function ReadingPaperModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [title, setT] = useState(init.title || '');
+  const [priority, setP] = useState(init.priority || 'med');
+  const [time, setTime] = useState(init.time || '1h');
+  const [doi, setDoi] = useState(init.doi || '');
+  const [searchQ, setSearchQ] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [results, setResults] = useState([]);
+  const editing = !!init.title && data.initial;
+
+  const lookupByDoi = async () => {
+    const cleaned = doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//, '');
+    if (!cleaned) return;
+    setSearching(true);
+    try {
+      const res = await fetch(`https://api.crossref.org/works/${encodeURIComponent(cleaned)}`);
+      if (!res.ok) throw new Error('not found');
+      const json = await res.json();
+      const w = json.message;
+      const author = (w.author && w.author[0]) ? `${w.author[0].family}` : 'Unknown';
+      const yr = (w.issued && w.issued['date-parts'] && w.issued['date-parts'][0][0]) || '';
+      setT(`${author} ${yr} — ${(w.title && w.title[0]) || 'Untitled'}`);
+      fireToast('DOI resolved');
+    } catch (e) {
+      fireToast(`Lookup failed: ${e.message}`, 'danger');
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const searchCrossref = async () => {
+    if (!searchQ.trim()) return;
+    setSearching(true);
+    try {
+      const res = await fetch(`https://api.crossref.org/works?query=${encodeURIComponent(searchQ)}&rows=5&select=DOI,title,author,issued`);
+      const json = await res.json();
+      setResults(json.message.items || []);
+    } catch (e) {
+      fireToast(`Search failed: ${e.message}`, 'danger');
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const pickResult = (w) => {
+    const author = (w.author && w.author[0]) ? w.author[0].family : 'Unknown';
+    const yr = (w.issued && w.issued['date-parts'] && w.issued['date-parts'][0][0]) || '';
+    setT(`${author} ${yr} — ${(w.title && w.title[0]) || 'Untitled'}`);
+    setDoi(w.DOI || '');
+    setResults([]);
+  };
+
+  const submit = () => {
+    if (!title) return;
+    data.onAdd({ title, priority, time, doi });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="list" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit paper' : 'Queue a paper'}</div>
+          <div className="modal-sub">Search by title, paste a DOI, or type freely.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">Search CrossRef</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input className="input" placeholder="Predictive coding mouse V1…" value={searchQ}
+                onChange={e => setSearchQ(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') searchCrossref(); }}/>
+              <button className="btn" onClick={searchCrossref} disabled={!searchQ.trim() || searching}>
+                {searching ? <div className="spinner"/> : <Icon name="search" size={13}/>}
+                Search
+              </button>
+            </div>
+          </div>
+          {results.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 200, overflowY: 'auto' }}>
+              {results.map((w, i) => (
+                <button key={i} className="palette-item" style={{ padding: '8px 10px' }} onClick={() => pickResult(w)}>
+                  <div className="pi-content">
+                    <div className="pi-title" style={{ fontSize: 12 }}>{(w.title && w.title[0]) || 'Untitled'}</div>
+                    <div className="pi-desc">
+                      {(w.author && w.author.slice(0, 2).map(a => a.family).join(', ')) || ''}
+                      {w.author && w.author.length > 2 ? ' et al.' : ''}
+                      {' · '}
+                      {(w.issued && w.issued['date-parts'] && w.issued['date-parts'][0][0]) || ''}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="form-row">
+            <label className="label">DOI (optional)</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input className="input" value={doi} onChange={e => setDoi(e.target.value)} placeholder="10.1038/…"/>
+              <button className="btn" onClick={lookupByDoi} disabled={!doi.trim() || searching}>Resolve</button>
+            </div>
+          </div>
+          <div className="form-row">
+            <label className="label">Title</label>
+            <input className="input" value={title} onChange={e => setT(e.target.value)} placeholder="Author Year — Short title"/>
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Priority</label>
+              <select className="select" value={priority} onChange={e => setP(e.target.value)}>
+                <option value="high">High</option>
+                <option value="med">Med</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+            <div className="form-row">
+              <label className="label">Est. read time</label>
+              <input className="input" value={time} onChange={e => setTime(e.target.value)} placeholder="2h, 90m, etc."/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!title}><Icon name={editing ? 'check' : 'plus'} size={13}/>{editing ? 'Save' : 'Queue'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Budget item ----------
+export function BudgetItemModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [label, setL] = useState(init.label || '');
+  const [spent, setS] = useState(init.spent ?? 0);
+  const [color, setC] = useState(init.color || '#3dd9d6');
+  const editing = !!init.label;
+  const colors = ['#3dd9d6', '#e864b8', '#f5b454', '#7ed98a', '#9b8cff', '#f06a6a'];
+
+  const submit = () => {
+    if (!label) return;
+    data.onSave({ label, spent: +spent || 0, color });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="wallet" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit category' : 'Add category'}</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">Category</label>
+            <input className="input" autoFocus value={label} onChange={e => setL(e.target.value)} placeholder="Equipment, travel, etc."/>
+          </div>
+          <div className="form-row">
+            <label className="label">Amount spent ($)</label>
+            <input className="input" type="number" value={spent} onChange={e => setS(e.target.value)} style={{ fontFamily: 'var(--canvas-mono)' }}/>
+          </div>
+          <div className="form-row">
+            <label className="label">Color</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              {colors.map(c => (
+                <button key={c} onClick={() => setC(c)} title={c}
+                  style={{ width: 28, height: 28, borderRadius: 6, background: c, border: color === c ? '2px solid var(--canvas-text)' : '2px solid transparent', cursor: 'pointer' }}/>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        {editing && data.onDelete && (
+          <button className="btn btn-danger" style={{ background: 'transparent', borderColor: 'transparent', color: 'var(--canvas-danger)', marginRight: 'auto' }} onClick={() => { data.onDelete(); onClose(); }}><Icon name="trash" size={13}/>Delete</button>
+        )}
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!label}><Icon name="check" size={13}/>{editing ? 'Save' : 'Add'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Note (with @mention autocomplete) ----------
+export function NoteModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [text, setT] = useState(init.text || '');
+  const [tag, setG] = useState(init.tag || '');
+  const [linkTo, setL] = useState(init.linkTo || '');
+  const [mention, setMention] = useState(null); // { start, query, choices }
+  const [mentionIdx, setMentionIdx] = useState(0);
+  const taRef = useRef(null);
+  const editing = !!init.id;
+
+  // Pull mention sources from the persisted canvas state so the modal stays self-contained.
+  const mentionSources = useMemo(() => {
+    try {
+      const all = JSON.parse(localStorage.getItem('canvas-states-v2') || '{}');
+      const out = [];
+      (all.bibliography?.entries || []).forEach(e => out.push({ key: '@' + e.key, label: e.title, kind: 'cite' }));
+      (all.writing?.chapters || []).forEach(c => out.push({ key: '@' + c.name.replace(/\s+/g, '-'), label: c.name, kind: 'chapter' }));
+      (all.kanban?.cards || []).forEach(c => out.push({ key: '@' + c.title.slice(0, 30).replace(/\s+/g, '-'), label: c.title, kind: 'task' }));
+      return out;
+    } catch { return []; }
+  }, []);
+
+  const onTextChange = (e) => {
+    const val = e.target.value;
+    const cursor = e.target.selectionStart;
+    setT(val);
+    // Look back from cursor for an @mention being typed
+    const before = val.slice(0, cursor);
+    const m = before.match(/@(\S*)$/);
+    if (m) {
+      const q = m[1].toLowerCase();
+      const choices = mentionSources
+        .filter(s => s.label.toLowerCase().includes(q) || s.key.toLowerCase().includes('@' + q))
+        .slice(0, 6);
+      setMention({ start: cursor - m[0].length, query: m[1], choices });
+      setMentionIdx(0);
+    } else {
+      setMention(null);
+    }
+  };
+
+  const insertMention = (item) => {
+    if (!mention) return;
+    const before = text.slice(0, mention.start);
+    const after = text.slice(mention.start + 1 + mention.query.length); // +1 for the @
+    const inserted = item.key + ' ';
+    setT(before + inserted + after);
+    setMention(null);
+    setTimeout(() => {
+      if (taRef.current) {
+        const pos = before.length + inserted.length;
+        taRef.current.setSelectionRange(pos, pos);
+        taRef.current.focus();
+      }
+    }, 0);
+  };
+
+  const onKeyDown = (e) => {
+    if (!mention || mention.choices.length === 0) return;
+    if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIdx(i => Math.min(mention.choices.length - 1, i + 1)); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIdx(i => Math.max(0, i - 1)); }
+    if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); insertMention(mention.choices[mentionIdx]); }
+    if (e.key === 'Escape') setMention(null);
+  };
+
+  const submit = () => {
+    if (!text.trim()) return;
+    data.onSave({ text: text.trim(), tag: tag.trim(), linkTo: linkTo.trim() });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="notes" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit note' : 'New note'}</div>
+          <div className="modal-sub">Markdown supported · **bold**, *italic*, `code`, lists, links</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row" style={{ position: 'relative' }}>
+            <textarea ref={taRef} className="textarea" autoFocus
+              style={{ minHeight: 140, fontFamily: 'var(--canvas-mono)', fontSize: 12.5 }}
+              value={text} onChange={onTextChange} onKeyDown={onKeyDown}
+              placeholder="What's the thought? Markdown welcome. Type @ to mention citations, chapters, tasks."/>
+            {mention && mention.choices.length > 0 && (
+              <div style={{
+                position: 'absolute',
+                top: '100%', left: 0, right: 0,
+                background: 'var(--canvas-surface)',
+                border: '1px solid var(--canvas-border-2)',
+                borderRadius: 7,
+                marginTop: 4,
+                boxShadow: 'var(--canvas-shadow-lg)',
+                zIndex: 10,
+                maxHeight: 200,
+                overflowY: 'auto',
+              }}>
+                {mention.choices.map((c, i) => (
+                  <button key={c.key + i} onMouseEnter={() => setMentionIdx(i)} onClick={() => insertMention(c)}
+                    style={{
+                      width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                      padding: '6px 10px', textAlign: 'left',
+                      background: i === mentionIdx ? 'var(--canvas-surface-2)' : 'transparent',
+                      color: 'var(--canvas-text)', border: 'none', cursor: 'pointer', fontSize: 12,
+                    }}>
+                    <span className="tag-pill">{c.kind}</span>
+                    <span style={{ fontFamily: 'var(--canvas-mono)', color: 'var(--canvas-accent)' }}>{c.key}</span>
+                    <span style={{ flex: 1, color: 'var(--canvas-text-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Tag</label>
+              <input className="input" value={tag} onChange={e => setG(e.target.value)} placeholder="theory, todo, idea…"/>
+            </div>
+            <div className="form-row">
+              <label className="label">Linked to</label>
+              <input className="input" value={linkTo} onChange={e => setL(e.target.value)} placeholder="@rao1999, Aim 2…"/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        {editing && data.onDelete && (
+          <button className="btn btn-danger" style={{ background: 'transparent', borderColor: 'transparent', color: 'var(--canvas-danger)', marginRight: 'auto' }} onClick={() => { data.onDelete(); onClose(); }}><Icon name="trash" size={13}/>Delete</button>
+        )}
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!text.trim()}><Icon name="check" size={13}/>{editing ? 'Save' : 'Add note'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Habit ----------
+export function HabitModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [label, setL] = useState(init.label || '');
+  const [icon, setI] = useState(init.icon || 'flame');
+  const editing = !!init.id;
+  const iconOpts = ['flame', 'pencil', 'book', 'flask', 'heart', 'graph', 'star'];
+  const submit = () => {
+    if (!label) return;
+    data.onSave({ label, icon });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="flame" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit habit' : 'New habit'}</div>
+          <div className="modal-sub">Tracked daily. Tap squares to mark done.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">Habit</label>
+            <input className="input" autoFocus value={label} onChange={e => setL(e.target.value)} placeholder="Read 1 paper, write 30 min…"/>
+          </div>
+          <div className="form-row">
+            <label className="label">Icon</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              {iconOpts.map(n => (
+                <button key={n} onClick={() => setI(n)} title={n}
+                  style={{ width: 32, height: 32, borderRadius: 7, background: icon === n ? 'var(--canvas-accent-glow)' : 'var(--canvas-surface-2)', color: icon === n ? 'var(--canvas-accent)' : 'var(--canvas-text-3)', border: `1px solid ${icon === n ? 'var(--canvas-accent)' : 'var(--canvas-border)'}`, display: 'grid', placeItems: 'center', cursor: 'pointer' }}>
+                  <Icon name={n} size={14}/>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        {editing && data.onDelete && (
+          <button className="btn btn-danger" style={{ background: 'transparent', borderColor: 'transparent', color: 'var(--canvas-danger)', marginRight: 'auto' }} onClick={() => { data.onDelete(); onClose(); }}><Icon name="trash" size={13}/>Delete</button>
+        )}
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!label}><Icon name="check" size={13}/>{editing ? 'Save' : 'Add habit'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Goal ----------
+export function GoalModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [label, setL] = useState(init.label || '');
+  const [progress, setP] = useState(init.progress ?? 0);
+  const [due, setD] = useState(init.due || '');
+  const editing = !!init.id;
+
+  const submit = () => {
+    if (!label) return;
+    data.onSave({ label, progress: +progress, due });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="bullseye" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit goal' : 'New goal'}</div>
+          <div className="modal-sub">Quarterly OKR or dissertation milestone.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-row">
+            <label className="label">Goal</label>
+            <input className="input" autoFocus value={label} onChange={e => setL(e.target.value)} placeholder="Submit Aim 2 to advisor by July"/>
+          </div>
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Progress · {progress}%</label>
+              <input type="range" min="0" max="100" step="5" value={progress} onChange={e => setP(+e.target.value)} style={{ accentColor: 'var(--canvas-accent)' }}/>
+            </div>
+            <div className="form-row">
+              <label className="label">Due (optional)</label>
+              <input className="input" value={due} onChange={e => setD(e.target.value)} placeholder="Q3 2026"/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        {editing && data.onDelete && (
+          <button className="btn btn-danger" style={{ background: 'transparent', borderColor: 'transparent', color: 'var(--canvas-danger)', marginRight: 'auto' }} onClick={() => { data.onDelete(); onClose(); }}><Icon name="trash" size={13}/>Delete</button>
+        )}
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!label}><Icon name="check" size={13}/>{editing ? 'Save' : 'Add goal'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Meeting ----------
+export function MeetingModal({ data, onClose }) {
+  const init = data.initial || {};
+  const [who, setW] = useState(init.who || '');
+  const [date, setD] = useState(init.date || new Date().toISOString().slice(0, 10));
+  const [notes, setN] = useState(init.notes || '');
+  const [actions, setA] = useState(init.actions || '');
+  const editing = !!init.id;
+
+  const submit = () => {
+    if (!who) return;
+    data.onSave({ who, date, notes, actions });
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal wide" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="message" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">{editing ? 'Edit meeting' : 'Log meeting'}</div>
+          <div className="modal-sub">Advisor / collaborator / sponsor — anyone you want to track.</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="form-grid">
+          <div className="form-grid two">
+            <div className="form-row">
+              <label className="label">Who</label>
+              <input className="input" autoFocus value={who} onChange={e => setW(e.target.value)} placeholder="Dr. Reineke"/>
+            </div>
+            <div className="form-row">
+              <label className="label">Date</label>
+              <input className="input" type="date" value={date} onChange={e => setD(e.target.value)}/>
+            </div>
+          </div>
+          <div className="form-row">
+            <label className="label">Notes</label>
+            <textarea className="textarea" value={notes} onChange={e => setN(e.target.value)} placeholder="Discussion topics, decisions…"/>
+          </div>
+          <div className="form-row">
+            <label className="label">Action items (one per line)</label>
+            <textarea className="textarea" value={actions} onChange={e => setA(e.target.value)} placeholder="Send draft Aim 2&#10;Re-analyze M3&#10;Schedule next 1:1"/>
+          </div>
+        </div>
+      </div>
+      <div className="modal-foot">
+        {editing && data.onDelete && (
+          <button className="btn btn-danger" style={{ background: 'transparent', borderColor: 'transparent', color: 'var(--canvas-danger)', marginRight: 'auto' }} onClick={() => { data.onDelete(); onClose(); }}><Icon name="trash" size={13}/>Delete</button>
+        )}
+        <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!who}><Icon name="check" size={13}/>{editing ? 'Save' : 'Log meeting'}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Widget palette ----------
+export function PaletteModal({ data, onClose }) {
+  const [q, setQ] = useState('');
+  const [cat, setCat] = useState('all');
+  const present = new Set(data.layout.map(w => w.type));
+
+  const filtered = useMemo(() => {
+    let r = WIDGET_CATALOG;
+    if (cat !== 'all') r = r.filter(w => w.cat === cat);
+    if (q) {
+      const ql = q.toLowerCase();
+      r = r.filter(w => w.name.toLowerCase().includes(ql) || w.desc.toLowerCase().includes(ql));
+    }
+    return r;
+  }, [q, cat]);
+
+  const add = (w) => {
+    if (present.has(w.type)) return;
+    data.onAdd(w);
+    fireToast(`${w.name} added to workspace`, w.critic ? 'critic' : 'success');
+  };
+
+  return (
+    <div className="canvas-modal huge" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-head">
+        <div className="modal-icon"><Icon name="layout" size={18}/></div>
+        <div style={{ flex: 1 }}>
+          <div className="modal-title">Add widget</div>
+          <div className="modal-sub">{WIDGET_CATALOG.length} widgets · {WIDGET_CATALOG.filter(w => w.critic).length} anti-yes-man</div>
+        </div>
+        <button className="icon-btn" onClick={onClose}><Icon name="x" size={16}/></button>
+      </div>
+      <div className="modal-body">
+        <div className="palette-search">
+          <div style={{ position: 'relative' }}>
+            <span style={{ position: 'absolute', left: 11, top: '50%', transform: 'translateY(-50%)', color: 'var(--canvas-text-3)' }}><Icon name="search" size={14}/></span>
+            <input className="input" autoFocus style={{ paddingLeft: 34 }} placeholder="Search widgets…" value={q} onChange={e => setQ(e.target.value)}/>
+          </div>
+          <div className="palette-cats" style={{ marginTop: 12 }}>
+            {CATEGORIES.map(c => (
+              <button key={c.id}
+                className={`palette-cat ${cat === c.id ? 'active' : ''} ${c.critic ? 'critic' : ''}`}
+                onClick={() => setCat(c.id)}>
+                {c.label}{c.critic && <span style={{ marginLeft: 4 }}>★</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="palette-grid">
+          {filtered.map(w => {
+            const added = present.has(w.type);
+            return (
+              <button key={w.type}
+                className={`palette-item ${w.critic ? 'critic' : ''} ${added ? 'added' : ''}`}
+                onClick={() => add(w)} disabled={added}>
+                <div className="pi-icon"><Icon name={w.icon} size={16}/></div>
+                <div className="pi-content">
+                  <div className="pi-title">
+                    {w.name}
+                    {w.critic && <span className="widget-tag" style={{ fontSize: 8.5 }}>WEDGE</span>}
+                    {w.critic && <span className="widget-tag widget-tag-chat" style={{ fontSize: 8.5 }} title="Real critique happens in the main chat — this widget is a scratchpad">BEST IN CHAT</span>}
+                    {w.enhanced && !w.stub && !w.critic && <span className="widget-tag widget-tag-enhanced" style={{ fontSize: 8.5 }}>ENHANCED</span>}
+                    {w.stub && <span style={{ fontSize: 9, color: 'var(--canvas-text-4)', fontFamily: 'var(--canvas-mono)', marginLeft: 4 }}>SOON</span>}
+                  </div>
+                  <div className="pi-desc">{w.desc}</div>
+                </div>
+                {added && <span className="pi-added">added</span>}
+              </button>
+            );
+          })}
+          {filtered.length === 0 && (
+            <div style={{ gridColumn: 'span 2', padding: 30, textAlign: 'center', color: 'var(--canvas-text-3)', fontSize: 13 }}>
+              No widgets match "{q}".
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Global content search (notes / quotes / citations / kanban / deadlines / outline) ----------
+export function GlobalSearchModal({ data, onClose }) {
+  const [q, setQ] = useState('');
+  const [idx, setIdx] = useState(0);
+  const states = data.states || {};
+
+  const items = useMemo(() => {
+    if (!q.trim()) return [];
+    const ql = q.toLowerCase();
+    const out = [];
+    // Notes
+    (states.notes?.items || []).forEach(n => {
+      if ((n.text || '').toLowerCase().includes(ql) || (n.tag || '').toLowerCase().includes(ql) || (n.linkTo || '').toLowerCase().includes(ql)) {
+        out.push({ kind: 'Note', label: (n.text || '').slice(0, 80), sub: n.tag ? `#${n.tag}` : '', icon: 'notes', widgetType: 'notes' });
+      }
+    });
+    // Citations
+    (states.bibliography?.entries || []).forEach(e => {
+      const blob = `${e.title} ${e.authors} ${e.journal} ${e.key}`.toLowerCase();
+      if (blob.includes(ql)) out.push({ kind: 'Citation', label: e.title, sub: `${e.authors} (${e.year})`, icon: 'book', widgetType: 'bibliography' });
+    });
+    // Kanban
+    (states.kanban?.cards || []).forEach(c => {
+      if (`${c.title} ${c.meta || ''}`.toLowerCase().includes(ql)) {
+        out.push({ kind: 'Task', label: c.title, sub: `${c.priority?.toUpperCase()} · ${c.meta || ''}`, icon: 'kanban', widgetType: 'kanban' });
+      }
+    });
+    // Deadlines
+    (states.deadlines || []).forEach(d => {
+      if (`${d.title} ${d.tag}`.toLowerCase().includes(ql)) {
+        out.push({ kind: 'Deadline', label: d.title, sub: `${d.date} · ${d.tag}`, icon: 'calendar', widgetType: 'deadlines' });
+      }
+    });
+    // Highlights
+    (states.highlights?.items || []).forEach(h => {
+      if (`${h.text} ${h.citeKey}`.toLowerCase().includes(ql)) {
+        out.push({ kind: 'Quote', label: `"${h.text}"`.slice(0, 80), sub: h.citeKey ? `@${h.citeKey}` : '', icon: 'cite', widgetType: 'highlights' });
+      }
+    });
+    // Outline
+    (states.outline?.items || []).forEach(o => {
+      if ((o.text || '').toLowerCase().includes(ql)) {
+        out.push({ kind: 'Outline', label: o.text, sub: `depth ${o.depth}`, icon: 'list', widgetType: 'outline' });
+      }
+    });
+    // Documenter
+    (states.documenter?.entries || []).forEach(e => {
+      if ((e.text || '').toLowerCase().includes(ql)) {
+        out.push({ kind: 'Journal', label: e.text.slice(0, 80), sub: e.date, icon: 'pencil', widgetType: 'documenter' });
+      }
+    });
+    return out.slice(0, 30);
+  }, [q, states]);
+
+  const jumpTo = (it) => {
+    const el = document.querySelector(`[data-widget-id^="w-"][data-widget-type="${it.widgetType}"]`)
+      || document.querySelector(`.widget`); // fallback: scroll to first
+    if (el) {
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      el.style.boxShadow = '0 0 0 2px var(--canvas-accent), 0 0 24px var(--canvas-accent-glow)';
+      setTimeout(() => { el.style.boxShadow = ''; }, 1400);
+    }
+    onClose();
+  };
+
+  return (
+    <div className="canvas-modal" style={{ maxWidth: 600 }} onClick={(e) => e.stopPropagation()}>
+      <div style={{ padding: '16px 18px 8px', borderBottom: '1px solid var(--canvas-border)', display: 'flex', alignItems: 'center', gap: 10 }}>
+        <Icon name="search" size={16} style={{ color: 'var(--canvas-text-3)' }}/>
+        <input
+          autoFocus
+          value={q}
+          onChange={e => { setQ(e.target.value); setIdx(0); }}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') { e.preventDefault(); setIdx(i => Math.min(items.length - 1, i + 1)); }
+            if (e.key === 'ArrowUp') { e.preventDefault(); setIdx(i => Math.max(0, i - 1)); }
+            if (e.key === 'Enter' && items[idx]) jumpTo(items[idx]);
+          }}
+          placeholder="Search across notes, citations, tasks, quotes, deadlines…"
+          style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: 'var(--canvas-text)', fontSize: 15, padding: '4px 0' }}
+        />
+        <kbd style={{ fontFamily: 'var(--canvas-mono)', fontSize: 10, color: 'var(--canvas-text-3)', background: 'var(--canvas-surface-2)', padding: '2px 6px', borderRadius: 4 }}>esc</kbd>
+      </div>
+      <div style={{ maxHeight: 420, overflowY: 'auto', padding: 6 }}>
+        {!q.trim() && (
+          <div style={{ padding: 30, textAlign: 'center', color: 'var(--canvas-text-3)', fontSize: 13 }}>
+            Type to search across your canvas content.
+          </div>
+        )}
+        {q.trim() && items.length === 0 && (
+          <div style={{ padding: 30, textAlign: 'center', color: 'var(--canvas-text-3)', fontSize: 13 }}>
+            No matches for "{q}".
+          </div>
+        )}
+        {items.map((it, i) => (
+          <button key={i} onClick={() => jumpTo(it)} onMouseEnter={() => setIdx(i)}
+            style={{
+              width: '100%', display: 'flex', alignItems: 'center', gap: 12,
+              padding: '8px 12px', borderRadius: 7, textAlign: 'left',
+              background: idx === i ? 'var(--canvas-surface-2)' : 'transparent',
+              color: 'var(--canvas-text)', border: 'none', cursor: 'pointer',
+            }}>
+            <div style={{ width: 24, height: 24, borderRadius: 5, background: 'var(--canvas-surface-2)', display: 'grid', placeItems: 'center', color: 'var(--canvas-accent)' }}>
+              <Icon name={it.icon} size={13}/>
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{it.label}</div>
+              <div style={{ fontSize: 11, color: 'var(--canvas-text-3)' }}>{it.sub}</div>
+            </div>
+            <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 9.5, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{it.kind}</span>
+          </button>
+        ))}
+      </div>
+      <div style={{ padding: '8px 14px', borderTop: '1px solid var(--canvas-border)', display: 'flex', gap: 14, fontSize: 10.5, color: 'var(--canvas-text-3)', fontFamily: 'var(--canvas-mono)' }}>
+        <span>↑↓ navigate</span><span>↵ jump</span><span>esc close</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Command palette ----------
+export function CommandPaletteModal({ data, onClose }) {
+  const [q, setQ] = useState('');
+  const [idx, setIdx] = useState(0);
+
+  const items = useMemo(() => {
+    const all = [
+      ...data.layout.map(w => {
+        const meta = WIDGET_CATALOG.find(m => m.type === w.type);
+        return { kind: 'widget', label: meta?.name || w.type, icon: meta?.icon || 'layout', sub: 'Open widget', action: () => {
+          const el = document.querySelector(`[data-widget-id="${w.id}"]`);
+          if (el) {
+            el.scrollIntoView({ block: 'center' });
+            el.style.boxShadow = '0 0 0 2px var(--canvas-accent), 0 0 24px var(--canvas-accent-glow)';
+            setTimeout(() => { el.style.boxShadow = ''; }, 1400);
+          }
+        }};
+      }),
+      ...WIDGET_CATALOG.filter(w => !data.layout.find(l => l.type === w.type)).map(w => ({
+        kind: 'add', label: 'Add: ' + w.name, icon: w.icon, sub: w.desc, action: () => data.onAddWidget(w),
+      })),
+      { kind: 'cmd', label: 'Switch to Insights', icon: 'insights', sub: 'View AI summaries', action: () => data.onSetView('insights') },
+      { kind: 'cmd', label: 'Switch to Workspace', icon: 'layout', sub: 'View dashboard', action: () => data.onSetView('workspace') },
+      { kind: 'cmd', label: 'Toggle theme', icon: 'star', sub: 'Dark / light', action: () => data.onToggleTheme() },
+      { kind: 'cmd', label: 'Export workspace JSON', icon: 'download', sub: 'Download current layout', action: () => data.onExport() },
+    ];
+    if (!q) return all.slice(0, 8);
+    const ql = q.toLowerCase();
+    return all.filter(it => it.label.toLowerCase().includes(ql) || it.sub.toLowerCase().includes(ql)).slice(0, 12);
+  }, [q, data]);
+
+  const run = (i) => { items[i]?.action(); onClose(); };
+
+  return (
+    <div className="canvas-modal" style={{ maxWidth: 540 }} onClick={(e) => e.stopPropagation()}>
+      <div style={{ padding: '16px 18px 8px', borderBottom: '1px solid var(--canvas-border)', display: 'flex', alignItems: 'center', gap: 10 }}>
+        <Icon name="search" size={16} style={{ color: 'var(--canvas-text-3)' }}/>
+        <input
+          autoFocus
+          value={q}
+          onChange={e => { setQ(e.target.value); setIdx(0); }}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') { e.preventDefault(); setIdx(i => Math.min(items.length - 1, i + 1)); }
+            if (e.key === 'ArrowUp') { e.preventDefault(); setIdx(i => Math.max(0, i - 1)); }
+            if (e.key === 'Enter') run(idx);
+          }}
+          placeholder="Search widgets, switch view, run a command…"
+          style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: 'var(--canvas-text)', fontSize: 15, padding: '4px 0' }}
+        />
+        <kbd style={{ fontFamily: 'var(--canvas-mono)', fontSize: 10, color: 'var(--canvas-text-3)', background: 'var(--canvas-surface-2)', padding: '2px 6px', borderRadius: 4 }}>esc</kbd>
+      </div>
+      <div style={{ maxHeight: 360, overflowY: 'auto', padding: 6 }}>
+        {items.map((it, i) => (
+          <button key={i}
+            onClick={() => run(i)}
+            onMouseEnter={() => setIdx(i)}
+            style={{
+              width: '100%', display: 'flex', alignItems: 'center', gap: 12,
+              padding: '8px 12px', borderRadius: 7, textAlign: 'left',
+              background: idx === i ? 'var(--canvas-surface-2)' : 'transparent',
+              color: 'var(--canvas-text)', border: 'none', cursor: 'pointer',
+            }}>
+            <div style={{ width: 24, height: 24, borderRadius: 5, background: 'var(--canvas-surface-2)', display: 'grid', placeItems: 'center', color: it.kind === 'add' ? 'var(--canvas-accent)' : 'var(--canvas-text-3)' }}>
+              <Icon name={it.icon} size={13}/>
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 500 }}>{it.label}</div>
+              <div style={{ fontSize: 11, color: 'var(--canvas-text-3)' }}>{it.sub}</div>
+            </div>
+            <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 9.5, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{it.kind}</span>
+          </button>
+        ))}
+        {items.length === 0 && (
+          <div style={{ padding: 20, textAlign: 'center', color: 'var(--canvas-text-3)', fontSize: 13 }}>No matches.</div>
+        )}
+      </div>
+      <div style={{ padding: '8px 14px', borderTop: '1px solid var(--canvas-border)', display: 'flex', gap: 14, fontSize: 10.5, color: 'var(--canvas-text-3)', fontFamily: 'var(--canvas-mono)' }}>
+        <span>↑↓ navigate</span><span>↵ run</span><span>esc close</span>
+      </div>
+    </div>
+  );
+}

--- a/phd-advisor-frontend/src/components/canvas/CanvasWelcomeTour.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasWelcomeTour.js
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react';
+import Icon from './CanvasIcon';
+
+const TOUR_KEY = 'canvas-tour-seen-v1';
+
+const STEPS = [
+  {
+    title: 'Welcome to your Canvas',
+    icon: 'sparkles',
+    body: 'AI-summarized highlights from your research conversations live here. Each insight is a discrete task you can mark open, in-progress, completed, or abandoned.',
+  },
+  {
+    title: 'Filter, sort, pin',
+    icon: 'layout',
+    body: 'Use the filter chips to narrow by status, category, or confidence. Pin the most important sections to keep them at the top. The Tasks view flattens everything into a single to-do list.',
+  },
+  {
+    title: 'Ask follow-up',
+    icon: 'message',
+    body: 'Each insight has an "Ask follow-up" action that opens a fresh chat with the relevant context preloaded — useful when a synthesis raises a new question worth digging into.',
+  },
+];
+
+const CanvasWelcomeTour = ({ forceShow = false, onClose }) => {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const seen = localStorage.getItem(TOUR_KEY);
+    if (forceShow || !seen) setVisible(true);
+  }, [forceShow]);
+
+  const dismiss = () => {
+    localStorage.setItem(TOUR_KEY, '1');
+    setVisible(false);
+    if (onClose) onClose();
+  };
+
+  if (!visible) return null;
+
+  const s = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <div className="canvas-modal-backdrop" onClick={(e) => { if (e.target === e.currentTarget) dismiss(); }}>
+      <div className="canvas-modal canvas-tour" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <div className="modal-icon"><Icon name={s.icon} size={18}/></div>
+          <div style={{ flex: 1 }}>
+            <div className="modal-title">{s.title}</div>
+            <div className="modal-sub">Step {step + 1} of {STEPS.length}</div>
+          </div>
+          <button className="icon-btn" onClick={dismiss} title="Skip"><Icon name="x" size={16}/></button>
+        </div>
+        <div className="modal-body" style={{ minHeight: 80 }}>
+          <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.6, color: 'var(--canvas-text-2)' }}>{s.body}</p>
+        </div>
+        <div className="modal-foot" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {STEPS.map((_, i) => (
+              <span key={i}
+                onClick={() => setStep(i)}
+                style={{
+                  width: 8, height: 8, borderRadius: '50%', cursor: 'pointer',
+                  background: i === step ? 'var(--canvas-accent)' : 'var(--canvas-surface-3)',
+                  transition: 'background .15s',
+                }}/>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {step > 0 && (
+              <button className="btn btn-ghost" onClick={() => setStep(s => s - 1)}>Back</button>
+            )}
+            {!isLast && (
+              <button className="btn btn-ghost" onClick={dismiss}>Skip</button>
+            )}
+            <button className="btn btn-primary" onClick={() => isLast ? dismiss() : setStep(s => s + 1)}>
+              {isLast ? <><Icon name="check" size={13}/>Get started</> : <>Next<Icon name="arrow" size={13}/></>}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CanvasWelcomeTour;

--- a/phd-advisor-frontend/src/components/canvas/CanvasWelcomeTour.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasWelcomeTour.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Icon from './CanvasIcon';
+import { MOD } from './platform';
 
 const TOUR_KEY = 'canvas-tour-seen-v1';
 
@@ -7,17 +8,22 @@ const STEPS = [
   {
     title: 'Welcome to your Canvas',
     icon: 'sparkles',
-    body: 'AI-summarized highlights from your research conversations live here. Each insight is a discrete task you can mark open, in-progress, completed, or abandoned.',
+    body: 'This is your research workspace. Two views — Insights (AI-summarized highlights from your chats) and Workspace (a customizable dashboard of widgets). It starts empty so you can build it the way you want.',
   },
   {
-    title: 'Filter, sort, pin',
+    title: 'Add widgets from the palette',
+    icon: 'plus',
+    body: `Click "Add widget" on the Workspace view, or hit ${MOD}+K and search. There are 30+ widgets — bibliography, kanban, pomodoro, writing tracker, plus three "anti-yes-man" widgets that push back on your thinking.`,
+  },
+  {
+    title: 'Make it yours',
     icon: 'layout',
-    body: 'Use the filter chips to narrow by status, category, or confidence. Pin the most important sections to keep them at the top. The Tasks view flattens everything into a single to-do list.',
+    body: 'Drag widget headers to reorder. Click the size pill (S/M/L) to resize. Hover and click trash to remove. Layout and content auto-save to your browser.',
   },
   {
-    title: 'Ask follow-up',
-    icon: 'message',
-    body: 'Each insight has an "Ask follow-up" action that opens a fresh chat with the relevant context preloaded — useful when a synthesis raises a new question worth digging into.',
+    title: 'Try the anti-yes-man widgets',
+    icon: 'gavel',
+    body: 'Reviewer 2, Devil\'s Advocate, and Scope Realism are tuned to push back, not validate. They\'re where the real work gets sharpened. Add them last — when you\'re ready for honest feedback.',
   },
 ];
 

--- a/phd-advisor-frontend/src/components/canvas/CanvasWidgets.js
+++ b/phd-advisor-frontend/src/components/canvas/CanvasWidgets.js
@@ -1,0 +1,1663 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import Icon from './CanvasIcon';
+import { MOD } from './platform';
+
+const fireToast = (msg, kind = 'success') =>
+  window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg, kind } }));
+const fireActivity = (source, msg) =>
+  window.dispatchEvent(new CustomEvent('canvas-activity', { detail: { source, msg } }));
+
+// Shared empty-state block — every widget uses this so the look stays consistent.
+function EmptyState({ icon = 'sparkles', title, hint, action }) {
+  return (
+    <div className="widget-empty">
+      <div className="widget-empty-icon"><Icon name={icon} size={20}/></div>
+      <div className="widget-empty-title">{title}</div>
+      {hint && <div className="widget-empty-hint">{hint}</div>}
+      {action && <div className="widget-empty-action">{action}</div>}
+    </div>
+  );
+}
+
+// Cross-widget drag-drop helpers — one mime type, JSON payload tagged by `kind`.
+const X_MIME = 'application/x-canvas-item';
+const setDragPayload = (e, kind, payload) => {
+  e.dataTransfer.setData(X_MIME, JSON.stringify({ kind, payload }));
+  e.dataTransfer.effectAllowed = 'copy';
+};
+const readDragPayload = (e) => {
+  try { return JSON.parse(e.dataTransfer.getData(X_MIME)); } catch { return null; }
+};
+
+// ===== Bibliography =====
+export function BibliographyWidget({ state, setState, openModal }) {
+  const formats = ['APA', 'MLA', 'Chicago', 'BibTeX'];
+  const fmt = state.format || 'APA';
+  const [sortBy, setSortBy] = useState('year');
+  const [dropOver, setDropOver] = useState(false);
+
+  const onDrop = async (e) => {
+    e.preventDefault();
+    setDropOver(false);
+    const data = readDragPayload(e);
+    if (!data || data.kind !== 'paper') return;
+    const p = data.payload;
+    // If we have a DOI, hit CrossRef and build a real citation; else stub from title.
+    const titleStr = p.title || 'Untitled';
+    let entry = {
+      key: 'cite' + Date.now(),
+      authors: 'Unknown',
+      title: titleStr.replace(/^.*?— /, ''),
+      journal: '',
+      year: new Date().getFullYear(),
+      cited: 0,
+      doi: p.doi || '',
+    };
+    if (p.doi) {
+      try {
+        const cleaned = p.doi.trim().replace(/^https?:\/\/(dx\.)?doi\.org\//, '');
+        const res = await fetch(`https://api.crossref.org/works/${encodeURIComponent(cleaned)}`);
+        if (res.ok) {
+          const json = await res.json();
+          const w = json.message;
+          entry.authors = (w.author || []).map(a => `${a.family || ''}, ${(a.given || '').charAt(0)}.`).join('; ') || entry.authors;
+          entry.title = (w.title && w.title[0]) || entry.title;
+          entry.journal = (w['container-title'] && w['container-title'][0]) || '';
+          entry.year = (w.issued && w.issued['date-parts'] && w.issued['date-parts'][0][0]) || entry.year;
+          const firstAuthor = (entry.authors.split(',')[0] || 'cite').toLowerCase().replace(/[^a-z]/g, '');
+          entry.key = firstAuthor + entry.year;
+        }
+      } catch { /* fall through with stub */ }
+    }
+    setState({ ...state, entries: [...state.entries, entry] });
+    fireToast(`@${entry.key} added from Reading Queue`);
+    fireActivity('Bibliography', `Added @${entry.key} (from Reading Queue)`);
+  };
+
+  const setFmt = (f) => setState({ ...state, format: f });
+
+  const formatEntry = (e) => {
+    if (fmt === 'APA') return `${e.authors} (${e.year}). ${e.title}. <em>${e.journal}</em>.`;
+    if (fmt === 'MLA') return `${e.authors.split(',')[0]}, et al. "${e.title}." <em>${e.journal}</em>, ${e.year}.`;
+    if (fmt === 'Chicago') return `${e.authors}. "${e.title}." <em>${e.journal}</em> (${e.year}).`;
+    return `@article{${e.key},\n  author = {${e.authors}},\n  title = {${e.title}},\n  journal = {${e.journal}},\n  year = {${e.year}}\n}`;
+  };
+
+  const sorted = useMemo(() => {
+    const arr = [...state.entries];
+    if (sortBy === 'year') arr.sort((a, b) => b.year - a.year);
+    if (sortBy === 'author') arr.sort((a, b) => a.authors.localeCompare(b.authors));
+    if (sortBy === 'cited') arr.sort((a, b) => b.cited - a.cited);
+    return arr;
+  }, [state.entries, sortBy]);
+
+  const copy = () => {
+    const out = sorted.map(formatEntry).map(s => s.replace(/<[^>]+>/g, '')).join('\n\n');
+    navigator.clipboard?.writeText(out);
+    fireToast(`${sorted.length} citations copied as ${fmt}`);
+  };
+
+  const remove = (key) => {
+    const e = state.entries.find(x => x.key === key);
+    setState({ ...state, entries: state.entries.filter(x => x.key !== key) });
+    fireToast(`Removed @${e.key}`);
+  };
+
+  const edit = (entry) => openModal('add-citation', {
+    initial: entry,
+    onAdd: (next) => setState({ ...state, entries: state.entries.map(e => e.key === entry.key ? next : e) }),
+  });
+
+  return (
+    <div
+      onDragOver={(e) => { if (e.dataTransfer.types.includes(X_MIME)) { e.preventDefault(); setDropOver(true); } }}
+      onDragLeave={() => setDropOver(false)}
+      onDrop={onDrop}
+      style={{ display: 'flex', flexDirection: 'column', gap: 10, position: 'relative', flex: 1 }}
+      className={dropOver ? 'canvas-drop-active' : ''}
+    >
+      {dropOver && (
+        <div className="canvas-drop-overlay">
+          <Icon name="plus" size={18}/>
+          <span>Drop to add citation</span>
+        </div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'space-between' }}>
+        <div className="format-tabs">
+          {formats.map(f => (
+            <button key={f} className={`format-tab ${fmt === f ? 'active' : ''}`} onClick={() => setFmt(f)}>{f}</button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <select className="select" style={{ width: 'auto', padding: '4px 8px', fontSize: 11, fontFamily: 'var(--canvas-mono)' }} value={sortBy} onChange={e => setSortBy(e.target.value)}>
+            <option value="year">↓ year</option>
+            <option value="author">A–Z</option>
+            <option value="cited">↓ cited</option>
+          </select>
+          <button className="icon-btn" onClick={copy} title="Copy all"><Icon name="copy" size={14}/></button>
+          <button className="icon-btn" onClick={() => openModal('add-citation', { onAdd: (entry) => setState({ ...state, entries: [...state.entries, entry] }) })} title="Add"><Icon name="plus" size={14}/></button>
+        </div>
+      </div>
+      <div className="bib-list">
+        {sorted.map(e => (
+          <div key={e.key} className="note-row" style={{ padding: '8px 10px' }}>
+            <div className="bib-cite" style={{ fontSize: 12 }} dangerouslySetInnerHTML={{ __html: formatEntry(e) }}/>
+            <div className="bib-meta">
+              <span className="key">@{e.key}</span>
+              <span>cited {e.cited.toLocaleString()}x</span>
+            </div>
+            <div className="row-actions">
+              <button className="icon-btn" onClick={() => edit(e)} title="Edit"><Icon name="pencil" size={11}/></button>
+              <button className="icon-btn" onClick={() => remove(e.key)} title="Delete"><Icon name="trash" size={11}/></button>
+            </div>
+          </div>
+        ))}
+        {sorted.length === 0 && (
+          <EmptyState
+            icon="book"
+            title="No citations yet"
+            hint="Add one with the + button, paste a DOI, or drag a paper here from the Reading Queue."
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ===== Kanban (with priority filter chips + due-date sort) =====
+const PRI_RANK = { high: 0, med: 1, low: 2 };
+export function KanbanWidget({ state, setState, openModal }) {
+  const [dragId, setDragId] = useState(null);
+  const [dragCol, setDragCol] = useState(null);
+  const [editId, setEditId] = useState(null);
+  const [priFilter, setPriFilter] = useState('all');
+  const [sortBy, setSortBy] = useState('manual');
+
+  const move = (id, toCol) => setState({ ...state, cards: state.cards.map(c => c.id === id ? { ...c, col: toCol } : c) });
+  const remove = (id) => setState({ ...state, cards: state.cards.filter(c => c.id !== id) });
+  const updateTitle = (id, title) => setState({ ...state, cards: state.cards.map(c => c.id === id ? { ...c, title } : c) });
+
+  const addCard = (col) => openModal('add-task', {
+    onAdd: (card) => setState({ ...state, cards: [...state.cards, { ...card, id: 'k' + Date.now(), col }] }),
+  });
+
+  const editCard = (card) => openModal('add-task', {
+    initial: card,
+    onAdd: (next) => setState({ ...state, cards: state.cards.map(c => c.id === card.id ? { ...c, ...next } : c) }),
+  });
+
+  const visibleCards = (state.cards || []).filter(c => priFilter === 'all' || c.priority === priFilter);
+  const sortCards = (cards) => {
+    if (sortBy === 'priority') return [...cards].sort((a, b) => (PRI_RANK[a.priority] ?? 9) - (PRI_RANK[b.priority] ?? 9));
+    if (sortBy === 'due') {
+      const parseDue = (m) => {
+        if (!m) return Infinity;
+        const d = new Date(m);
+        return isNaN(d) ? Infinity : d.getTime();
+      };
+      return [...cards].sort((a, b) => parseDue(a.meta) - parseDue(b.meta));
+    }
+    return cards;
+  };
+
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap', fontSize: 11 }}>
+        <span style={{ color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 600 }}>Filter</span>
+        {[['all', 'All'], ['high', 'High'], ['med', 'Med'], ['low', 'Low']].map(([v, l]) => (
+          <button key={v} className={`palette-cat ${priFilter === v ? 'active' : ''}`}
+            onClick={() => setPriFilter(v)} style={{ padding: '3px 9px', fontSize: 11 }}>{l}</button>
+        ))}
+        <span style={{ marginLeft: 'auto', color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 600 }}>Sort</span>
+        <select className="select" style={{ width: 'auto', padding: '3px 8px', fontSize: 11 }} value={sortBy} onChange={e => setSortBy(e.target.value)}>
+          <option value="manual">Manual</option>
+          <option value="priority">Priority</option>
+          <option value="due">Due date</option>
+        </select>
+      </div>
+    <div className="kanban">
+      {state.cols.map(col => {
+        const cards = sortCards(visibleCards.filter(c => c.col === col.id));
+        return (
+          <div key={col.id}
+            className={`kan-col ${dragCol === col.id ? 'drag-target' : ''}`}
+            onDragOver={(e) => { e.preventDefault(); setDragCol(col.id); }}
+            onDragLeave={() => setDragCol(null)}
+            onDrop={(e) => { e.preventDefault(); if (dragId) move(dragId, col.id); setDragCol(null); setDragId(null); }}>
+            <div className="kan-col-head">
+              <span>{col.label}</span>
+              <span className="count">{cards.length}</span>
+            </div>
+            {cards.map(card => (
+              <div key={card.id}
+                className={`kan-card ${card.priority} ${dragId === card.id ? 'dragging' : ''}`}
+                draggable={editId !== card.id}
+                onDragStart={(e) => { setDragId(card.id); e.dataTransfer.effectAllowed = 'move'; }}
+                onDragEnd={() => { setDragId(null); setDragCol(null); }}
+                onDoubleClick={() => editCard(card)}>
+                <span className="priority-bar"/>
+                {editId === card.id ? (
+                  <input
+                    className="inline-input"
+                    style={{ marginLeft: 6, width: 'calc(100% - 6px)' }}
+                    autoFocus
+                    defaultValue={card.title}
+                    onBlur={(e) => { updateTitle(card.id, e.target.value); setEditId(null); }}
+                    onKeyDown={(e) => { if (e.key === 'Enter') e.target.blur(); if (e.key === 'Escape') setEditId(null); }}
+                  />
+                ) : (
+                  <div className="kan-title" onClick={() => setEditId(card.id)}>{card.title}</div>
+                )}
+                <div className="kan-meta">
+                  <span>{card.priority.toUpperCase()}</span>
+                  <span>·</span>
+                  <span>{card.meta}</span>
+                  <span style={{ flex: 1 }}/>
+                  <button className="icon-btn" style={{ width: 16, height: 16, opacity: 0.5 }} onClick={(e) => { e.stopPropagation(); remove(card.id); }} title="Delete"><Icon name="x" size={10}/></button>
+                </div>
+              </div>
+            ))}
+            <button className="add-tiny" onClick={() => addCard(col.id)}>+ Add</button>
+          </div>
+        );
+      })}
+    </div>
+    </>
+  );
+}
+
+// ===== Pomodoro =====
+export function PomodoroWidget({ state, setState }) {
+  const [running, setRunning] = useState(false);
+  const [mode, setMode] = useState('focus');
+  const [secs, setSecs] = useState(state.focus * 60);
+  const [editing, setEditing] = useState(false);
+  const total = (mode === 'focus' ? state.focus : state.brk) * 60;
+
+  useEffect(() => {
+    if (!running) return;
+    const t = setInterval(() => {
+      setSecs(s => {
+        if (s <= 1) {
+          const next = mode === 'focus' ? 'break' : 'focus';
+          setMode(next);
+          if (mode === 'focus') {
+            setState({ ...state, sessionsToday: state.sessionsToday + 1 });
+            fireToast('Focus session complete — 5 min break');
+          }
+          return (next === 'focus' ? state.focus : state.brk) * 60;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(t);
+  }, [running, mode, state, setState]);
+
+  const mm = String(Math.floor(secs / 60)).padStart(2, '0');
+  const ss = String(secs % 60).padStart(2, '0');
+  const r = 56, c = 2 * Math.PI * r;
+  const dash = c * (1 - secs / total);
+  const reset = () => { setRunning(false); setMode('focus'); setSecs(state.focus * 60); };
+
+  return (
+    <div className="pomo">
+      <div className={`pomo-ring ${mode === 'break' ? 'break' : ''}`}>
+        <svg width="130" height="130">
+          <circle className="track" cx="65" cy="65" r={r} strokeWidth="6" fill="none"/>
+          <circle className="fill" cx="65" cy="65" r={r} strokeWidth="6" fill="none" strokeDasharray={c} strokeDashoffset={dash}/>
+        </svg>
+        <div className="pomo-time">
+          <div className="t">{mm}:{ss}</div>
+          <div className="l">{mode === 'focus' ? 'focus' : 'break'}</div>
+        </div>
+      </div>
+      <div className="pomo-controls">
+        <button className="btn btn-primary" onClick={() => setRunning(r => !r)}>
+          <Icon name={running ? 'pause' : 'play'} size={13}/>{running ? 'Pause' : 'Start'}
+        </button>
+        <button className="btn" onClick={reset} title="Reset"><Icon name="reset" size={13}/></button>
+        <button className="btn" onClick={() => setEditing(e => !e)} title="Edit durations"><Icon name="settings" size={13}/></button>
+      </div>
+      {editing ? (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 11, color: 'var(--canvas-text-3)' }}>
+          <span>focus</span>
+          <input type="number" min="1" max="90" className="input" style={{ width: 50, padding: '4px 6px', fontFamily: 'var(--canvas-mono)' }}
+            value={state.focus} onChange={e => { const v = +e.target.value || 25; setState({ ...state, focus: v }); if (!running) setSecs(v*60); }}/>
+          <span>break</span>
+          <input type="number" min="1" max="30" className="input" style={{ width: 50, padding: '4px 6px', fontFamily: 'var(--canvas-mono)' }}
+            value={state.brk} onChange={e => setState({ ...state, brk: +e.target.value || 5 })}/>
+          <span>min</span>
+        </div>
+      ) : (
+        <div className="pomo-stats">
+          <span>today <b>{state.sessionsToday}</b></span><span>·</span>
+          <span>{state.focus}/{state.brk} min</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ===== Writing tracker =====
+// Inline writing pad with multi-chapter targets, live word count, and 28-day heatmap.
+const todayKey = () => new Date().toISOString().slice(0, 10);
+const countWords = (s) => (s || '').trim().split(/\s+/).filter(Boolean).length;
+
+export function WritingWidget({ state, setState }) {
+  const chapters = state.chapters || [];
+  const activeId = state.activeChapterId || chapters[0]?.id;
+  const active = chapters.find(c => c.id === activeId) || chapters[0];
+  const dailyTotals = state.dailyTotals || {};
+  const today = todayKey();
+  const todayWords = dailyTotals[today] || 0;
+  const target = active?.target ?? state.target ?? 500;
+  const pct = target > 0 ? Math.min(100, Math.round((todayWords / target) * 100)) : 0;
+
+  // Streak: count consecutive days back from today with words > 0
+  const streak = (() => {
+    let s = 0;
+    const d = new Date();
+    while (true) {
+      const k = d.toISOString().slice(0, 10);
+      if ((dailyTotals[k] || 0) > 0) { s++; d.setDate(d.getDate() - 1); } else break;
+      if (s > 365) break;
+    }
+    return s;
+  })();
+
+  const updateChapter = (id, patch) => setState({
+    ...state,
+    chapters: chapters.map(c => c.id === id ? { ...c, ...patch } : c),
+  });
+
+  const onDraftChange = (text) => {
+    const words = countWords(text);
+    updateChapter(active.id, { draft: text });
+    // Track per-day session word count keyed off the active chapter's last-saved baseline
+    const sessionBaseline = active.savedAt === today ? (active.savedWords || 0) : 0;
+    const delta = Math.max(0, words - sessionBaseline);
+    setState({
+      ...state,
+      chapters: chapters.map(c => c.id === active.id ? { ...c, draft: text } : c),
+      dailyTotals: { ...dailyTotals, [today]: (dailyTotals[today] || 0) - (state._sessionDelta || 0) + delta },
+      _sessionDelta: delta,
+    });
+  };
+
+  const saveSession = () => {
+    const words = countWords(active.draft || '');
+    setState({
+      ...state,
+      chapters: chapters.map(c => c.id === active.id ? { ...c, savedAt: today, savedWords: words } : c),
+      _sessionDelta: 0,
+    });
+    fireToast(`Saved · ${words} words in ${active.name}`);
+    fireActivity('Writing', `Saved ${words} words to "${active.name}"`);
+  };
+
+  const addChapter = () => {
+    const id = 'c-' + Date.now();
+    setState({
+      ...state,
+      chapters: [...chapters, { id, name: 'New chapter', target: 500, draft: '' }],
+      activeChapterId: id,
+    });
+  };
+
+  const deleteChapter = (id) => {
+    if (chapters.length === 1) return fireToast('Need at least one chapter', 'danger');
+    const next = chapters.filter(c => c.id !== id);
+    setState({ ...state, chapters: next, activeChapterId: next[0].id });
+  };
+
+  // 28-day heatmap
+  const days = Array.from({ length: 28 }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - (27 - i));
+    return d.toISOString().slice(0, 10);
+  });
+  const allCounts = Object.values(dailyTotals);
+  const maxDay = Math.max(target, ...allCounts, 1);
+  const intensity = (n) => {
+    if (!n) return 0;
+    const ratio = n / maxDay;
+    if (ratio < 0.25) return 1;
+    if (ratio < 0.5) return 2;
+    if (ratio < 0.75) return 3;
+    return 4;
+  };
+
+  const draftWords = countWords(active?.draft || '');
+  const totalWritten = chapters.reduce((sum, c) => sum + countWords(c.draft || ''), 0);
+  const totalTarget = chapters.reduce((sum, c) => sum + (c.target || 0), 0);
+
+  return (
+    <>
+      {/* Chapter switcher */}
+      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
+        {chapters.map(c => (
+          <button key={c.id}
+            onClick={() => setState({ ...state, activeChapterId: c.id })}
+            className={`format-tab ${c.id === active?.id ? 'active' : ''}`}
+            style={{ padding: '4px 9px', fontSize: 11, fontFamily: 'var(--canvas-sans)', textTransform: 'none', letterSpacing: 0 }}>
+            {c.name}
+          </button>
+        ))}
+        <button className="add-tiny" onClick={addChapter} style={{ padding: '4px 8px' }}>+ Chapter</button>
+      </div>
+
+      {/* Active chapter editing */}
+      {active && (
+        <>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input
+              className="inline-input"
+              style={{ flex: 1, fontSize: 12.5, fontWeight: 500 }}
+              value={active.name}
+              onChange={e => updateChapter(active.id, { name: e.target.value })}
+            />
+            <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11, color: 'var(--canvas-text-3)' }}>target</span>
+            <input
+              type="number"
+              className="inline-input"
+              style={{ width: 70, fontFamily: 'var(--canvas-mono)' }}
+              value={active.target ?? 500}
+              onChange={e => updateChapter(active.id, { target: +e.target.value || 0 })}
+            />
+            {chapters.length > 1 && (
+              <button className="icon-btn" style={{ width: 22, height: 22 }} onClick={() => deleteChapter(active.id)} title="Delete chapter">
+                <Icon name="trash" size={11}/>
+              </button>
+            )}
+          </div>
+
+          <textarea
+            className="textarea"
+            placeholder="Start writing here. Word count tracks live."
+            style={{ minHeight: 110, fontFamily: 'var(--canvas-sans)', fontSize: 13, lineHeight: 1.55 }}
+            value={active.draft || ''}
+            onChange={e => onDraftChange(e.target.value)}
+          />
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontFamily: 'var(--canvas-mono)', fontSize: 11, color: 'var(--canvas-text-3)' }}>
+            <span style={{ color: 'var(--canvas-accent)', fontWeight: 600 }}>{draftWords}</span>
+            <span>/</span>
+            <span>{active.target ?? 500} words</span>
+            <div className="progress" style={{ flex: 1, height: 4 }}>
+              <i style={{ width: Math.min(100, (draftWords / Math.max(1, active.target ?? 500)) * 100) + '%' }}/>
+            </div>
+            <button className="btn" style={{ padding: '4px 9px', fontSize: 11 }} onClick={saveSession}>
+              <Icon name="check" size={11}/>Save session
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* Today/streak/total stats */}
+      <div className="write-stats">
+        <div className="stat">
+          <div className="stat-label">Today</div>
+          <div className="stat-value accent">{todayWords}</div>
+          <div className="stat-sub">{pct}% of {target}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-label">Streak</div>
+          <div className="stat-value">{streak}<span style={{ fontSize: 13, color: 'var(--canvas-text-3)', marginLeft: 3 }}>d</span></div>
+          <div className="stat-sub">days writing</div>
+        </div>
+        <div className="stat">
+          <div className="stat-label">Total</div>
+          <div className="stat-value">{totalWritten}</div>
+          <div className="stat-sub">/ {totalTarget} all chapters</div>
+        </div>
+      </div>
+
+      {/* 28-day heatmap */}
+      <div>
+        <div style={{ fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 4 }}>
+          Last 28 days
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(28, 1fr)', gap: 2 }}>
+          {days.map(d => {
+            const n = dailyTotals[d] || 0;
+            const lvl = intensity(n);
+            const bg = ['var(--canvas-surface-2)', 'var(--canvas-accent-glow)', 'rgba(99,102,241,0.45)', 'rgba(99,102,241,0.7)', 'var(--canvas-accent)'][lvl];
+            return (
+              <div key={d}
+                title={`${d}: ${n} words`}
+                style={{ aspectRatio: '1', borderRadius: 2, background: bg, border: '1px solid var(--canvas-border)' }}/>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ===== Deadlines (with .ics calendar export) =====
+const toICSDate = (d) => {
+  const z = (n) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}${z(d.getUTCMonth() + 1)}${z(d.getUTCDate())}T${z(d.getUTCHours())}${z(d.getUTCMinutes())}00Z`;
+};
+const downloadICS = (deadline) => {
+  const start = new Date(deadline.date + 'T09:00:00Z');
+  const end = new Date(deadline.date + 'T10:00:00Z');
+  const escape = (s) => (s || '').replace(/[,;\\]/g, m => '\\' + m).replace(/\n/g, '\\n');
+  const ics = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Canvas//Deadlines//EN',
+    'BEGIN:VEVENT',
+    `UID:${deadline.id}@canvas`,
+    `DTSTAMP:${toICSDate(new Date())}`,
+    `DTSTART:${toICSDate(start)}`,
+    `DTEND:${toICSDate(end)}`,
+    `SUMMARY:${escape(deadline.title)}`,
+    `DESCRIPTION:Tag: ${escape(deadline.tag || '')}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+  const blob = new Blob([ics], { type: 'text/calendar' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `${deadline.title.replace(/[^\w\d-]/g, '_')}.ics`;
+  a.click();
+  fireToast(`Calendar event downloaded for "${deadline.title}"`);
+};
+
+export function DeadlinesWidget({ state, setState, openModal }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const enriched = state.map(d => {
+    const date = new Date(d.date);
+    const days = Math.ceil((date - today) / (1000 * 60 * 60 * 24));
+    return { ...d, days, date };
+  }).sort((a, b) => a.days - b.days);
+
+  const remove = (id) => {
+    const dl = state.find(x => x.id === id);
+    setState(state.filter(x => x.id !== id));
+    fireToast(`Removed "${dl.title}"`);
+  };
+  const edit = (dl) => openModal('add-deadline', {
+    initial: dl,
+    onAdd: (next) => setState(state.map(x => x.id === dl.id ? { ...x, ...next } : x)),
+  });
+
+  return (
+    <>
+      <div className="dl-list">
+        {enriched.map(d => {
+          const cls = d.days <= 7 ? 'urgent' : d.days <= 21 ? 'warn' : '';
+          return (
+            <div key={d.id} className="dl-row" style={{ position: 'relative' }}>
+              <div className={`dl-day ${cls}`}>
+                <span className="num">{d.days}</span>
+                <span className="lbl">days</span>
+              </div>
+              <div className="dl-info">
+                <div className="dl-title">{d.title}</div>
+                <div className="dl-sub">{d.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} · {d.tag}</div>
+              </div>
+              <div className="row-actions">
+                <button className="icon-btn" onClick={() => downloadICS(d)} title="Add to calendar (.ics)"><Icon name="download" size={11}/></button>
+                <button className="icon-btn" onClick={() => edit(d)} title="Edit"><Icon name="pencil" size={11}/></button>
+                <button className="icon-btn" onClick={() => remove(d.id)} title="Delete"><Icon name="trash" size={11}/></button>
+              </div>
+            </div>
+          );
+        })}
+        {enriched.length === 0 && (
+          <EmptyState
+            icon="calendar"
+            title="No deadlines yet"
+            hint="Track due dates and download them straight into your calendar as .ics files."
+          />
+        )}
+      </div>
+      <button className="add-tiny" onClick={() => openModal('add-deadline', {
+        onAdd: (dl) => setState([...state, { ...dl, id: 'd' + Date.now() }]),
+      })}>+ Add deadline</button>
+    </>
+  );
+}
+
+// ===== Budget =====
+export function BudgetWidget({ state, setState, openModal }) {
+  const total = state.items.reduce((a, b) => a + b.spent, 0);
+  const pct = (total / state.cap) * 100;
+  const [editingCap, setEditingCap] = useState(false);
+
+  const editItem = (item, idx) => openModal('budget-item', {
+    initial: item,
+    onSave: (next) => setState({ ...state, items: state.items.map((x, i) => i === idx ? next : x) }),
+    onDelete: () => setState({ ...state, items: state.items.filter((_, i) => i !== idx) }),
+  });
+  const addItem = () => openModal('budget-item', {
+    onSave: (next) => setState({ ...state, items: [...state.items, next] }),
+  });
+
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <div>
+          <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 22, fontWeight: 600, letterSpacing: '-0.02em' }}>${total.toLocaleString()}</span>
+          {editingCap ? (
+            <input type="number" autoFocus className="inline-input" style={{ width: 80, marginLeft: 6, fontFamily: 'var(--canvas-mono)' }}
+              defaultValue={state.cap}
+              onBlur={(e) => { setState({ ...state, cap: +e.target.value || state.cap }); setEditingCap(false); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') e.target.blur(); }}/>
+          ) : (
+            <span onClick={() => setEditingCap(true)} style={{ color: 'var(--canvas-text-3)', fontFamily: 'var(--canvas-mono)', fontSize: 12, marginLeft: 4, cursor: 'pointer', textDecoration: 'underline dashed', textDecorationColor: 'var(--canvas-text-4)', textUnderlineOffset: 2 }}>/ ${state.cap.toLocaleString()}</span>
+          )}
+        </div>
+        <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11, color: pct > 80 ? 'var(--canvas-warn)' : 'var(--canvas-text-3)' }}>{pct.toFixed(0)}% used</span>
+      </div>
+      <div className="budget-bar">
+        {state.items.map(item => (
+          <i key={item.label} style={{ background: item.color, width: (item.spent / state.cap * 100) + '%' }}/>
+        ))}
+      </div>
+      <div className="budget-list">
+        {state.items.map((item, i) => (
+          <div key={item.label} className="budget-row" style={{ cursor: 'pointer' }} onClick={() => editItem(item, i)}>
+            <span className="swatch" style={{ background: item.color }}/>
+            <span>{item.label}</span>
+            <span className="amt">${item.spent.toLocaleString()}</span>
+            <span className="pct">{((item.spent/state.cap)*100).toFixed(0)}%</span>
+          </div>
+        ))}
+      </div>
+      <button className="add-tiny" onClick={addItem}>+ Add category</button>
+    </>
+  );
+}
+
+// ===== Reading queue =====
+export function ReadingQueueWidget({ state, setState, openModal }) {
+  const colors = { high: 'var(--canvas-danger)', med: 'var(--canvas-warn)', low: 'var(--canvas-text-4)' };
+  const remove = (i, p) => {
+    setState(state.filter((_, j) => j !== i));
+    fireToast(`Marked "${p.title.slice(0, 30)}…" as read`);
+  };
+  const add = () => openModal('reading-paper', { onAdd: (p) => setState([...state, p]) });
+  const edit = (p, i) => openModal('reading-paper', {
+    initial: p,
+    onAdd: (next) => setState(state.map((x, j) => i === j ? next : x)),
+  });
+
+  return (
+    <>
+      <div className="dl-list">
+        {state.map((p, i) => (
+          <div key={i} className="dl-row"
+            draggable
+            onDragStart={(e) => setDragPayload(e, 'paper', p)}
+            title="Drag to Bibliography to add as citation"
+            style={{ padding: '7px 9px', position: 'relative', cursor: 'grab' }}>
+            <span style={{ width: 4, height: 28, borderRadius: 2, background: colors[p.priority], flexShrink: 0 }}/>
+            <div className="dl-info" onClick={() => edit(p, i)} style={{ cursor: 'pointer' }}>
+              <div className="dl-title" style={{ fontSize: 12 }}>{p.title}</div>
+              <div className="dl-sub">{p.priority} · ~{p.time}{p.doi ? ' · ' + p.doi : ''}</div>
+            </div>
+            <button className="icon-btn" style={{width:24,height:24}} title="Mark read" onClick={() => remove(i, p)}>
+              <Icon name="check" size={13}/>
+            </button>
+          </div>
+        ))}
+      </div>
+      <button className="add-tiny" onClick={add}>+ Add paper</button>
+    </>
+  );
+}
+
+// ===== Notes / Scratchpad — Markdown rendering + full-text search =====
+export function NotesWidget({ state, setState, openModal }) {
+  const notes = state.items || [];
+  const [search, setSearch] = useState('');
+  const add = () => openModal('note', { onSave: (n) => setState({ ...state, items: [{ ...n, id: 'n' + Date.now(), at: Date.now() }, ...notes] }) });
+  const edit = (note) => openModal('note', {
+    initial: note,
+    onSave: (next) => setState({ ...state, items: notes.map(x => x.id === note.id ? { ...x, ...next, at: Date.now() } : x) }),
+    onDelete: () => setState({ ...state, items: notes.filter(x => x.id !== note.id) }),
+  });
+
+  const fmt = (t) => {
+    const d = Date.now() - t;
+    if (d < 60_000) return 'just now';
+    if (d < 3600_000) return Math.floor(d / 60_000) + 'm';
+    if (d < 86400_000) return Math.floor(d / 3600_000) + 'h';
+    return Math.floor(d / 86400_000) + 'd';
+  };
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return notes;
+    const q = search.toLowerCase();
+    return notes.filter(n =>
+      (n.text || '').toLowerCase().includes(q) ||
+      (n.tag || '').toLowerCase().includes(q) ||
+      (n.linkTo || '').toLowerCase().includes(q)
+    );
+  }, [notes, search]);
+
+  return (
+    <>
+      <div style={{ position: 'relative' }}>
+        <span style={{ position: 'absolute', left: 9, top: '50%', transform: 'translateY(-50%)', color: 'var(--canvas-text-3)' }}>
+          <Icon name="search" size={12}/>
+        </span>
+        <input
+          className="input"
+          placeholder="Search notes (text, tag, link)…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ paddingLeft: 28, fontSize: 12 }}
+        />
+      </div>
+      <div className="note-list">
+        {filtered.map(n => (
+          <div key={n.id} className="note-row" onClick={() => edit(n)} style={{ cursor: 'pointer' }}>
+            <div className="note-text canvas-md">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{n.text || ''}</ReactMarkdown>
+            </div>
+            <div className="note-meta">
+              {n.tag && <span className="tag-pill">{n.tag}</span>}
+              <span>{fmt(n.at)}</span>
+              {n.linkTo && <span>→ {n.linkTo}</span>}
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          notes.length === 0 ? (
+            <EmptyState icon="notes" title="No notes yet" hint="Capture quick thoughts. Markdown supported. Type @ to mention citations, chapters, or tasks."/>
+          ) : (
+            <EmptyState icon="search" title={`No notes match "${search}"`} hint="Try a shorter query or clear the search box."/>
+          )
+        )}
+      </div>
+      <button className="add-tiny" onClick={add}>+ New note</button>
+    </>
+  );
+}
+
+// ===== Habit tracker =====
+export function HabitsWidget({ state, setState, openModal }) {
+  const habits = state.items || [];
+  const days = 7;
+  const dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+  const toggle = (id, day) => {
+    setState({
+      ...state,
+      items: habits.map(h => h.id === id
+        ? { ...h, log: { ...h.log, [day]: !h.log?.[day] } }
+        : h),
+    });
+  };
+  const add = () => openModal('habit', { onSave: (h) => setState({ ...state, items: [...habits, { ...h, id: 'h' + Date.now(), log: {} }] }) });
+  const edit = (h) => openModal('habit', {
+    initial: h,
+    onSave: (next) => setState({ ...state, items: habits.map(x => x.id === h.id ? { ...x, ...next } : x) }),
+    onDelete: () => setState({ ...state, items: habits.filter(x => x.id !== h.id) }),
+  });
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr repeat(7, 22px)', gap: 4, fontSize: 9.5, color: 'var(--canvas-text-4)', fontFamily: 'var(--canvas-mono)', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '0 2px' }}>
+          <span/>
+          {dayLabels.map((d, i) => <span key={i} style={{ textAlign: 'center' }}>{d}</span>)}
+        </div>
+        {habits.map(h => {
+          const checked = Array.from({length: days}, (_, i) => h.log?.[i]).filter(Boolean).length;
+          return (
+            <div key={h.id} style={{ display: 'grid', gridTemplateColumns: '1fr repeat(7, 22px)', gap: 4, alignItems: 'center' }}>
+              <div onClick={() => edit(h)} style={{ cursor: 'pointer', fontSize: 12, display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Icon name={h.icon || 'flame'} size={12} style={{ color: 'var(--canvas-accent)' }}/>
+                <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.label}</span>
+                <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 9.5, color: 'var(--canvas-text-3)' }}>{checked}/{days}</span>
+              </div>
+              {Array.from({length: days}).map((_, i) => (
+                <button key={i}
+                  onClick={() => toggle(h.id, i)}
+                  style={{
+                    width: 20, height: 20, borderRadius: 4,
+                    background: h.log?.[i] ? 'var(--canvas-accent)' : 'var(--canvas-surface-2)',
+                    border: `1px solid ${h.log?.[i] ? 'var(--canvas-accent)' : 'var(--canvas-border)'}`,
+                    color: h.log?.[i] ? 'var(--canvas-bg)' : 'transparent',
+                    display: 'grid', placeItems: 'center', cursor: 'pointer',
+                    transition: 'all .12s',
+                  }}>
+                  {h.log?.[i] && <Icon name="check" size={10}/>}
+                </button>
+              ))}
+            </div>
+          );
+        })}
+        {habits.length === 0 && (
+          <EmptyState icon="flame" title="No habits yet" hint="Track daily research practices. Read 1 paper, write 30 min, lab notebook entry."/>
+        )}
+      </div>
+      <button className="add-tiny" onClick={add}>+ New habit</button>
+    </>
+  );
+}
+
+// ===== Goals =====
+export function GoalsWidget({ state, setState, openModal }) {
+  const goals = state.items || [];
+  const add = () => openModal('goal', { onSave: (g) => setState({ ...state, items: [...goals, { ...g, id: 'g' + Date.now() }] }) });
+  const edit = (g) => openModal('goal', {
+    initial: g,
+    onSave: (next) => setState({ ...state, items: goals.map(x => x.id === g.id ? { ...x, ...next } : x) }),
+    onDelete: () => setState({ ...state, items: goals.filter(x => x.id !== g.id) }),
+  });
+  const updateProgress = (id, pct) => setState({ ...state, items: goals.map(g => g.id === id ? { ...g, progress: pct } : g) });
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {goals.map(g => (
+          <div key={g.id} className="note-row" style={{ padding: '10px 12px', cursor: 'pointer' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }} onClick={() => edit(g)}>
+              <Icon name="bullseye" size={13} style={{ color: 'var(--canvas-accent)' }}/>
+              <span style={{ fontSize: 13, fontWeight: 500, flex: 1 }}>{g.label}</span>
+              <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11, color: 'var(--canvas-accent)' }}>{g.progress}%</span>
+            </div>
+            <div className="progress" style={{ height: 5, marginTop: 2 }}>
+              <i style={{ width: g.progress + '%' }}/>
+            </div>
+            <input type="range" min="0" max="100" step="5" value={g.progress}
+              onChange={e => updateProgress(g.id, +e.target.value)}
+              style={{ width: '100%', accentColor: 'var(--canvas-accent)', marginTop: 2, height: 12 }}/>
+            {g.due && <div className="note-meta"><span>due {g.due}</span></div>}
+          </div>
+        ))}
+        {goals.length === 0 && (
+          <EmptyState icon="bullseye" title="No goals yet" hint="Quarterly OKRs, dissertation milestones, anything you want to track."/>
+        )}
+      </div>
+      <button className="add-tiny" onClick={add}>+ New goal</button>
+    </>
+  );
+}
+
+// ===== Meeting log =====
+export function MeetingsWidget({ state, setState, openModal }) {
+  const meetings = state.items || [];
+  const add = () => openModal('meeting', { onSave: (m) => setState({ ...state, items: [{ ...m, id: 'm' + Date.now() }, ...meetings] }) });
+  const edit = (m) => openModal('meeting', {
+    initial: m,
+    onSave: (next) => setState({ ...state, items: meetings.map(x => x.id === m.id ? { ...x, ...next } : x) }),
+    onDelete: () => setState({ ...state, items: meetings.filter(x => x.id !== m.id) }),
+  });
+
+  return (
+    <>
+      <div className="note-list">
+        {meetings.map(m => (
+          <div key={m.id} className="note-row" onClick={() => edit(m)} style={{ cursor: 'pointer' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <Icon name="user" size={12} style={{ color: 'var(--canvas-accent)' }}/>
+              <span style={{ fontSize: 12.5, fontWeight: 500, flex: 1 }}>{m.who}</span>
+              <span className="note-meta"><span>{m.date}</span></span>
+            </div>
+            {m.notes && <div className="note-text" style={{ fontSize: 12, color: 'var(--canvas-text-2)' }}>{m.notes}</div>}
+            {m.actions && <div className="note-meta"><span className="tag-pill">{(m.actions.match(/\n/g)?.length ?? 0) + 1} action(s)</span></div>}
+          </div>
+        ))}
+        {meetings.length === 0 && (
+          <EmptyState icon="message" title="No meetings logged" hint="Capture decisions, action items, and last contact for each stakeholder."/>
+        )}
+      </div>
+      <button className="add-tiny" onClick={add}>+ Log meeting</button>
+    </>
+  );
+}
+
+// ===== Outline Builder — nested collapsible tree, drag-reorder, indent/outdent =====
+export function OutlineWidget({ state, setState }) {
+  const items = state.items || [];
+  const expanded = state.expanded || {};
+  const [editingId, setEditingId] = useState(null);
+
+  const toggle = (id) => setState({ ...state, expanded: { ...expanded, [id]: !expanded[id] } });
+  const update = (id, patch) => setState({
+    ...state,
+    items: items.map(it => it.id === id ? { ...it, ...patch } : it),
+  });
+  const addItem = (afterId, depth = 0) => {
+    const id = 'o' + Date.now();
+    const idx = afterId ? items.findIndex(it => it.id === afterId) : items.length - 1;
+    const next = [...items];
+    next.splice(idx + 1, 0, { id, text: '', depth });
+    setState({ ...state, items: next });
+    setTimeout(() => setEditingId(id), 0);
+  };
+  const remove = (id) => setState({ ...state, items: items.filter(it => it.id !== id) });
+  const indent = (id) => {
+    const idx = items.findIndex(it => it.id === id);
+    if (idx <= 0) return;
+    const max = items[idx - 1].depth + 1;
+    if (items[idx].depth >= max) return;
+    update(id, { depth: items[idx].depth + 1 });
+  };
+  const outdent = (id) => {
+    const it = items.find(x => x.id === id);
+    if (!it || it.depth === 0) return;
+    update(id, { depth: it.depth - 1 });
+  };
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {items.length === 0 ? (
+          <EmptyState icon="list" title="Empty outline" hint="Click + Node below. Use Tab/Shift+Tab to indent, Enter for a sibling."/>
+        ) : items.map((it, i) => {
+          const hasChildren = items[i + 1] && items[i + 1].depth > it.depth;
+          const isCollapsed = !!expanded[it.id] && hasChildren;
+          // Hide rows that are descendants of a collapsed node
+          let parentCollapsed = false;
+          for (let j = i - 1; j >= 0; j--) {
+            if (items[j].depth < it.depth) {
+              if (expanded[items[j].id] && hasDescendantsAt(items, j, items[j].depth)) { parentCollapsed = true; break; }
+            }
+            if (items[j].depth === 0) break;
+          }
+          if (parentCollapsed) return null;
+          return (
+            <div key={it.id} style={{
+              display: 'flex', alignItems: 'center', gap: 4,
+              paddingLeft: it.depth * 18,
+              fontSize: 13, lineHeight: 1.5,
+            }}>
+              <button className="icon-btn" style={{ width: 18, height: 18 }}
+                onClick={() => hasChildren && toggle(it.id)}
+                title={hasChildren ? (isCollapsed ? 'Expand' : 'Collapse') : ''}>
+                {hasChildren ? (
+                  <Icon name="chevron" size={11} style={{ transform: isCollapsed ? 'none' : 'rotate(90deg)', transition: 'transform .15s' }}/>
+                ) : <span style={{ color: 'var(--canvas-text-4)', fontSize: 8 }}>•</span>}
+              </button>
+              {editingId === it.id ? (
+                <input
+                  className="inline-input"
+                  autoFocus
+                  defaultValue={it.text}
+                  onBlur={(e) => { update(it.id, { text: e.target.value }); setEditingId(null); }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); addItem(it.id, it.depth); }
+                    if (e.key === 'Escape') setEditingId(null);
+                    if (e.key === 'Tab') { e.preventDefault(); update(it.id, { text: e.target.value }); e.shiftKey ? outdent(it.id) : indent(it.id); }
+                  }}
+                />
+              ) : (
+                <span onClick={() => setEditingId(it.id)} style={{ flex: 1, cursor: 'text', color: it.text ? 'var(--canvas-text)' : 'var(--canvas-text-4)' }}>
+                  {it.text || 'Click to edit'}
+                </span>
+              )}
+              <button className="icon-btn" style={{ width: 18, height: 18, opacity: 0.5 }} onClick={() => remove(it.id)}>
+                <Icon name="x" size={10}/>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ display: 'flex', gap: 4, fontSize: 11, color: 'var(--canvas-text-3)' }}>
+        <button className="add-tiny" onClick={() => addItem(items[items.length - 1]?.id, 0)}>+ Node</button>
+        <span style={{ color: 'var(--canvas-text-4)', fontFamily: 'var(--canvas-mono)' }}>· Tab/Shift+Tab to indent · Enter to add sibling</span>
+      </div>
+    </>
+  );
+}
+function hasDescendantsAt(items, idx, depth) {
+  return items[idx + 1] && items[idx + 1].depth > depth;
+}
+
+// ===== Highlights & Quotes — paste a quote, attach citation, copy formatted =====
+export function HighlightsWidget({ state, setState }) {
+  const items = state.items || [];
+  const [text, setText] = useState('');
+  const [citeKey, setCiteKey] = useState('');
+  const [page, setPage] = useState('');
+
+  const add = () => {
+    if (!text.trim()) return;
+    const id = 'q' + Date.now();
+    setState({ ...state, items: [{ id, text: text.trim(), citeKey: citeKey.trim(), page: page.trim(), at: Date.now() }, ...items] });
+    setText(''); setCiteKey(''); setPage('');
+    fireToast('Quote saved');
+  };
+
+  const copy = (q) => {
+    const formatted = `"${q.text}" (${q.citeKey || 'unknown'}${q.page ? ', p. ' + q.page : ''})`;
+    navigator.clipboard?.writeText(formatted);
+    fireToast('Copied to clipboard');
+  };
+
+  const remove = (id) => setState({ ...state, items: items.filter(x => x.id !== id) });
+
+  return (
+    <>
+      <div className="form-grid">
+        <textarea
+          className="textarea"
+          placeholder="Paste a quote or excerpt…"
+          rows={3}
+          style={{ minHeight: 60, fontSize: 12.5 }}
+          value={text}
+          onChange={e => setText(e.target.value)}
+        />
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input className="input" placeholder="@citeKey" value={citeKey} onChange={e => setCiteKey(e.target.value)} style={{ flex: 1, fontFamily: 'var(--canvas-mono)' }}/>
+          <input className="input" placeholder="page" value={page} onChange={e => setPage(e.target.value)} style={{ width: 60, fontFamily: 'var(--canvas-mono)' }}/>
+          <button className="btn btn-primary" onClick={add} disabled={!text.trim()}>
+            <Icon name="plus" size={13}/>Add
+          </button>
+        </div>
+      </div>
+      <div className="note-list">
+        {items.map(q => (
+          <div key={q.id} className="note-row">
+            <div className="note-text" style={{ fontStyle: 'italic' }}>"{q.text}"</div>
+            <div className="note-meta">
+              {q.citeKey && <span className="tag-pill">@{q.citeKey}</span>}
+              {q.page && <span>p. {q.page}</span>}
+              <span style={{ flex: 1 }}/>
+              <button className="icon-btn" style={{ width: 22, height: 22 }} onClick={() => copy(q)} title="Copy formatted"><Icon name="copy" size={11}/></button>
+              <button className="icon-btn" style={{ width: 22, height: 22 }} onClick={() => remove(q.id)} title="Delete"><Icon name="trash" size={11}/></button>
+            </div>
+          </div>
+        ))}
+        {items.length === 0 && (
+          <EmptyState icon="cite" title="No quotes yet" hint="Paste a quote above with citation key and page; copy formatted with one click."/>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ===== LaTeX Scratchpad — live KaTeX rendering (loaded from CDN) =====
+const KATEX_CDN_CSS = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css';
+const KATEX_CDN_JS = 'https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js';
+let katexLoadingPromise = null;
+const ensureKatex = () => {
+  if (window.katex) return Promise.resolve(window.katex);
+  if (katexLoadingPromise) return katexLoadingPromise;
+  katexLoadingPromise = new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = KATEX_CDN_CSS;
+    document.head.appendChild(link);
+    const script = document.createElement('script');
+    script.src = KATEX_CDN_JS;
+    script.onload = () => resolve(window.katex);
+    script.onerror = () => reject(new Error('KaTeX CDN failed to load'));
+    document.head.appendChild(script);
+  });
+  return katexLoadingPromise;
+};
+
+export function LatexWidget({ state, setState }) {
+  const source = state.source ?? '';
+  const displayMode = state.displayMode ?? true;
+  const containerRef = useRef(null);
+  const [error, setError] = useState('');
+  const [katexReady, setKatexReady] = useState(!!window.katex);
+
+  useEffect(() => {
+    ensureKatex().then(() => setKatexReady(true)).catch(e => setError(e.message));
+  }, []);
+
+  useEffect(() => {
+    if (!katexReady || !containerRef.current) return;
+    try {
+      window.katex.render(source || '\\text{Type LaTeX above…}', containerRef.current, {
+        displayMode,
+        throwOnError: false,
+        errorColor: '#DC2626',
+      });
+      setError('');
+    } catch (e) {
+      setError(e.message);
+    }
+  }, [source, displayMode, katexReady]);
+
+  const insertSnippet = (snippet) => {
+    setState({ ...state, source: (source || '') + snippet });
+  };
+
+  const copyOut = () => {
+    navigator.clipboard?.writeText(source);
+    fireToast('LaTeX copied');
+  };
+
+  return (
+    <>
+      <textarea
+        className="textarea"
+        placeholder="\frac{1}{n}\sum_{i=1}^{n} x_i"
+        style={{ minHeight: 70, fontFamily: 'var(--canvas-mono)', fontSize: 12.5 }}
+        value={source}
+        onChange={e => setState({ ...state, source: e.target.value })}
+      />
+      <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap', fontSize: 11 }}>
+        <span style={{ color: 'var(--canvas-text-4)', fontFamily: 'var(--canvas-mono)' }}>insert:</span>
+        {[
+          ['frac', '\\frac{a}{b}'],
+          ['sum', '\\sum_{i=1}^{n}'],
+          ['int', '\\int_{a}^{b}'],
+          ['sqrt', '\\sqrt{x}'],
+          ['vec', '\\vec{x}'],
+          ['α', '\\alpha'],
+          ['β', '\\beta'],
+          ['Σ', '\\Sigma'],
+        ].map(([label, snip]) => (
+          <button key={label} className="chip" onClick={() => insertSnippet(snip)}>{label}</button>
+        ))}
+        <span style={{ flex: 1 }}/>
+        <button className="chip" onClick={() => setState({ ...state, displayMode: !displayMode })}>
+          {displayMode ? 'inline' : 'display'}
+        </button>
+        <button className="icon-btn" style={{ width: 22, height: 22 }} onClick={copyOut} title="Copy LaTeX source">
+          <Icon name="copy" size={11}/>
+        </button>
+      </div>
+      <div
+        style={{
+          background: 'var(--canvas-bg-2)',
+          border: '1px solid var(--canvas-border)',
+          borderRadius: 7,
+          padding: 14,
+          minHeight: 60,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--canvas-text)',
+          overflowX: 'auto',
+        }}
+      >
+        {!katexReady && !error && <span className="spinner"/>}
+        {error && <span style={{ fontSize: 11, color: 'var(--canvas-danger)', fontFamily: 'var(--canvas-mono)' }}>{error}</span>}
+        <div ref={containerRef} style={{ width: '100%', textAlign: 'center' }}/>
+      </div>
+    </>
+  );
+}
+
+// ===== Calendar — month grid with deadlines (red) and writing days (green) =====
+export function CalendarWidget({ state, setState, allStates = {} }) {
+  const monthStr = state.viewMonth || new Date().toISOString().slice(0, 7);
+  const [year, month] = monthStr.split('-').map(Number);
+  const first = new Date(year, month - 1, 1);
+  const startWeekday = first.getDay(); // Sunday-indexed
+  const daysInMonth = new Date(year, month, 0).getDate();
+
+  // Source data from cross-widget state
+  const deadlines = (allStates.deadlines || []).reduce((m, d) => {
+    const k = d.date.slice(0, 10);
+    (m[k] ||= []).push({ kind: 'deadline', ...d });
+    return m;
+  }, {});
+  const writing = ((allStates.writing && allStates.writing.dailyTotals) || {});
+  const kanbanCards = (allStates.kanban && allStates.kanban.cards) || [];
+
+  const cells = [];
+  for (let i = 0; i < startWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+    cells.push({ d, dateStr });
+  }
+  while (cells.length % 7) cells.push(null);
+
+  const shiftMonth = (delta) => {
+    const next = new Date(year, month - 1 + delta, 1);
+    setState({ ...state, viewMonth: next.toISOString().slice(0, 7) });
+  };
+  const monthLabel = first.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  const today = new Date().toISOString().slice(0, 10);
+
+  const goToToday = () => setState({ ...state, viewMonth: new Date().toISOString().slice(0, 7) });
+  const isCurrentMonth = monthStr === new Date().toISOString().slice(0, 7);
+
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <button className="icon-btn" onClick={() => shiftMonth(-1)} title="Previous month"><Icon name="chevron" size={14} style={{ transform: 'rotate(180deg)' }}/></button>
+        <div style={{ flex: 1, fontWeight: 600, fontSize: 13 }}>{monthLabel}</div>
+        {!isCurrentMonth && (
+          <button className="chip" onClick={goToToday} title="Jump to today" style={{ fontSize: 10.5 }}>Today</button>
+        )}
+        <button className="icon-btn" onClick={() => shiftMonth(1)} title="Next month"><Icon name="chevron" size={14}/></button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3, fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.06em', textAlign: 'center', fontFamily: 'var(--canvas-mono)' }}>
+        {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => <div key={i}>{d}</div>)}
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3 }}>
+        {cells.map((c, i) => {
+          if (!c) return <div key={i} style={{ aspectRatio: '1' }}/>;
+          const dls = deadlines[c.dateStr] || [];
+          const words = writing[c.dateStr] || 0;
+          const dueCards = kanbanCards.filter(card => (card.meta || '').includes(c.dateStr));
+          const isToday = c.dateStr === today;
+          return (
+            <div key={i}
+              title={[
+                ...dls.map(d => `Deadline: ${d.title}`),
+                ...(words ? [`${words} words written`] : []),
+                ...dueCards.map(d => `Task: ${d.title}`),
+              ].join('\n') || c.dateStr}
+              style={{
+                aspectRatio: '1',
+                border: `1px solid ${isToday ? 'var(--canvas-accent)' : 'var(--canvas-border)'}`,
+                background: isToday ? 'var(--canvas-accent-glow)' : 'var(--canvas-bg-2)',
+                borderRadius: 4,
+                padding: 3,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1,
+                fontSize: 10,
+                position: 'relative',
+              }}
+            >
+              <span style={{ fontFamily: 'var(--canvas-mono)', color: isToday ? 'var(--canvas-accent)' : 'var(--canvas-text-2)', fontWeight: isToday ? 700 : 500 }}>
+                {c.d}
+              </span>
+              <div style={{ display: 'flex', gap: 2, flexWrap: 'wrap', marginTop: 'auto' }}>
+                {dls.length > 0 && <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--canvas-danger)' }}/>}
+                {words > 0 && <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--canvas-ok)' }}/>}
+                {dueCards.length > 0 && <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--canvas-warn)' }}/>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ display: 'flex', gap: 12, fontSize: 10, color: 'var(--canvas-text-3)', flexWrap: 'wrap' }}>
+        <span><span style={{ display: 'inline-block', width: 6, height: 6, borderRadius: '50%', background: 'var(--canvas-danger)', marginRight: 4 }}/>Deadlines</span>
+        <span><span style={{ display: 'inline-block', width: 6, height: 6, borderRadius: '50%', background: 'var(--canvas-ok)', marginRight: 4 }}/>Writing</span>
+        <span><span style={{ display: 'inline-block', width: 6, height: 6, borderRadius: '50%', background: 'var(--canvas-warn)', marginRight: 4 }}/>Tasks</span>
+      </div>
+    </>
+  );
+}
+
+// ===== Activity Feed — surfaces recent edits across all widgets =====
+// Activity entries are written by other widgets via window.dispatchEvent('canvas-activity').
+// We persist a rolling buffer of the last 100 events in this widget's own state.
+export function ActivityWidget({ state, setState }) {
+  const events = state.events || [];
+  useEffect(() => {
+    const handler = (e) => {
+      const entry = { id: 'a' + Date.now() + Math.random(), at: Date.now(), ...e.detail };
+      setState(prev => {
+        const next = { ...(prev || {}), events: [entry, ...((prev && prev.events) || [])].slice(0, 100) };
+        return next;
+      });
+    };
+    window.addEventListener('canvas-activity', handler);
+    return () => window.removeEventListener('canvas-activity', handler);
+    // setState ref is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fmt = (t) => {
+    const d = Date.now() - t;
+    if (d < 60_000) return 'just now';
+    if (d < 3600_000) return Math.floor(d / 60_000) + 'm ago';
+    if (d < 86400_000) return Math.floor(d / 3600_000) + 'h ago';
+    return Math.floor(d / 86400_000) + 'd ago';
+  };
+
+  return (
+    <>
+      <div className="note-list">
+        {events.length === 0 && (
+          <EmptyState icon="graph" title="No activity yet" hint="Edits across your widgets will show up here as you work."/>
+        )}
+        {events.map(e => (
+          <div key={e.id} className="note-row" style={{ padding: '7px 9px' }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <span className="tag-pill">{e.source}</span>
+              <span style={{ fontSize: 12, flex: 1 }}>{e.msg}</span>
+              <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 10, color: 'var(--canvas-text-3)' }}>{fmt(e.at)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      {events.length > 0 && (
+        <button className="add-tiny" onClick={() => setState({ ...state, events: [] })}>Clear feed</button>
+      )}
+    </>
+  );
+}
+
+// ===== Daily Documenter — date-stamped journal with stub AI weekly summary =====
+export function DocumenterWidget({ state, setState }) {
+  const entries = state.entries || [];
+  const [draft, setDraft] = useState('');
+  const today = new Date().toISOString().slice(0, 10);
+  const [generating, setGenerating] = useState(false);
+
+  const append = () => {
+    if (!draft.trim()) return;
+    const entry = { id: 'doc' + Date.now(), date: today, text: draft.trim(), at: Date.now() };
+    setState({ ...state, entries: [entry, ...entries] });
+    setDraft('');
+    window.dispatchEvent(new CustomEvent('canvas-activity', {
+      detail: { source: 'Documenter', msg: `Logged: ${draft.trim().slice(0, 50)}…` },
+    }));
+    fireToast('Entry saved');
+  };
+
+  const remove = (id) => setState({ ...state, entries: entries.filter(e => e.id !== id) });
+
+  // TODO(LLM): wire to /api/summarize-week with last 7 days of entries.
+  // Backend call shape (commented because endpoint isn't ready):
+  // const generateSummary = async () => {
+  //   const last7 = entries.filter(e => Date.now() - e.at < 7*86400_000);
+  //   const res = await fetch(`${process.env.REACT_APP_API_URL}/api/canvas/summarize`, {
+  //     method: 'POST',
+  //     body: JSON.stringify({ entries: last7 }),
+  //   });
+  //   const { summary } = await res.json();
+  //   setState({ ...state, lastSummary: { at: Date.now(), text: summary } });
+  // };
+  const generateSummary = () => {
+    // Stub: echo back a structured summary built from the local entries so the UI
+    // shape is real even though no LLM is hooked up yet.
+    setGenerating(true);
+    setTimeout(() => {
+      const last7 = entries.filter(e => Date.now() - e.at < 7 * 86400_000);
+      const text = last7.length === 0
+        ? 'No entries in the last 7 days.'
+        : `**This week** · ${last7.length} entries logged.\n\n` +
+          '_LLM summary will replace this once the backend endpoint is wired._\n\n' +
+          last7.slice(0, 3).map(e => `- ${e.date}: ${e.text.slice(0, 80)}${e.text.length > 80 ? '…' : ''}`).join('\n');
+      setState({ ...state, lastSummary: { at: Date.now(), text } });
+      setGenerating(false);
+      fireToast('Weekly summary generated (stub)');
+    }, 600);
+  };
+
+  // Group entries by date
+  const grouped = entries.reduce((m, e) => { (m[e.date] ||= []).push(e); return m; }, {});
+  const dates = Object.keys(grouped).sort().reverse();
+
+  return (
+    <>
+      <div className="form-grid">
+        <textarea
+          className="textarea"
+          placeholder={`What did you do today? (${today})`}
+          rows={3}
+          style={{ minHeight: 50, fontSize: 12.5 }}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) append(); }}
+        />
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button className="btn btn-primary" onClick={append} disabled={!draft.trim()}>
+            <Icon name="plus" size={13}/>Log entry
+          </button>
+          <button className="btn" onClick={generateSummary} disabled={entries.length === 0 || generating}>
+            {generating ? <><div className="spinner"/>Summarizing</> : <><Icon name="sparkles" size={13}/>Weekly summary</>}
+          </button>
+        </div>
+      </div>
+      {state.lastSummary && (
+        <div className="review" style={{ borderLeftColor: 'var(--canvas-accent)' }}>
+          <span className="review-tag" style={{ color: 'var(--canvas-accent)' }}>
+            Generated {new Date(state.lastSummary.at).toLocaleString()} · stub
+          </span>
+          <div className="canvas-md">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{state.lastSummary.text}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+      <div className="note-list" style={{ maxHeight: 260 }}>
+        {dates.map(date => (
+          <div key={date}>
+            <div style={{ fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, fontFamily: 'var(--canvas-mono)', padding: '6px 2px 2px' }}>
+              {new Date(date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            </div>
+            {grouped[date].map(e => (
+              <div key={e.id} className="note-row" style={{ position: 'relative' }}>
+                <div className="note-text">{e.text}</div>
+                <div className="row-actions">
+                  <button className="icon-btn" onClick={() => remove(e.id)}><Icon name="trash" size={11}/></button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+        {entries.length === 0 && (
+          <EmptyState icon="pencil" title="No entries yet" hint={`Drop a line about today. Hit ${MOD}+↵ to log it. Tap Weekly summary anytime.`}/>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ===== PhD Journey — standard milestones with status + notes =====
+// Captures the "General Journey" list: courses, prelim, lit review, IRB,
+// committee, topic, comps, defense, ProQuest. Each milestone has a status
+// (open/in-progress/completed) and an inline note.
+const PHD_MILESTONES = [
+  { id: 'courses', label: 'Course selection & dissertation credits', hint: 'Plan term-by-term. Check funding constraints.' },
+  { id: 'prelim', label: 'Preliminary exam', hint: 'Department format varies — consult your handbook.' },
+  { id: 'lit-review', label: 'Literature review', hint: 'Coverage + critique. Bibliography widget pairs well here.' },
+  { id: 'topic', label: 'Pick dissertation topic', hint: 'Narrow until your advisor pushes back.' },
+  { id: 'committee', label: 'Select committee', hint: 'Pros/cons of a co-chair: more buy-in, more scheduling.' },
+  { id: 'irb', label: 'IRB approval', hint: 'Allow 6–12 weeks. Pre-fill paperwork early.' },
+  { id: 'data', label: 'Data collection', hint: 'Pilot first. Plan for the inevitable instrument failure.' },
+  { id: 'comps', label: 'Comprehensive exam', hint: 'Department format varies.' },
+  { id: 'analysis', label: 'Data analysis & visualization', hint: 'Make the figures before the prose.' },
+  { id: 'writing', label: 'Write dissertation', hint: 'One chapter at a time. Aim for "good enough to defend".' },
+  { id: 'defense', label: 'Oral defense', hint: 'Slides + practice Q&A. Use the Defense Slides template.' },
+  { id: 'proquest', label: 'Final admin (ProQuest upload)', hint: 'Read the formatting checklist before you start formatting.' },
+];
+
+export function PhdJourneyWidget({ state, setState }) {
+  const statuses = state.statuses || {};
+  const notes = state.notes || {};
+  const [editingId, setEditingId] = useState(null);
+  const completed = PHD_MILESTONES.filter(m => statuses[m.id] === 'completed').length;
+  const total = PHD_MILESTONES.length;
+  const pct = Math.round((completed / total) * 100);
+
+  const cycleStatus = (id) => {
+    const cur = statuses[id] || 'open';
+    const next = cur === 'open' ? 'in-progress' : cur === 'in-progress' ? 'completed' : 'open';
+    setState({ ...state, statuses: { ...statuses, [id]: next } });
+  };
+  const updateNote = (id, text) => setState({ ...state, notes: { ...notes, [id]: text } });
+
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 12, color: 'var(--canvas-text-2)' }}>
+        <span style={{ fontFamily: 'var(--canvas-mono)', fontWeight: 700, fontSize: 16, color: 'var(--canvas-text)' }}>
+          {completed}<span style={{ color: 'var(--canvas-text-3)', fontWeight: 500 }}>/{total}</span>
+        </span>
+        <div className="progress" style={{ flex: 1, height: 6 }}>
+          <i style={{ width: pct + '%' }}/>
+        </div>
+        <span style={{ fontFamily: 'var(--canvas-mono)', fontSize: 11, color: 'var(--canvas-text-3)' }}>{pct}%</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {PHD_MILESTONES.map(m => {
+          const status = statuses[m.id] || 'open';
+          const note = notes[m.id] || '';
+          return (
+            <div key={m.id} className={`phd-milestone milestone-${status}`}>
+              <button
+                className="phd-milestone-check"
+                onClick={() => cycleStatus(m.id)}
+                title={`Status: ${status} (click to advance)`}
+              >
+                {status === 'completed' && <Icon name="check" size={11}/>}
+                {status === 'in-progress' && <span className="task-check-dot"/>}
+              </button>
+              <div className="phd-milestone-body" onClick={() => setEditingId(editingId === m.id ? null : m.id)}>
+                <div className="phd-milestone-label">{m.label}</div>
+                {(note || editingId === m.id) ? (
+                  editingId === m.id ? (
+                    <input
+                      className="inline-input"
+                      autoFocus
+                      defaultValue={note}
+                      placeholder={m.hint}
+                      onBlur={(e) => { updateNote(m.id, e.target.value); setEditingId(null); }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') e.target.blur(); if (e.key === 'Escape') setEditingId(null); }}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ marginTop: 2, fontSize: 11.5 }}
+                    />
+                  ) : (
+                    <div className="phd-milestone-note">{note}</div>
+                  )
+                ) : (
+                  <div className="phd-milestone-hint">{m.hint}</div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+// ===== PhD Resources — curated links + open-source apps =====
+// Static curated list of useful PhD tools and resources, plus user-added links.
+const PHD_RESOURCE_GROUPS = [
+  {
+    label: 'Open-source PhD tools',
+    items: [
+      { name: 'Zotero', href: 'https://www.zotero.org/', desc: 'Reference manager — free and open source' },
+      { name: 'Obsidian', href: 'https://obsidian.md/', desc: 'Local-first knowledge graph for notes' },
+      { name: 'JabRef', href: 'https://www.jabref.org/', desc: 'BibTeX-native reference manager' },
+      { name: 'Pandoc', href: 'https://pandoc.org/', desc: 'Universal document converter' },
+      { name: 'Quarto', href: 'https://quarto.org/', desc: 'Scientific publishing with R/Python/Julia' },
+    ],
+  },
+  {
+    label: 'Writing & formatting',
+    items: [
+      { name: 'Overleaf', href: 'https://www.overleaf.com/', desc: 'Browser LaTeX editor with templates' },
+      { name: 'LaTeX Templates', href: 'https://www.latextemplates.com/', desc: 'Thesis, CV, poster templates' },
+      { name: 'Hemingway Editor', href: 'https://hemingwayapp.com/', desc: 'Plain-language readability check' },
+    ],
+  },
+  {
+    label: 'Community & career',
+    items: [
+      { name: 'Academic Twitter / #PhDChat', href: 'https://twitter.com/search?q=%23PhDChat', desc: 'Peers + advisors discussing the grind' },
+      { name: 'ORCID', href: 'https://orcid.org/', desc: 'Permanent researcher ID for citations + grants' },
+      { name: 'Conferences & CFPs (WikiCFP)', href: 'http://www.wikicfp.com/', desc: 'Upcoming deadlines across fields' },
+    ],
+  },
+];
+
+export function PhdResourcesWidget({ state, setState }) {
+  const customLinks = state.customLinks || [];
+  const [name, setName] = useState('');
+  const [href, setHref] = useState('');
+
+  const addLink = () => {
+    if (!name.trim() || !href.trim()) return;
+    setState({ ...state, customLinks: [...customLinks, { id: 'r' + Date.now(), name: name.trim(), href: href.trim() }] });
+    setName(''); setHref('');
+    fireToast('Resource added');
+  };
+  const removeLink = (id) => setState({ ...state, customLinks: customLinks.filter(l => l.id !== id) });
+
+  return (
+    <>
+      {PHD_RESOURCE_GROUPS.map(g => (
+        <div key={g.label}>
+          <div style={{ fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 6 }}>
+            {g.label}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 10 }}>
+            {g.items.map(it => (
+              <a key={it.name} href={it.href} target="_blank" rel="noopener noreferrer" className="phd-resource-link">
+                <span className="phd-resource-name">{it.name}</span>
+                <span className="phd-resource-desc">{it.desc}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      ))}
+      {customLinks.length > 0 && (
+        <div>
+          <div style={{ fontSize: 10, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, marginBottom: 6 }}>
+            Your links
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 10 }}>
+            {customLinks.map(l => (
+              <div key={l.id} className="phd-resource-link" style={{ position: 'relative' }}>
+                <a href={l.href} target="_blank" rel="noopener noreferrer" style={{ display: 'flex', flexDirection: 'column', flex: 1, textDecoration: 'none', color: 'inherit' }}>
+                  <span className="phd-resource-name">{l.name}</span>
+                  <span className="phd-resource-desc">{l.href}</span>
+                </a>
+                <button className="icon-btn" onClick={() => removeLink(l.id)} style={{ position: 'absolute', right: 4, top: 4, width: 20, height: 20 }}>
+                  <Icon name="x" size={11}/>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: 4 }}>
+        <input className="input" placeholder="Resource name" value={name} onChange={e => setName(e.target.value)} style={{ fontSize: 12, padding: '5px 8px' }}/>
+        <input className="input" placeholder="https://…" value={href} onChange={e => setHref(e.target.value)} style={{ fontSize: 12, padding: '5px 8px', flex: 2 }}/>
+        <button className="btn" onClick={addLink} disabled={!name.trim() || !href.trim()}>
+          <Icon name="plus" size={12}/>Add
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ===== Stub — roadmap preview card =====
+// Shows what's coming for this widget type so adding it from the palette
+// doesn't feel like a dead end.
+const STUB_PLANS = {
+  'concept-map': ['Drag papers as nodes', 'Connect by theme', 'Auto-cluster by citation overlap'],
+  'highlights': ['Pull quotes with auto-citation', 'Search across all notes'],
+  'paper-tldr': ['Drop a PDF', 'Get claim / method / limits / gaps', 'Save to Bibliography in one click'],
+  'outline': ['Collapsible tree', 'Drop Insights into slots', 'Promote to Deliverable section'],
+  'latex': ['Render math as you type', 'Snippet library', 'Copy as image / TeX'],
+  'draft-locker': ['Versioned chapter drafts', 'Diff between versions', 'Roll back any change'],
+  'gantt': ['Proposal → IRB → defense timeline', 'Critical-path highlighting', 'Drag to reschedule'],
+  'mood': ['Daily slider', 'Trend graph', 'Correlate with productive days'],
+  'sleep': ['Sleep duration vs. word output', 'Energy heatmap', 'Apple Health import'],
+  'focus': ['Curated ambient playlists', 'Focus session timer', 'Auto-pause on Pomodoro break'],
+  'cfp': ['CFP deadlines by venue', 'Fit score by topic', 'Submission status pipeline'],
+  'grants': ['Grant deadlines + amounts', 'Award log', 'Generate budget justification'],
+  'crm': ['Collaborators with last touch', 'Quick-add from Meeting Log', 'Reminders for cold contacts'],
+  'cv': ['Track outputs over time', 'Auto-generate CV from Bibliography', 'Highlight by impact factor'],
+  'datasets': ['Public datasets by domain', 'Saved searches', 'License + access notes'],
+  'methods': ['When to use what test', 'Examples + citations', 'Saved templates per chapter'],
+  'discounts': ['Software & services with edu pricing', 'Discount expiration tracking'],
+  'assumption': ['Names hidden assumptions', 'Asks "what if wrong?"', 'Logs to a hypothesis tree'],
+  'whats-missing': ['Gap analysis on lit review', 'Compares to top venues', 'Suggests targeted reads'],
+  'calibrator': ['Challenges every "results show" claim', 'Asks for the prior', 'Flags p-hacking patterns'],
+};
+
+export function StubWidget({ meta }) {
+  const plan = STUB_PLANS[meta.type] || [];
+  return (
+    <div className="widget-stub">
+      <div className="widget-stub-icon"><Icon name={meta.icon} size={18}/></div>
+      <div className="widget-stub-tag">Coming soon</div>
+      <div className="widget-stub-title">{meta.name}</div>
+      <div className="widget-stub-desc">{meta.desc}</div>
+      {plan.length > 0 && (
+        <ul className="widget-stub-plan">
+          {plan.map((p, i) => <li key={i}>{p}</li>)}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/phd-advisor-frontend/src/components/canvas/canvasData.js
+++ b/phd-advisor-frontend/src/components/canvas/canvasData.js
@@ -122,3 +122,181 @@ export const INSIGHTS = [
     ],
   },
 ];
+
+export const WIDGET_CATALOG = [
+  { type: 'bibliography', name: 'Bibliography', desc: 'DOI lookup + BibTeX import; APA/MLA/Chicago/BibTeX export', icon: 'book', cat: 'research', defaultSize: 'M', enhanced: true },
+  { type: 'reading-queue', name: 'Reading Queue', desc: 'CrossRef title search + DOI resolve to auto-fill papers', icon: 'list', cat: 'research', defaultSize: 'S', enhanced: true },
+  { type: 'notes', name: 'Note Inbox', desc: 'Markdown rendering with full-text search', icon: 'notes', cat: 'research', defaultSize: 'S', enhanced: true },
+  { type: 'concept-map', name: 'Concept Map', desc: 'Drag papers as nodes, tag themes', icon: 'network', cat: 'research', defaultSize: 'M', stub: true },
+  { type: 'highlights', name: 'Highlights & Quotes', desc: 'Pulled quotes with citation key, copy-formatted', icon: 'cite', cat: 'research', defaultSize: 'M', enhanced: true },
+  { type: 'paper-tldr', name: 'Paper TL;DR', desc: 'PDF → claim / method / limits / gaps', icon: 'microscope', cat: 'research', defaultSize: 'M', stub: true },
+
+  { type: 'writing', name: 'Writing Tracker', desc: 'Inline writing pad, multi-chapter, 28-day heatmap', icon: 'pencil', cat: 'writing', defaultSize: 'M', enhanced: true },
+  { type: 'outline', name: 'Outline Builder', desc: 'Collapsible tree with indent / outdent / inline editing', icon: 'list', cat: 'writing', defaultSize: 'M', enhanced: true },
+  { type: 'latex', name: 'LaTeX Scratchpad', desc: 'Live KaTeX render-as-you-type with snippet chips', icon: 'flask', cat: 'writing', defaultSize: 'M', enhanced: true },
+  { type: 'draft-locker', name: 'Draft Locker', desc: 'Versioned chapter drafts', icon: 'shield', cat: 'writing', defaultSize: 'S', stub: true },
+
+  { type: 'kanban', name: 'Task Board', desc: 'Drag-to-move with priority filter chips and due-date sort', icon: 'kanban', cat: 'project', defaultSize: 'L', enhanced: true },
+  { type: 'deadlines', name: 'Deadlines', desc: 'Countdown plus per-deadline .ics calendar export', icon: 'calendar', cat: 'project', defaultSize: 'S', enhanced: true },
+  { type: 'pomodoro', name: 'Pomodoro', desc: 'Real timer with break cycle and session counter', icon: 'timer', cat: 'project', defaultSize: 'S', enhanced: true },
+  { type: 'gantt', name: 'Milestone Timeline', desc: 'Proposal → IRB → defense', icon: 'flag', cat: 'project', defaultSize: 'L', stub: true },
+  { type: 'meeting-log', name: 'Meeting Log', desc: 'Per-stakeholder, last contact, actions', icon: 'message', cat: 'project', defaultSize: 'M' },
+  { type: 'goals', name: 'Goals / OKRs', desc: 'Quarterly milestones with progress sliders', icon: 'bullseye', cat: 'project', defaultSize: 'M' },
+  { type: 'calendar', name: 'Calendar', desc: 'Month grid with deadlines and writing days', icon: 'calendar', cat: 'project', defaultSize: 'M', enhanced: true },
+  { type: 'activity', name: 'Activity Feed', desc: 'Chronological log of edits across widgets', icon: 'graph', cat: 'project', defaultSize: 'M', enhanced: true },
+  { type: 'documenter', name: 'Daily Documenter', desc: 'Date-stamped journal · AI weekly summary (LLM stub)', icon: 'pencil', cat: 'project', defaultSize: 'M', enhanced: true },
+  { type: 'phd-journey', name: 'PhD Journey', desc: 'Standard PhD milestones — courses → defense → ProQuest', icon: 'flag', cat: 'project', defaultSize: 'M', enhanced: true },
+  { type: 'phd-resources', name: 'PhD Resources', desc: 'Curated open-source tools, handbooks, and community links', icon: 'star', cat: 'research', defaultSize: 'M', enhanced: true },
+
+  { type: 'mood', name: 'Mood / Burnout Check-in', desc: 'Daily slider, trend graph', icon: 'smile', cat: 'wellness', defaultSize: 'S', stub: true },
+  { type: 'sleep', name: 'Sleep & Energy', desc: 'Correlate with productive days', icon: 'heart', cat: 'wellness', defaultSize: 'S', stub: true },
+  { type: 'habits', name: 'Habit Tracker', desc: 'Daily research practices', icon: 'flame', cat: 'wellness', defaultSize: 'S' },
+  { type: 'focus', name: 'Focus Playlist', desc: 'Ambient sounds & music', icon: 'music', cat: 'wellness', defaultSize: 'S', stub: true },
+
+  { type: 'cfp', name: 'Conference / CFP Tracker', desc: 'Deadlines, fit, submission status', icon: 'send', cat: 'career', defaultSize: 'M', stub: true },
+  { type: 'grants', name: 'Grant Tracker', desc: 'Applications, deadlines, awards', icon: 'award', cat: 'career', defaultSize: 'S', stub: true },
+  { type: 'crm', name: 'Networking CRM', desc: 'Collaborators, last touch', icon: 'network', cat: 'career', defaultSize: 'M', stub: true },
+  { type: 'cv', name: 'CV / Publications', desc: 'Track outputs, generate CV', icon: 'user', cat: 'career', defaultSize: 'S', stub: true },
+
+  { type: 'datasets', name: 'Dataset Library', desc: 'Public datasets by domain', icon: 'database', cat: 'data', defaultSize: 'M', stub: true },
+  { type: 'methods', name: 'Methods Cheat Sheet', desc: 'When to use what test', icon: 'flask', cat: 'data', defaultSize: 'M', stub: true },
+
+  { type: 'budget', name: 'Budget Tracker', desc: 'Research spend vs. cap', icon: 'wallet', cat: 'practical', defaultSize: 'S' },
+  { type: 'discounts', name: 'Student Discounts', desc: 'Software & services with edu pricing', icon: 'star', cat: 'practical', defaultSize: 'S', stub: true },
+
+  { type: 'reviewer-2', name: 'Reviewer 2 Simulator', desc: 'Paste a draft → harsh peer-review-style critique', icon: 'gavel', cat: 'critic', defaultSize: 'M', critic: true },
+  { type: 'devils-advocate', name: 'Devil\'s Advocate', desc: 'Strongest counter-arguments to your hypothesis', icon: 'scale', cat: 'critic', defaultSize: 'M', critic: true },
+  { type: 'scope-realism', name: 'Scope Realism Check', desc: 'Brutal feasibility verdict given timeline', icon: 'bullseye', cat: 'critic', defaultSize: 'M', critic: true },
+  { type: 'assumption', name: 'Assumption Excavator', desc: 'Names hidden assumptions, asks "what if wrong?"', icon: 'brain', cat: 'critic', defaultSize: 'M', critic: true, stub: true },
+  { type: 'whats-missing', name: '"What\'s Missing"', desc: 'Gap analysis on lit review or method', icon: 'alert', cat: 'critic', defaultSize: 'S', critic: true, stub: true },
+  { type: 'calibrator', name: 'Confidence Calibrator', desc: 'Challenges every "results show X" claim', icon: 'scale', cat: 'critic', defaultSize: 'S', critic: true, stub: true },
+];
+
+export const CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'research', label: 'Research' },
+  { id: 'writing', label: 'Writing' },
+  { id: 'project', label: 'Project' },
+  { id: 'wellness', label: 'Wellness' },
+  { id: 'career', label: 'Career' },
+  { id: 'data', label: 'Data' },
+  { id: 'practical', label: 'Practical' },
+  { id: 'critic', label: 'Anti-yes-man', critic: true },
+];
+
+// Workspace starts empty — users add widgets from the palette or pick a preset.
+export const DEFAULT_LAYOUT = [];
+
+// Curated starter layouts. Each preset assigns its own widget IDs so reseeding
+// won't collide with manually-added widgets.
+const presetIds = (types) => types.map((t, i) => ({ id: `pre-${t.type}-${i}`, ...t }));
+export const WORKSPACE_PRESETS = [
+  {
+    id: 'day1-phd',
+    name: 'Day-1 PhD',
+    desc: 'Get oriented: reading queue, bibliography, notes, deadlines, kanban, pomodoro.',
+    icon: 'sparkles',
+    layout: presetIds([
+      { type: 'reading-queue', size: 'M' },
+      { type: 'bibliography', size: 'M' },
+      { type: 'notes', size: 'M' },
+      { type: 'deadlines', size: 'S' },
+      { type: 'pomodoro', size: 'S' },
+      { type: 'kanban', size: 'L' },
+    ]),
+  },
+  {
+    id: 'writing-sprint',
+    name: 'Writing Sprint',
+    desc: 'Focus mode for drafting: writing pad, outline, LaTeX, highlights, pomodoro.',
+    icon: 'pencil',
+    layout: presetIds([
+      { type: 'writing', size: 'M' },
+      { type: 'outline', size: 'M' },
+      { type: 'pomodoro', size: 'S' },
+      { type: 'latex', size: 'M' },
+      { type: 'highlights', size: 'M' },
+      { type: 'bibliography', size: 'M' },
+    ]),
+  },
+  {
+    id: 'quals-prep',
+    name: 'Quals Prep',
+    desc: 'Lit-review heavy: bibliography, reading queue, notes, highlights, kanban.',
+    icon: 'book',
+    layout: presetIds([
+      { type: 'bibliography', size: 'L' },
+      { type: 'reading-queue', size: 'M' },
+      { type: 'notes', size: 'M' },
+      { type: 'highlights', size: 'M' },
+      { type: 'kanban', size: 'M' },
+    ]),
+  },
+  {
+    id: 'defense-mode',
+    name: 'Defense Mode',
+    desc: 'Final stretch: writing, outline, anti-yes-man critics, deadlines.',
+    icon: 'gavel',
+    layout: presetIds([
+      { type: 'writing', size: 'M' },
+      { type: 'outline', size: 'M' },
+      { type: 'reviewer-2', size: 'M', critic: true },
+      { type: 'devils-advocate', size: 'M', critic: true },
+      { type: 'scope-realism', size: 'M', critic: true },
+      { type: 'deadlines', size: 'S' },
+    ]),
+  },
+];
+
+// Initial state when a widget is first added — minimal scaffolding, no demo content.
+export const EMPTY_STATE = {
+  bibliography: { format: 'APA', entries: [] },
+  kanban: {
+    cols: [
+      { id: 'todo', label: 'To Do' },
+      { id: 'doing', label: 'Doing' },
+      { id: 'stuck', label: 'Stuck' },
+      { id: 'done', label: 'Done' },
+    ],
+    cards: [],
+  },
+  pomodoro: { focus: 25, brk: 5, sessionsToday: 0 },
+  writing: {
+    chapters: [{ id: 'c-default', name: 'Untitled chapter', target: 500, draft: '' }],
+    activeChapterId: 'c-default',
+    dailyTotals: {},
+    target: 500,
+  },
+  deadlines: [],
+  budget: { cap: 1000, items: [] },
+  notes: { items: [] },
+  habits: { items: [] },
+  goals: { items: [] },
+  'meeting-log': { items: [] },
+  'reading-queue': [],
+  'reviewer-2': { lastDraft: '', lastReview: null },
+  'devils-advocate': { claim: '', counters: [] },
+  'scope-realism': {
+    target: '',
+    score: 0,
+    label: 'Set a target',
+    factors: [],
+    notes: '',
+  },
+  outline: { items: [], expanded: {} },
+  highlights: { items: [] },
+  latex: { source: '', displayMode: true },
+  calendar: { viewMonth: new Date().toISOString().slice(0, 7) },
+  activity: {},
+  documenter: { entries: [], lastSummary: null },
+  'phd-journey': {
+    // Status per milestone: 'open' | 'in-progress' | 'completed'
+    // Milestones come from the standard PhD journey (course selection → ProQuest)
+    statuses: {},
+    notes: {},
+  },
+  'phd-resources': {
+    customLinks: [],
+  },
+};
+

--- a/phd-advisor-frontend/src/components/canvas/canvasData.js
+++ b/phd-advisor-frontend/src/components/canvas/canvasData.js
@@ -1,0 +1,124 @@
+// Demo data for a Year-2 PhD student in computational neuroscience.
+
+export const DEMO_PROJECT = {
+  title: "Cortical Predictive Coding in Mouse V1",
+  meta: "Year 2 · PhD · Adv. Dr. Reineke",
+};
+
+export const INSIGHTS = [
+  {
+    id: 'i-progress',
+    title: 'Research progress',
+    icon: 'graph',
+    category: 'progress',
+    confidence: 78,
+    summary: 'Primary recordings from 4 of 6 planned animals are complete. Remaining two scheduled for May 18 and May 25. Analysis pipeline working on existing data; first results draft expected June.',
+    bullets: [
+      'V1 recordings: <strong>4/6 animals</strong> complete (M1–M4)',
+      'Pipeline: spike-sorting validated, GLM model converging on M1–M2',
+      '<strong>Risk:</strong> M3 fixation drift suspected; need re-review with adv.',
+    ],
+    pinned: true,
+    sources: 12,
+    updatedMinutesAgo: 3,
+    quotes: [
+      '"Animal M4 recording finished today, sorting completes tomorrow." — May 6 lab notes',
+      '"Pipeline is happy with M1, M2; M3 looks drifty." — chat with Reineke advisor',
+    ],
+  },
+  {
+    id: 'i-method',
+    title: 'Methodology',
+    icon: 'flask',
+    category: 'theory',
+    confidence: 64,
+    summary: 'GLM with spike-history kernel + visual drive is your declared model. You\'ve resisted committing to a specific predictive-coding formulation; this comes up in every advisor meeting.',
+    bullets: [
+      'Decided: <strong>GLM with history kernel</strong> + drift-reg covariates',
+      'Open: which predictive-coding variant — Rao & Ballard vs. Bastos top-down',
+      'Open: how to operationalize "prediction error" from extracellular spikes',
+    ],
+    sources: 8,
+    updatedMinutesAgo: 12,
+    quotes: [
+      '"Need to pick a PC formulation by next 1:1." — meeting notes May 2',
+      '"Bastos lets you predict laminar profile; Rao&Ballard does not." — methodologist chat',
+    ],
+  },
+  {
+    id: 'i-lit',
+    title: 'Literature review',
+    icon: 'book',
+    category: 'literature',
+    confidence: 71,
+    summary: 'Strong on canonical predictive coding (Rao & Ballard 1999, Bastos 2012, Keller & Mrsic-Flogel 2018). Thin on recent feedback-circuit anatomy and on counter-evidence — this is showing up as a critique gap.',
+    bullets: [
+      '<strong>Coverage:</strong> 47 papers; ~30 well-summarized',
+      '<strong>Gap:</strong> sparse on L5b feedback anatomy (Harris/Shepherd lab)',
+      '<strong>Gap:</strong> no engagement with anti-PC critiques (e.g. Heeger 2017)',
+    ],
+    sources: 47,
+    updatedMinutesAgo: 22,
+    quotes: [
+      '"Have you read Heeger 2017? It changes a lot." — lit-review aide',
+      '"L5b feedback anatomy is your weak spot." — devil\'s advocate',
+    ],
+  },
+  {
+    id: 'i-questions',
+    title: 'Open research questions',
+    icon: 'sparkles',
+    category: 'theory',
+    confidence: 58,
+    summary: 'Three live threads. Question 1 (does L2/3 spiking encode prediction error?) is the dissertation core. Q2 and Q3 are scoped to specific aims.',
+    bullets: [
+      '<strong>Q1:</strong> Does L2/3 firing during oddball encode prediction error vs. surprise?',
+      '<strong>Q2:</strong> How does this depend on context length (1 vs. 4 vs. 16 trials)?',
+      '<strong>Q3:</strong> Is the signal sharpened by feedback from V2/RSC?',
+    ],
+    sources: 6,
+    updatedMinutesAgo: 38,
+    quotes: [
+      '"Q1 is what the whole dissertation rests on." — methodologist',
+      '"Q3 is exciting but probably out of scope for the thesis." — Reineke',
+    ],
+  },
+  {
+    id: 'i-next',
+    title: 'Next steps',
+    icon: 'arrow',
+    category: 'action',
+    confidence: 82,
+    summary: 'Concrete, near-term actions. Two of these have been on the list for 3+ weeks.',
+    bullets: [
+      'Re-review M3 drift artifact w/ adv. (overdue, 3w)',
+      'Draft Aim 2 analysis section (target: May 22)',
+      'Read Heeger 2017 + Aitchison & Lengyel 2017',
+      'Schedule pilot with M5 (May 18)',
+    ],
+    sources: 5,
+    updatedMinutesAgo: 8,
+    quotes: [
+      '"Aim 2 draft has to land by May 22 or quals slip." — Reineke',
+      '"M3 review keeps getting punted." — last 3 advisor meetings',
+    ],
+  },
+  {
+    id: 'i-blockers',
+    title: 'Blockers & risks',
+    icon: 'alert',
+    category: 'risk',
+    confidence: 70,
+    summary: 'One technical, one structural. The structural one is more important and you are deferring it.',
+    bullets: [
+      '<strong>Technical:</strong> Drift on M3 — may lose 1 animal of data',
+      '<strong>Structural:</strong> No clear predictive-coding theory commitment yet → hard to define what counts as evidence',
+    ],
+    sources: 4,
+    updatedMinutesAgo: 18,
+    quotes: [
+      '"If M3 is unusable you\'re at n=5 — still publishable but tight." — methodologist',
+      '"Without a theory commitment you can\'t falsify anything." — devil\'s advocate',
+    ],
+  },
+];

--- a/phd-advisor-frontend/src/components/canvas/platform.js
+++ b/phd-advisor-frontend/src/components/canvas/platform.js
@@ -1,0 +1,5 @@
+// Tiny helper so keyboard shortcut hints adapt to the user's OS.
+// Detect once at module load — we don't expect platform to change mid-session.
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+export const MOD = isMac ? '⌘' : 'Ctrl';
+export const MOD_LABEL = isMac ? 'Cmd' : 'Ctrl';

--- a/phd-advisor-frontend/src/pages/CanvasPage.js
+++ b/phd-advisor-frontend/src/pages/CanvasPage.js
@@ -1,17 +1,108 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { HelpCircle } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAppConfig } from '../contexts/AppConfigContext';
 import Sidebar from '../components/Sidebar';
 import AppHeader from '../components/AppHeader';
 import Icon from '../components/canvas/CanvasIcon';
-import { INSIGHTS } from '../components/canvas/canvasData';
+import {
+  INSIGHTS, WIDGET_CATALOG, DEFAULT_LAYOUT, EMPTY_STATE, WORKSPACE_PRESETS,
+} from '../components/canvas/canvasData';
+import {
+  BibliographyWidget, KanbanWidget, PomodoroWidget, WritingWidget,
+  DeadlinesWidget, BudgetWidget, ReadingQueueWidget, NotesWidget,
+  HabitsWidget, GoalsWidget, MeetingsWidget,
+  OutlineWidget, HighlightsWidget, LatexWidget,
+  CalendarWidget, DocumenterWidget, ActivityWidget,
+  PhdJourneyWidget, PhdResourcesWidget,
+  StubWidget,
+} from '../components/canvas/CanvasWidgets';
+import {
+  Reviewer2Widget, DevilsAdvocateWidget, ScopeRealismWidget,
+  ReviewerModal, DevilsModal, ScopeModal,
+} from '../components/canvas/CanvasCriticWidgets';
+import {
+  AddCitationModal, AddTaskModal, AddDeadlineModal, LogWordsModal,
+  ConfirmRemoveModal, ReadingPaperModal, BudgetItemModal,
+  NoteModal, HabitModal, GoalModal, MeetingModal,
+  PaletteModal, CommandPaletteModal, GlobalSearchModal,
+} from '../components/canvas/CanvasModals';
 import CanvasWelcomeTour from '../components/canvas/CanvasWelcomeTour';
+import DeliverablesView, { TEMPLATES as DELIVERABLE_TEMPLATES } from '../components/canvas/CanvasDeliverables';
 import { MOD } from '../components/canvas/platform';
 import '../styles/CanvasPage.css';
 
-const VIEW_KEY = 'canvas-view-v2';
+const LAYOUT_KEY = 'canvas-layout-v2';
 const STATES_KEY = 'canvas-states-v2';
+const VIEW_KEY = 'canvas-view-v2';
+
+function renderWidget(type, state, setState, openModal, allStates) {
+  const props = { state, setState, openModal, allStates };
+  switch (type) {
+    case 'bibliography': return <BibliographyWidget {...props}/>;
+    case 'kanban': return <KanbanWidget {...props}/>;
+    case 'pomodoro': return <PomodoroWidget {...props}/>;
+    case 'writing': return <WritingWidget {...props}/>;
+    case 'deadlines': return <DeadlinesWidget {...props}/>;
+    case 'budget': return <BudgetWidget {...props}/>;
+    case 'reading-queue': return <ReadingQueueWidget {...props}/>;
+    case 'notes': return <NotesWidget {...props}/>;
+    case 'habits': return <HabitsWidget {...props}/>;
+    case 'goals': return <GoalsWidget {...props}/>;
+    case 'meeting-log': return <MeetingsWidget {...props}/>;
+    case 'reviewer-2': return <Reviewer2Widget {...props}/>;
+    case 'devils-advocate': return <DevilsAdvocateWidget {...props}/>;
+    case 'scope-realism': return <ScopeRealismWidget {...props}/>;
+    case 'outline': return <OutlineWidget {...props}/>;
+    case 'highlights': return <HighlightsWidget {...props}/>;
+    case 'latex': return <LatexWidget {...props}/>;
+    case 'calendar': return <CalendarWidget {...props}/>;
+    case 'documenter': return <DocumenterWidget {...props}/>;
+    case 'activity': return <ActivityWidget {...props}/>;
+    case 'phd-journey': return <PhdJourneyWidget {...props}/>;
+    case 'phd-resources': return <PhdResourcesWidget {...props}/>;
+    default: {
+      const meta = WIDGET_CATALOG.find(w => w.type === type);
+      return <StubWidget meta={meta}/>;
+    }
+  }
+}
+
+function CanvasWidget({ widget, isDragging, isDragOver, onDragStart, onDragOver, onDragEnd, onDrop, state, setState, onRemove, onResize, openModal, allStates }) {
+  const meta = WIDGET_CATALOG.find(w => w.type === widget.type);
+  if (!meta) return null;
+  const sizes = ['S', 'M', 'L'];
+  const cycleSize = () => onResize(widget.id, sizes[(sizes.indexOf(widget.size) + 1) % sizes.length]);
+
+  return (
+    <div
+      className={`widget size-${widget.size} ${meta.critic ? 'critic' : ''} ${isDragging ? 'dragging' : ''} ${isDragOver ? 'drag-over' : ''}`}
+      data-widget-id={widget.id}
+      data-widget-type={widget.type}
+      onDragOver={(e) => { e.preventDefault(); onDragOver(widget.id); }}
+      onDrop={(e) => { e.preventDefault(); onDrop(widget.id); }}
+    >
+      <div
+        className="widget-head"
+        draggable
+        onDragStart={(e) => { onDragStart(widget.id); e.dataTransfer.effectAllowed = 'move'; }}
+        onDragEnd={onDragEnd}
+      >
+        <span className="drag-grip"><Icon name="grip" size={14}/></span>
+        <div className="widget-icon"><Icon name={meta.icon} size={14}/></div>
+        <div className="widget-title">{meta.name}</div>
+        {meta.critic && <span className="widget-tag">wedge</span>}
+        <span className="size-pill" onClick={cycleSize} title="Cycle size S → M → L">{widget.size}</span>
+        <div className="widget-actions">
+          <button className="icon-btn" onClick={() => onRemove(widget.id, meta.name)} title="Remove"><Icon name="trash" size={13}/></button>
+        </div>
+      </div>
+      <div className="widget-body">
+        {renderWidget(widget.type, state, setState, openModal, allStates)}
+      </div>
+    </div>
+  );
+}
 
 // ============================================================================
 // Insights view — AI-synthesized highlights with stats bar, filters, and
@@ -120,11 +211,9 @@ function InsightsView({ widgetStates, setWidgetStates, onNavigateToChat }) {
     return plain.length > 80 ? plain.slice(0, 77) + '…' : plain;
   };
 
-  // Pre-stages a kanban card in shared widget state so that when the user adds a
-  // Kanban widget (next PR) the work transferred from Insights is already there.
   const sendToKanban = (ins) => {
     if (!setWidgetStates) return;
-    const kanban = widgetStates.kanban || { cards: [] };
+    const kanban = widgetStates.kanban || EMPTY_STATE.kanban;
     const card = {
       id: 'k' + Date.now(),
       col: 'todo',
@@ -132,7 +221,7 @@ function InsightsView({ widgetStates, setWidgetStates, onNavigateToChat }) {
       priority: 'med',
       meta: `from Insights · ${ins.title}`,
     };
-    setWidgetStates(s => ({ ...s, kanban: { ...kanban, cards: [...(kanban.cards || []), card] } }));
+    setWidgetStates(s => ({ ...s, kanban: { ...kanban, cards: [...kanban.cards, card] } }));
     window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: 'Sent to Kanban (To Do)', kind: 'success' } }));
   };
 
@@ -534,6 +623,173 @@ function ConfidenceRing({ value }) {
   );
 }
 
+function PresetPicker({ onPick }) {
+  return (
+    <div className="canvas-presets">
+      <div className="canvas-presets-head">
+        <div className="canvas-presets-title">Start from a preset</div>
+        <div className="canvas-presets-sub">Or skip and add widgets one at a time.</div>
+      </div>
+      <div className="canvas-presets-grid">
+        {WORKSPACE_PRESETS.map(p => (
+          <button key={p.id} className="canvas-preset-card" onClick={() => onPick(p)}>
+            <div className="canvas-preset-icon"><Icon name={p.icon} size={18}/></div>
+            <div className="canvas-preset-content">
+              <div className="canvas-preset-name">{p.name}</div>
+              <div className="canvas-preset-desc">{p.desc}</div>
+              <div className="canvas-preset-meta">{p.layout.length} widgets</div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceView({ openModal, layout, setLayout, widgetStates, setWidgetStates }) {
+  const [dragId, setDragId] = useState(null);
+  const [dragOverId, setDragOverId] = useState(null);
+
+  const onDragStart = (id) => setDragId(id);
+  const onDragOver = (id) => { if (id !== dragId) setDragOverId(id); };
+  const onDragEnd = () => { setDragId(null); setDragOverId(null); };
+  const onDrop = (targetId) => {
+    if (!dragId || dragId === targetId) { onDragEnd(); return; }
+    const next = [...layout];
+    const fromIdx = next.findIndex(w => w.id === dragId);
+    const toIdx = next.findIndex(w => w.id === targetId);
+    const [moved] = next.splice(fromIdx, 1);
+    next.splice(toIdx, 0, moved);
+    setLayout(next);
+    onDragEnd();
+  };
+
+  const setWState = (type) => (updater) => {
+    setWidgetStates(s => ({
+      ...s,
+      [type]: typeof updater === 'function' ? updater(s[type]) : updater,
+    }));
+  };
+
+  const removeWidget = (id, label) => {
+    openModal('confirm-remove', {
+      label,
+      onConfirm: () => {
+        setLayout(l => l.filter(w => w.id !== id));
+        window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: label + ' removed', kind: 'success' } }));
+      },
+    });
+  };
+
+  const resizeWidget = (id, size) => setLayout(l => l.map(w => w.id === id ? { ...w, size } : w));
+
+  // Each widget starts from scratch — fresh empty state, no demo content.
+  const addWidget = (meta) => {
+    const id = 'w-' + Date.now();
+    setLayout(l => [...l, { id, type: meta.type, size: meta.defaultSize, critic: meta.critic }]);
+    if (EMPTY_STATE[meta.type]) {
+      setWidgetStates(s => ({ ...s, [meta.type]: JSON.parse(JSON.stringify(EMPTY_STATE[meta.type])) }));
+    }
+  };
+
+  const applyPreset = (preset) => {
+    setLayout(preset.layout.map(w => ({ ...w })));
+    // Seed empty state for any widget types not already present
+    const seeds = {};
+    preset.layout.forEach(w => {
+      if (!widgetStates[w.type] && EMPTY_STATE[w.type]) {
+        seeds[w.type] = JSON.parse(JSON.stringify(EMPTY_STATE[w.type]));
+      }
+    });
+    if (Object.keys(seeds).length) setWidgetStates(s => ({ ...s, ...seeds }));
+    window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: `${preset.name} preset loaded`, kind: 'success' } }));
+  };
+
+  const reset = () => {
+    if (!window.confirm('Reset workspace? All widgets and content will be cleared.')) return;
+    setLayout([]);
+    setWidgetStates({});
+    localStorage.removeItem(LAYOUT_KEY);
+    localStorage.removeItem(STATES_KEY);
+  };
+
+  return (
+    <>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">Workspace</h1>
+          <div className="page-sub">{layout.length} widgets · {layout.filter(w => w.critic).length} anti-yes-man · drag headers to reorder, click size pill to resize</div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-ghost" onClick={reset} title="Reset layout"><Icon name="reset" size={13}/>Reset</button>
+          <button className="btn btn-primary" onClick={() => openModal('palette', {
+            layout, onAdd: addWidget,
+          })}><Icon name="plus" size={13}/>Add widget</button>
+        </div>
+      </div>
+      {layout.length === 0 && (
+        <PresetPicker onPick={applyPreset}/>
+      )}
+      <div className="workspace">
+        {layout.length === 0 && (
+          <div className="empty-cell">
+            <Icon name="layout" size={28} style={{ color: 'var(--canvas-text-4)' }}/>
+            <div style={{ fontSize: 14, color: 'var(--canvas-text-2)', fontWeight: 500 }}>Or build from scratch</div>
+            <button className="btn btn-primary" onClick={() => openModal('palette', { layout, onAdd: addWidget })} style={{ marginTop: 6 }}>
+              <Icon name="plus" size={13}/>Add your first widget
+            </button>
+          </div>
+        )}
+        {layout.map((w) => (
+          <CanvasWidget
+            key={w.id}
+            widget={w}
+            isDragging={dragId === w.id}
+            isDragOver={dragOverId === w.id}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDragEnd={onDragEnd}
+            onDrop={onDrop}
+            state={widgetStates[w.type] ?? (EMPTY_STATE[w.type] ?? {})}
+            setState={setWState(w.type)}
+            onRemove={removeWidget}
+            onResize={resizeWidget}
+            openModal={openModal}
+            allStates={widgetStates}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function ModalRouter({ modal, onClose }) {
+  if (!modal) return null;
+  const handleBackdropClick = (e) => { if (e.target === e.currentTarget) onClose(); };
+  let content = null;
+  switch (modal.kind) {
+    case 'palette':         content = <PaletteModal data={modal.data} onClose={onClose}/>; break;
+    case 'add-citation':    content = <AddCitationModal data={modal.data} onClose={onClose}/>; break;
+    case 'add-task':        content = <AddTaskModal data={modal.data} onClose={onClose}/>; break;
+    case 'add-deadline':    content = <AddDeadlineModal data={modal.data} onClose={onClose}/>; break;
+    case 'log-words':       content = <LogWordsModal data={modal.data} onClose={onClose}/>; break;
+    case 'confirm-remove':  content = <ConfirmRemoveModal data={modal.data} onClose={onClose}/>; break;
+    case 'reviewer-2':      content = <ReviewerModal data={modal.data} onClose={onClose}/>; break;
+    case 'devils-advocate': content = <DevilsModal data={modal.data} onClose={onClose}/>; break;
+    case 'scope-realism':   content = <ScopeModal data={modal.data} onClose={onClose}/>; break;
+    case 'reading-paper':   content = <ReadingPaperModal data={modal.data} onClose={onClose}/>; break;
+    case 'budget-item':     content = <BudgetItemModal data={modal.data} onClose={onClose}/>; break;
+    case 'note':            content = <NoteModal data={modal.data} onClose={onClose}/>; break;
+    case 'habit':           content = <HabitModal data={modal.data} onClose={onClose}/>; break;
+    case 'goal':            content = <GoalModal data={modal.data} onClose={onClose}/>; break;
+    case 'meeting':         content = <MeetingModal data={modal.data} onClose={onClose}/>; break;
+    case 'command':         content = <CommandPaletteModal data={modal.data} onClose={onClose}/>; break;
+    case 'global-search':   content = <GlobalSearchModal data={modal.data} onClose={onClose}/>; break;
+    default: return null;
+  }
+  return <div className="canvas-modal-backdrop" onClick={handleBackdropClick}>{content}</div>;
+}
+
 function ToastStack() {
   const [toasts, setToasts] = useState([]);
   useEffect(() => {
@@ -559,27 +815,28 @@ function ToastStack() {
 
 
 const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSignOut }) => {
-  const { theme } = useTheme();
+  const { theme, toggleTheme } = useTheme();
   useAppConfig();
-  // Insights is the only view available in this PR. Workspace + Documents land
-  // in follow-up PRs but the storage key + tab-switching plumbing stay so those
-  // PRs can extend without touching this file's structure.
-  const [view, setView] = useState(() => {
-    const saved = localStorage.getItem(VIEW_KEY);
-    return saved === 'insights' ? saved : 'insights';
-  });
+  const [view, setView] = useState(() => localStorage.getItem(VIEW_KEY) || 'workspace');
+  const [modal, setModal] = useState(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [tourForceShow, setTourForceShow] = useState(0);
 
-  // Shared widget-state store. Empty in this PR (no widgets yet); kept so the
-  // Insights "Send to Kanban" can pre-stage work for the next PR's Kanban widget.
+  const [layout, setLayout] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LAYOUT_KEY);
+      return saved ? JSON.parse(saved) : DEFAULT_LAYOUT;
+    } catch { return DEFAULT_LAYOUT; }
+  });
   const [widgetStates, setWidgetStates] = useState(() => {
     try {
       const saved = localStorage.getItem(STATES_KEY);
       return saved ? JSON.parse(saved) : {};
     } catch { return {}; }
   });
+
+  useEffect(() => { localStorage.setItem(LAYOUT_KEY, JSON.stringify(layout)); }, [layout]);
   useEffect(() => { localStorage.setItem(STATES_KEY, JSON.stringify(widgetStates)); }, [widgetStates]);
   useEffect(() => { localStorage.setItem(VIEW_KEY, view); }, [view]);
 
@@ -589,6 +846,39 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
     return () => { delete document.body.dataset.canvasTheme; };
   }, [theme]);
 
+  const openModal = useCallback((kind, data = {}) => setModal({ kind, data }), []);
+  const closeModal = useCallback(() => setModal(null), []);
+
+  const exportWorkspace = useCallback(() => {
+    const data = { layout, states: widgetStates };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'canvas-workspace.json';
+    a.click();
+    window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: 'Workspace exported as JSON', kind: 'success' } }));
+  }, [layout, widgetStates]);
+
+  const openCommandPalette = useCallback(() => {
+    openModal('command', {
+      layout,
+      onSetView: (v) => setView(v),
+      onAddWidget: (meta) => {
+        const id = 'w-' + Date.now();
+        setLayout(l => [...l, { id, type: meta.type, size: meta.defaultSize, critic: meta.critic }]);
+        if (EMPTY_STATE[meta.type]) {
+          setWidgetStates(s => ({ ...s, [meta.type]: JSON.parse(JSON.stringify(EMPTY_STATE[meta.type])) }));
+        }
+      },
+      onToggleTheme: toggleTheme,
+      onExport: exportWorkspace,
+    });
+  }, [openModal, layout, toggleTheme, exportWorkspace]);
+
+  const openGlobalSearch = useCallback(() => {
+    openModal('global-search', { states: widgetStates });
+  }, [openModal, widgetStates]);
+
   // Critic widgets dispatch `canvas-open-in-chat` when the user wants real LLM history.
   useEffect(() => {
     const handler = () => onNavigateToChat && onNavigateToChat();
@@ -596,9 +886,20 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
     return () => window.removeEventListener('canvas-open-in-chat', handler);
   }, [onNavigateToChat]);
 
+  // Esc closes modal, ⌘K opens command palette, ⌘/ opens global content search,
   // ? opens the welcome tour for help (matches the icon in the topbar).
   useEffect(() => {
     const k = (e) => {
+      if (e.key === 'Escape') closeModal();
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        openCommandPalette();
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === '/') {
+        e.preventDefault();
+        openGlobalSearch();
+      }
+      // ? key (Shift+/) — only when the user isn't typing in an input
       if (e.key === '?' && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
         e.preventDefault();
         setTourForceShow(n => n + 1);
@@ -606,9 +907,9 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
     };
     window.addEventListener('keydown', k);
     return () => window.removeEventListener('keydown', k);
-  }, []);
+  }, [closeModal, openCommandPalette, openGlobalSearch]);
 
-  // Highlight a section when picked from the sidebar
+  // Highlight a widget when picked from the sidebar
   const flashScrollTo = (selector) => {
     const el = document.querySelector(selector);
     if (!el) return;
@@ -616,6 +917,26 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
     el.style.boxShadow = '0 0 0 2px var(--canvas-accent), 0 0 24px var(--canvas-accent-glow)';
     setTimeout(() => { el.style.boxShadow = ''; }, 1400);
   };
+
+  // Workspace: group widgets by category for the new sidebar
+  const widgetGroups = useMemo(() => {
+    const groups = {};
+    layout.forEach(w => {
+      const meta = WIDGET_CATALOG.find(m => m.type === w.type);
+      if (!meta) return;
+      const cat = meta.cat;
+      (groups[cat] ||= { id: cat, label: cat, items: [] }).items.push({
+        id: w.id,
+        label: meta.name,
+        icon: meta.icon,
+        critic: meta.critic,
+        onClick: () => flashScrollTo(`[data-widget-id="${w.id}"]`),
+      });
+    });
+    // Order: critic last
+    const order = ['research', 'writing', 'project', 'wellness', 'career', 'data', 'practical', 'critic'];
+    return order.map(c => groups[c]).filter(Boolean);
+  }, [layout]);
 
   // Insights: list of sections — Daniel's feedback said sidebar should show sections here
   const insightSections = useMemo(() => {
@@ -635,7 +956,45 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
         onClick: () => flashScrollTo(`#insight-${ins.id}`),
       };
     });
-  }, [view, widgetStates]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [view, layout, widgetStates]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Deliverables: list of projects with sections + history actions
+  const deliverableProjects = useMemo(() => {
+    try {
+      const dStore = JSON.parse(localStorage.getItem('canvas-deliverables-v2') || '{}');
+      const projects = Object.values(dStore.projects || {});
+      return projects.map(p => {
+        const t = DELIVERABLE_TEMPLATES.find(x => x.id === p.templateId);
+        return {
+          id: p.id,
+          name: p.name,
+          icon: t?.icon || 'book',
+          versions: p.versions?.length || 0,
+          isActive: p.id === dStore.activeProjectId,
+          sections: (t?.sections || []).map(s => ({
+            id: s.id,
+            name: s.name,
+            wc: ((p.sections || {})[s.id] || '').trim().split(/\s+/).filter(Boolean).length,
+            onClick: () => {
+              if (p.id !== dStore.activeProjectId) {
+                // Open this project first; section scroll happens after a tick.
+                const next = { ...dStore, activeProjectId: p.id };
+                localStorage.setItem('canvas-deliverables-v2', JSON.stringify(next));
+                window.dispatchEvent(new Event('storage'));
+              }
+              setTimeout(() => flashScrollTo(`#notion-section-${s.id}`), 80);
+            },
+          })),
+          onOpen: () => {
+            const next = { ...dStore, activeProjectId: p.id };
+            localStorage.setItem('canvas-deliverables-v2', JSON.stringify(next));
+            window.dispatchEvent(new Event('storage'));
+          },
+        };
+      });
+    } catch { return []; }
+    // re-derive when view or layout changes (layout proxy for "user did something")
+  }, [view, layout, widgetStates]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="canvas-page-with-sidebar" data-canvas-theme={theme}>
@@ -651,6 +1010,8 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
         onNewChat={() => onNavigateToChat && onNavigateToChat()}
         pageContext="canvas"
         canvasSubview={view}
+        widgetGroups={widgetGroups}
+        deliverableProjects={deliverableProjects}
         insightSections={insightSections}
       />
       <div className={`canvas-main-area ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
@@ -659,18 +1020,27 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
             currentPage={`canvas-${view}`}
             onNavigateToHome={onNavigateToHome}
             onNavigateToChat={onNavigateToChat}
-            onNavigateToCanvas={(v) => setView(v || 'insights')}
+            onNavigateToCanvas={(v) => setView(v || 'workspace')}
             onMobileMenu={() => setIsMobileMenuOpen(true)}
           >
             <button className="icon-btn" onClick={() => setTourForceShow(n => n + 1)} title="Show tour">
               <HelpCircle size={18}/>
             </button>
+            <button className="icon-btn" onClick={openGlobalSearch} title={`Search canvas content (${MOD}+/)`}>
+              <Icon name="search" size={16}/>
+            </button>
+            <button className="icon-btn" onClick={openCommandPalette} title={`Commands (${MOD}+K)`}>
+              <Icon name="zap" size={16}/>
+            </button>
           </AppHeader>
           <div className="canvas-content">
             {view === 'insights' && <InsightsView widgetStates={widgetStates} setWidgetStates={setWidgetStates} onNavigateToChat={onNavigateToChat}/>}
+            {view === 'workspace' && <WorkspaceView openModal={openModal} layout={layout} setLayout={setLayout} widgetStates={widgetStates} setWidgetStates={setWidgetStates}/>}
+            {view === 'deliverables' && <DeliverablesView allStates={widgetStates}/>}
           </div>
         </div>
       </div>
+      <ModalRouter modal={modal} onClose={closeModal}/>
       <ToastStack/>
       <CanvasWelcomeTour key={tourForceShow} forceShow={tourForceShow > 0}/>
       <ShortcutHint/>
@@ -678,7 +1048,7 @@ const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSig
   );
 };
 
-// Subtle floating hint bar showing the help shortcut.
+// Subtle floating hint bar showing the most-used keyboard shortcuts.
 // Auto-hides on small screens and after the first 12s, until the user hovers.
 function ShortcutHint() {
   const [visible, setVisible] = useState(true);
@@ -692,8 +1062,9 @@ function ShortcutHint() {
       onMouseEnter={() => setVisible(true)}
       onMouseLeave={() => setVisible(false)}
     >
+      <span><kbd>{MOD}</kbd><kbd>K</kbd> commands</span>
+      <span><kbd>{MOD}</kbd><kbd>/</kbd> search</span>
       <span><kbd>?</kbd> help</span>
-      <span style={{ opacity: 0.5 }}>{MOD}K commands · coming soon</span>
     </div>
   );
 }

--- a/phd-advisor-frontend/src/pages/CanvasPage.js
+++ b/phd-advisor-frontend/src/pages/CanvasPage.js
@@ -1,574 +1,701 @@
-import React, { useState, useEffect } from 'react';
-import {
-  FileText,
-  RefreshCw,
-  Download,
-  Calendar,
-  TrendingUp,
-  Target,
-  BookOpen,
-  Lightbulb,
-  AlertTriangle,
-  Users,
-  BarChart3,
-  Heart,
-  ArrowLeft,
-  Printer,
-  Trash2,
-  MessageCircle,
-  ArrowRight
-} from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { HelpCircle } from 'lucide-react';
+import { useTheme } from '../contexts/ThemeContext';
 import { useAppConfig } from '../contexts/AppConfigContext';
-import CopyrightNotice from '../components/CopyrightNotice';
-import ConfirmDialog from '../components/ConfirmDialog';
+import Sidebar from '../components/Sidebar';
+import AppHeader from '../components/AppHeader';
+import Icon from '../components/canvas/CanvasIcon';
+import { INSIGHTS } from '../components/canvas/canvasData';
+import CanvasWelcomeTour from '../components/canvas/CanvasWelcomeTour';
+import { MOD } from '../components/canvas/platform';
 import '../styles/CanvasPage.css';
 
-// Section icons mapping
-const sectionIcons = {
-  research_progress: TrendingUp,
-  methodology: BarChart3,
-  theoretical_framework: BookOpen,
-  challenges_obstacles: AlertTriangle,
-  next_steps: Target,
-  writing_communication: FileText,
-  career_development: Users,
-  literature_review: BookOpen,
-  data_analysis: BarChart3,
-  motivation_mindset: Heart
-};
+const VIEW_KEY = 'canvas-view-v2';
+const STATES_KEY = 'canvas-states-v2';
 
-const CanvasSection = ({ section, sectionKey, isExpanded, onToggle }) => {
-  const IconComponent = sectionIcons[sectionKey] || Lightbulb;
-  
-  return (
-    <div className="canvas-section">
-      <div 
-        className="section-header" 
-        onClick={() => onToggle(sectionKey)}
-      >
-        <div className="section-header-content">
-          <IconComponent className="section-icon" />
-          <div className="section-titles">
-            <h3 className="section-title">{section.title}</h3>
-            <p className="section-description">{section.description}</p>
-          </div>
-        </div>
-        <div className="section-meta">
-          <span className="insight-count">{section.insights.length} insights</span>
-          <div className={`expand-arrow ${isExpanded ? 'expanded' : ''}`}>
-            ▼
-          </div>
-        </div>
-      </div>
-      
-      {isExpanded && (
-        <div className="section-content">
-          {section.insights.length === 0 ? (
-            <div className="empty-section">
-              <Lightbulb className="empty-icon" />
-              <p>No insights yet. Keep chatting with your advisors to build this section!</p>
-            </div>
-          ) : (
-            <div className="insights-grid">
-              {section.insights.map((insight, index) => (
-                <div key={index} className="insight-card">
-                  <div className="insight-content">
-                    {insight.content}
-                  </div>
-                  <div className="insight-footer">
-                    <span className="insight-source">{insight.source_persona}</span>
-                    <span className="insight-confidence">
-                      {Math.round(insight.confidence_score * 100)}% confidence
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
+// ============================================================================
+// Insights view — AI-synthesized highlights with stats bar, filters, and
+// click-to-expand source quotes.
+// ============================================================================
+const INSIGHT_CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'open', label: 'Open' },
+  { id: 'in-progress', label: 'In progress' },
+  { id: 'completed', label: 'Completed' },
+  { id: 'abandoned', label: 'Abandoned' },
+  { id: 'pinned', label: 'Pinned' },
+  { id: 'high', label: 'High confidence' },
+  { id: 'progress', label: 'Progress' },
+  { id: 'theory', label: 'Theory' },
+  { id: 'literature', label: 'Literature' },
+  { id: 'action', label: 'Actions' },
+  { id: 'risk', label: 'Risks' },
+];
+const CATEGORY_TINT = {
+  progress: 'rgba(16, 185, 129, 0.12)',
+  theory: 'rgba(99, 102, 241, 0.12)',
+  literature: 'rgba(245, 158, 11, 0.12)',
+  action: 'rgba(59, 130, 246, 0.12)',
+  risk: 'rgba(220, 38, 38, 0.12)',
 };
+const CATEGORY_FG = {
+  progress: '#10B981',
+  theory: '#818CF8',
+  literature: '#F59E0B',
+  action: '#3B82F6',
+  risk: '#DC2626',
+};
+const confidenceTier = (c) => c >= 75 ? 'high' : c >= 60 ? 'med' : 'low';
 
-const CanvasPage = ({ user, authToken, onNavigateToChat, onSignOut }) => {
-  const { config } = useAppConfig();
-  const appName = config?.app_settings?.app_name || 'Advisory Panel';
-  const [canvasData, setCanvasData] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [expandedSections, setExpandedSections] = useState({});
-  const [stats, setStats] = useState({});
-  const [isPrintView, setIsPrintView] = useState(false);
-  const [isProcessingFirstTime, setIsProcessingFirstTime] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
-  const [isClearing, setIsClearing] = useState(false);
+// Task statuses live on each individual bullet within an insight, not on the
+// whole card — Daniel's feedback: "each card is a discrete task, not a set of tasks".
+const TASK_STATUSES = [
+  { id: 'open', label: 'Open', color: 'var(--canvas-text-3)', icon: 'sparkles' },
+  { id: 'in-progress', label: 'In progress', color: '#3B82F6', icon: 'graph' },
+  { id: 'completed', label: 'Completed', color: '#10B981', icon: 'check' },
+  { id: 'abandoned', label: 'Abandoned', color: 'var(--canvas-text-4)', icon: 'x' },
+];
+const TASK_STATUS_KEY = 'canvas-task-status-v1';
+const taskKey = (insId, idx) => `${insId}::${idx}`;
+
+function InsightsView({ widgetStates, setWidgetStates, onNavigateToChat }) {
+  const [pinned, setPinned] = useState(() => new Set(INSIGHTS.filter(i => i.pinned).map(i => i.id)));
+  const [taskStatuses, setTaskStatuses] = useState(() => {
+    try { return JSON.parse(localStorage.getItem(TASK_STATUS_KEY) || '{}'); } catch { return {}; }
+  });
+  const [filter, setFilter] = useState('all');
+  const [sortBy, setSortBy] = useState('confidence');
+  const [expanded, setExpanded] = useState(new Set());
+  const [refreshing, setRefreshing] = useState(false);
+  const [openStatusMenu, setOpenStatusMenu] = useState(null);
+  // 'cards' = current cards-of-tasks layout, 'tasks' = flat task list per Daniel's
+  // "Sections in sidebar, Tasks in the main view" suggestion.
+  const [viewMode, setViewMode] = useState(() => localStorage.getItem('canvas-insights-view') || 'cards');
+  useEffect(() => { localStorage.setItem('canvas-insights-view', viewMode); }, [viewMode]);
 
   useEffect(() => {
-    let pollInterval = null;
-    
-    const initializeCanvas = async () => {
-      await fetchCanvas();
-      await fetchStats();
-      await triggerAutoUpdate();
-      
-      setTimeout(() => {
-        checkForEmptyCanvasWithChats();
-      }, 2000);
+    localStorage.setItem(TASK_STATUS_KEY, JSON.stringify(taskStatuses));
+  }, [taskStatuses]);
+
+  const taskStatusOf = (insId, idx) => taskStatuses[taskKey(insId, idx)] || 'open';
+  const setTaskStatus = (insId, idx, status) => {
+    setTaskStatuses(prev => ({ ...prev, [taskKey(insId, idx)]: status }));
+    const lbl = TASK_STATUSES.find(s => s.id === status)?.label || status;
+    window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: `Task marked ${lbl}`, kind: 'success' } }));
+  };
+
+  // Roll up to a card-level status: completed if all tasks done, abandoned if all abandoned,
+  // in-progress if any are in-progress, otherwise open.
+  const insightRollup = (ins) => {
+    const states = ins.bullets.map((_, idx) => taskStatusOf(ins.id, idx));
+    const total = states.length;
+    if (total === 0) return { state: 'open', done: 0, total: 0, pct: 0 };
+    const done = states.filter(s => s === 'completed').length;
+    const inProg = states.filter(s => s === 'in-progress').length;
+    const abandoned = states.filter(s => s === 'abandoned').length;
+    let state = 'open';
+    if (done === total) state = 'completed';
+    else if (abandoned === total) state = 'abandoned';
+    else if (inProg > 0 || done > 0) state = 'in-progress';
+    return { state, done, total, inProg, abandoned, pct: Math.round((done / total) * 100) };
+  };
+
+  const togglePin = (id) => {
+    setPinned(prev => {
+      const n = new Set(prev);
+      if (n.has(id)) n.delete(id); else n.add(id);
+      return n;
+    });
+  };
+  const toggleExpand = (id) => {
+    setExpanded(prev => {
+      const n = new Set(prev);
+      if (n.has(id)) n.delete(id); else n.add(id);
+      return n;
+    });
+  };
+
+  const insightToTaskTitle = (ins) => {
+    const plain = (ins.bullets[0] || ins.summary || ins.title).replace(/<[^>]+>/g, '');
+    return plain.length > 80 ? plain.slice(0, 77) + '…' : plain;
+  };
+
+  // Pre-stages a kanban card in shared widget state so that when the user adds a
+  // Kanban widget (next PR) the work transferred from Insights is already there.
+  const sendToKanban = (ins) => {
+    if (!setWidgetStates) return;
+    const kanban = widgetStates.kanban || { cards: [] };
+    const card = {
+      id: 'k' + Date.now(),
+      col: 'todo',
+      title: insightToTaskTitle(ins),
+      priority: 'med',
+      meta: `from Insights · ${ins.title}`,
     };
-    
-    initializeCanvas();
-    
-    // Cleanup on unmount
-    return () => {
-      if (pollInterval) {
-        clearInterval(pollInterval);
-      }
-    };
-  }, []);
-
-  const fetchCanvas = async () => {
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setCanvasData(data);
-        
-        // Auto-expand sections with insights
-        const sectionsToExpand = {};
-        Object.entries(data.sections).forEach(([key, section]) => {
-          if (section.insights.length > 0) {
-            sectionsToExpand[key] = true;
-          }
-        });
-        setExpandedSections(sectionsToExpand);
-      } else {
-        console.error('Failed to fetch canvas');
-      }
-    } catch (error) {
-      console.error('Error fetching canvas:', error);
-    } finally {
-      setIsLoading(false);
-    }
+    setWidgetStates(s => ({ ...s, kanban: { ...kanban, cards: [...(kanban.cards || []), card] } }));
+    window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: 'Sent to Kanban (To Do)', kind: 'success' } }));
   };
 
-  const fetchStats = async () => {
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas/stats`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setStats(data);
-      }
-    } catch (error) {
-      console.error('Error fetching stats:', error);
-    }
+  // TODO(LLM): real refresh hits the orchestrator and re-synthesizes insights.
+  const handleRefresh = () => {
+    setRefreshing(true);
+    setTimeout(() => setRefreshing(false), 900);
+    window.dispatchEvent(new CustomEvent('canvas-toast', { detail: { msg: 'Refreshing insights… (stub)', kind: 'success' } }));
   };
 
-  // Check if user has chats but empty canvas
-  const checkForEmptyCanvasWithChats = async () => {
+  // "Ask follow-up": stash a draft prompt + insight context that the chat page
+  // can pick up on next navigation. Backend hookup TODO: include source-conversation IDs.
+  const askFollowUp = (ins) => {
+    const plain = (ins.bullets[0] || ins.summary || '').replace(/<[^>]+>/g, '');
+    const prompt = `Follow up on the insight "${ins.title}": ${plain}`;
     try {
-      const isEmpty = !canvasData || canvasData.total_insights === 0;
-      
-      if (isEmpty) {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-sessions/count`, {
-          headers: {
-            'Authorization': `Bearer ${authToken}`,
-            'Content-Type': 'application/json'
-          }
-        });
-        
-        if (response.ok) {
-          const { count } = await response.json();
-          if (count > 0) {
-            console.log(`User has ${count} chats but empty canvas. Triggering full refresh.`);
-            await handleFullRefresh();
-          }
-        } else {
-          console.error('Failed to fetch chat sessions count:', response.status);
-          // Don't trigger refresh if count fails
-          return;
-        }
-      }
-    } catch (error) {
-      console.error('Error checking for empty canvas with chats:', error);
-      // Stop the polling if there's an error
-      return;
-    }
-  };
-
-  const triggerAutoUpdate = async () => {
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas/auto-update`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-      
-      if (response.ok) {
-        const result = await response.json();
-        
-        // If this is a first-time canvas update, show appropriate message
-        if (result.type === 'full_update') {
-          console.log('First-time canvas detected. Processing all your chats...');
-          
-          // Show loading state
-          setIsProcessingFirstTime(true);
-          setIsUpdating(true);
-          
-          // Poll for updates every 10 seconds for up to 3 minutes
-          let attempts = 0;
-          const maxAttempts = 18; // 3 minutes / 10 seconds
-          
-          const pollForUpdates = setInterval(async () => {
-            attempts++;
-            
-            try {
-              await fetchCanvas();
-              
-              // If canvas now has insights, stop polling
-              if (canvasData && canvasData.total_insights > 0) {
-                clearInterval(pollForUpdates);
-                setIsUpdating(false);
-                setIsProcessingFirstTime(false);
-                console.log('Canvas successfully populated with insights!');
-              }
-              
-              // Stop polling after max attempts
-              if (attempts >= maxAttempts) {
-                clearInterval(pollForUpdates);
-                setIsUpdating(false);
-                setIsProcessingFirstTime(false);
-              }
-            } catch (error) {
-              console.error('Error polling for updates:', error);
-            }
-          }, 10000);
-        }
-      }
-    } catch (error) {
-      console.error('Error triggering auto-update:', error);
-    }
-  };
-
-  const handleClearCanvas = async () => {
-    setIsClearing(true);
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-      if (response.ok) {
-        setCanvasData(null);
-        await fetchCanvas();
-      }
-    } catch (error) {
-      console.error('Error clearing canvas:', error);
-    } finally {
-      setIsClearing(false);
-      setShowClearConfirm(false);
-    }
-  };
-
-  const handleRefreshCanvas = async () => {
-    // Prevent multiple simultaneous refresh requests
-    if (isRefreshing || isUpdating) {
-      console.log('Refresh already in progress, ignoring duplicate request');
-      return;
-    }
-    
-    setIsRefreshing(true);
-    setIsUpdating(true);
-    
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas/refresh`, {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        console.log('Full refresh initiated:', result);
-        
-        // Poll for updates
-        setTimeout(() => {
-          fetchCanvas();
-          fetchStats();
-        }, 5000);
-        
-        setTimeout(() => {
-          setIsUpdating(false);
-          setIsRefreshing(false);
-        }, 10000);
-      }
-    } catch (error) {
-      console.error('Error refreshing canvas:', error);
-      setIsUpdating(false);
-      setIsRefreshing(false);
-    }
-  };
-
-  const handleFullRefresh = async () => {
-    // Prevent multiple simultaneous refresh requests
-    if (isRefreshing || isUpdating) {
-      console.log('Refresh already in progress, ignoring duplicate request');
-      return;
-    }
-    
-    setIsRefreshing(true);
-    setIsUpdating(true);
-    
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/api/phd-canvas/refresh`, {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        console.log('Full refresh initiated:', result);
-        
-        // Poll for updates
-        setTimeout(() => {
-          fetchCanvas();
-          fetchStats();
-        }, 5000);
-        
-        setTimeout(() => {
-          setIsUpdating(false);
-          setIsRefreshing(false);
-        }, 10000);
-      }
-    } catch (error) {
-      console.error('Error refreshing canvas:', error);
-      setIsUpdating(false);
-      setIsRefreshing(false);
-    }
-  };
-
-  const toggleSection = (sectionKey) => {
-    setExpandedSections(prev => ({
-      ...prev,
-      [sectionKey]: !prev[sectionKey]
+      localStorage.setItem('canvas-chat-handoff', JSON.stringify({
+        at: Date.now(),
+        prompt,
+        insightId: ins.id,
+        insightTitle: ins.title,
+      }));
+    } catch { /* ignore */ }
+    window.dispatchEvent(new CustomEvent('canvas-toast', {
+      detail: { msg: `Follow-up drafted: "${ins.title}" — opening chat`, kind: 'success' },
     }));
+    // Use the existing navigation prop if present; falls back to the global event.
+    if (onNavigateToChat) onNavigateToChat();
   };
 
-  const handlePrint = () => {
-    setIsPrintView(true);
-    setTimeout(() => {
-      window.print();
-      setIsPrintView(false);
-    }, 100);
-  };
+  const filtered = useMemo(() => {
+    let r = INSIGHTS;
+    if (filter === 'pinned') r = r.filter(i => pinned.has(i.id));
+    else if (filter === 'high') r = r.filter(i => i.confidence >= 75);
+    else if (['open', 'in-progress', 'completed', 'abandoned'].includes(filter)) r = r.filter(i => insightRollup(i).state === filter);
+    else if (filter !== 'all') r = r.filter(i => i.category === filter);
+    if (sortBy === 'confidence') r = [...r].sort((a, b) => b.confidence - a.confidence);
+    if (sortBy === 'recent') r = [...r].sort((a, b) => (a.updatedMinutesAgo || 0) - (b.updatedMinutesAgo || 0));
+    if (sortBy === 'progress') r = [...r].sort((a, b) => insightRollup(b).pct - insightRollup(a).pct);
+    return r;
+  }, [filter, sortBy, pinned, taskStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const formatDate = (dateString) => {
-    if (!dateString) return 'Never';
-    return new Date(dateString).toLocaleDateString();
-  };
+  // Aggregate stats over individual TASKS, not insights (Daniel's framing)
+  const stats = useMemo(() => {
+    const allTasks = INSIGHTS.flatMap(i => i.bullets.map((_, idx) => taskStatusOf(i.id, idx)));
+    const taskTotal = allTasks.length;
+    const completed = allTasks.filter(s => s === 'completed').length;
+    const inProgress = allTasks.filter(s => s === 'in-progress').length;
+    const abandoned = allTasks.filter(s => s === 'abandoned').length;
+    const open = taskTotal - completed - inProgress - abandoned;
+    const totalSources = INSIGHTS.reduce((s, i) => s + (i.sources || 0), 0);
+    const avgConf = Math.round(INSIGHTS.reduce((s, i) => s + i.confidence, 0) / INSIGHTS.length);
+    return {
+      sections: INSIGHTS.length, taskTotal, completed, inProgress, abandoned, open,
+      totalSources, avgConf, pinnedCount: pinned.size,
+    };
+  }, [pinned, taskStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (isLoading) {
+  const lastUpdated = Math.min(...INSIGHTS.map(i => i.updatedMinutesAgo || 0));
+
+  // Empty state — defensive (current data is hardcoded but a real backend could send [])
+  if (INSIGHTS.length === 0) {
     return (
-      <div className="canvas-loading">
-        <div className="loading-spinner"></div>
-        <p>Loading your {appName} Canvas...</p>
-      </div>
+      <>
+        <div className="page-header">
+          <div>
+            <h1 className="page-title">Insights</h1>
+            <div className="page-sub">AI-synthesized from your research conversations.</div>
+          </div>
+        </div>
+        <div className="empty-cell">
+          <Icon name="sparkles" size={32} style={{ color: 'var(--canvas-text-4)' }}/>
+          <div style={{ fontSize: 14, color: 'var(--canvas-text-2)', fontWeight: 500 }}>No insights yet</div>
+          <div>Have a conversation with your advisors and insights will appear here.</div>
+        </div>
+      </>
     );
   }
 
-  // Sort sections by priority and insights count
-  const sortedSections = Object.entries(canvasData?.sections || {})
-    .sort(([, a], [, b]) => {
-      // First by priority (lower number = higher priority)
-      if (a.priority !== b.priority) {
-        return a.priority - b.priority;
-      }
-      // Then by insights count (more insights first)
-      return b.insights.length - a.insights.length;
-    });
-
   return (
-    <div className={`canvas-page ${isPrintView ? 'print-view' : ''}`}>
-      {/* Header */}
-      <div className="canvas-header">
-        <div className="canvas-header-top">
-          <button
-            className="back-button"
-            onClick={onNavigateToChat}
-          >
-            <ArrowLeft size={20} />
-            Back to Chat
-          </button>
-
-          <div className="header-actions">
-            <button
-              onClick={handleRefreshCanvas}
-              disabled={isRefreshing || isUpdating}
-              className={`canvas-icon-btn refresh-button ${(isRefreshing || isUpdating) ? 'disabled' : ''}`}
-              title={(isRefreshing || isUpdating) ? 'Refreshing…' : 'Refresh Canvas'}
-              aria-label="Refresh canvas"
-            >
-              <RefreshCw className={`refresh-icon ${(isRefreshing || isUpdating) ? 'spinning' : ''}`} />
-            </button>
-
-            <button
-              className="canvas-icon-btn print-button"
-              onClick={handlePrint}
-              title="Print"
-              aria-label="Print canvas"
-            >
-              <Printer className="action-icon" />
-            </button>
-
-            <button
-              className="canvas-icon-btn clear-canvas-btn"
-              onClick={() => setShowClearConfirm(true)}
-              disabled={isClearing}
-              title="Clear Canvas"
-              aria-label="Clear canvas"
-            >
-              <Trash2 className="action-icon" />
-            </button>
-          </div>
-        </div>
-
-        <div className="canvas-title-section">
-          <h1 className="canvas-title">
-            <FileText className="canvas-title-icon" />
-            {appName} Canvas
-          </h1>
-          <p className="canvas-subtitle">Your research progress at a glance</p>
+    <>
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">Insights</h1>
+          <div className="page-sub">AI-synthesized from your research conversations.</div>
         </div>
       </div>
 
-      {/* Stats Bar */}
-      <div className="canvas-stats">
-        <div className="stat-item">
-          <span className="stat-number">{canvasData?.total_insights || 0}</span>
-          <span className="stat-label">Total Insights</span>
+      {/* Stats bar */}
+      <div className="insights-stats">
+        <div className="insights-stat">
+          <span className="insights-stat-value">{stats.completed}/{stats.taskTotal}</span>
+          <span className="insights-stat-label">tasks done</span>
         </div>
-        <div className="stat-item">
-          <span className="stat-number">
-            {Object.keys(canvasData?.sections || {}).filter(key => 
-              canvasData.sections[key].insights.length > 0
-            ).length}
+        <div className="insights-stat insights-stat-progress">
+          <div className="insights-progress-bar">
+            <i className="ip-completed" style={{ width: `${(stats.completed / Math.max(1, stats.taskTotal)) * 100}%` }}/>
+            <i className="ip-inprogress" style={{ width: `${(stats.inProgress / Math.max(1, stats.taskTotal)) * 100}%` }}/>
+            <i className="ip-abandoned" style={{ width: `${(stats.abandoned / Math.max(1, stats.taskTotal)) * 100}%` }}/>
+          </div>
+          <span className="insights-stat-label">
+            {stats.completed} done · {stats.inProgress} in progress · {stats.open} open
+            {stats.abandoned > 0 && ` · ${stats.abandoned} abandoned`}
           </span>
-          <span className="stat-label">Active Sections</span>
         </div>
-        <div className="stat-item">
-          <span className="stat-number">
-            {formatDate(canvasData?.last_updated)}
+        <div className="insights-stat">
+          <span className="insights-stat-value">{stats.sections}</span>
+          <span className="insights-stat-label">sections</span>
+        </div>
+        <div className="insights-stat">
+          <span className="insights-stat-value">{stats.avgConf}%</span>
+          <span className="insights-stat-label">avg confidence</span>
+        </div>
+        <span style={{ flex: 1 }}/>
+        <span className="insights-stat-update">
+          <span className="dot"/>
+          updated {lastUpdated} min ago
+        </span>
+        <button className="btn btn-ghost" onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? <div className="spinner"/> : <Icon name="refresh" size={13}/>}
+          Refresh
+        </button>
+      </div>
+
+      {/* View toggle: Cards (sections with their tasks) vs Tasks (flat list) */}
+      <div className="insights-view-toggle">
+        <button className={viewMode === 'cards' ? 'active' : ''} onClick={() => setViewMode('cards')}>
+          <Icon name="layout" size={12}/>Cards
+        </button>
+        <button className={viewMode === 'tasks' ? 'active' : ''} onClick={() => setViewMode('tasks')}>
+          <Icon name="task" size={12}/>Tasks
+        </button>
+      </div>
+
+      {/* Filter + sort */}
+      <div className="insights-filters">
+        <div className="palette-cats" style={{ marginBottom: 0 }}>
+          {INSIGHT_CATEGORIES.map(c => {
+            const count =
+              c.id === 'all' ? INSIGHTS.length :
+              c.id === 'pinned' ? pinned.size :
+              c.id === 'high' ? INSIGHTS.filter(i => i.confidence >= 75).length :
+              ['open', 'in-progress', 'completed', 'abandoned'].includes(c.id) ? INSIGHTS.filter(i => insightRollup(i).state === c.id).length :
+              INSIGHTS.filter(i => i.category === c.id).length;
+            if (count === 0 && c.id !== 'all') return null;
+            return (
+              <button key={c.id}
+                className={`palette-cat ${filter === c.id ? 'active' : ''}`}
+                onClick={() => setFilter(c.id)}>
+                {c.label}<span style={{ marginLeft: 6, opacity: 0.6 }}>{count}</span>
+              </button>
+            );
+          })}
+        </div>
+        <select className="select" style={{ width: 'auto', padding: '4px 8px', fontSize: 11, fontFamily: 'var(--canvas-mono)' }}
+          value={sortBy} onChange={e => setSortBy(e.target.value)}>
+          <option value="confidence">↓ confidence</option>
+          <option value="recent">↓ recent</option>
+          <option value="progress">↓ progress</option>
+        </select>
+      </div>
+
+      {/* Pinned strip — only when there are pins and we're not already filtering by pinned */}
+      {pinned.size > 0 && filter !== 'pinned' && (
+        <div className="insights-pinned-strip">
+          <span style={{ fontSize: 11, color: 'var(--canvas-text-4)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600 }}>
+            Pinned
           </span>
-          <span className="stat-label">Last Updated</span>
-        </div>
-      </div>
-
-      {/* Canvas Content */}
-      <div className="canvas-content">
-        {sortedSections.length === 0 ? (
-          <div className="empty-canvas">
-            <FileText className="empty-canvas-icon" />
-            <h2>Your Canvas is Empty</h2>
-            {isUpdating || isProcessingFirstTime ? (
-              <div>
-                <p>
-                  {isProcessingFirstTime 
-                    ? 'Processing your chat history to populate insights...' 
-                    : 'Updating canvas with latest insights...'
-                  }
-                </p>
-                <div className="inline-loading-spinner">
-                  <RefreshCw className="spinning" />
-                </div>
-                <p className="processing-note">
-                  This may take a few minutes for extensive chat history.
-                </p>
-              </div>
-            ) : (
-              <div>
-                <p>Start chatting with your AI advisors to populate your {appName} Canvas with insights!</p>
-                <div className="empty-canvas-actions">
-                  <button
-                    className="empty-canvas-btn primary"
-                    onClick={onNavigateToChat}
-                  >
-                    <MessageCircle size={18} />
-                    <span>Start Chatting</span>
-                    <ArrowRight size={16} className="empty-canvas-btn-arrow" />
-                  </button>
-                  <button
-                    className="empty-canvas-btn secondary"
-                    onClick={handleFullRefresh}
-                  >
-                    <RefreshCw size={16} />
-                    <span>Process Existing Chats</span>
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        ) : (
-          <div className="sections-container">
-            {sortedSections.map(([sectionKey, section]) => (
-              <CanvasSection
-                key={sectionKey}
-                section={section}
-                sectionKey={sectionKey}
-                isExpanded={expandedSections[sectionKey]}
-                onToggle={toggleSection}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Copyright Footer */}
-      <footer className="canvas-copyright-footer">
-        <CopyrightNotice />
-      </footer>
-
-      {/* Print Footer */}
-      {isPrintView && (
-        <div className="print-footer">
-          <p>Generated by {appName} - {new Date().toLocaleDateString()}</p>
-          <p>Student: {user?.email} | Total Insights: {canvasData?.total_insights || 0}</p>
+          {INSIGHTS.filter(i => pinned.has(i.id)).map(ins => (
+            <button key={ins.id} className="insights-pinned-pill" onClick={() => {
+              const el = document.getElementById(`insight-${ins.id}`);
+              if (el) {
+                el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                el.style.boxShadow = '0 0 0 2px var(--canvas-accent), 0 0 24px var(--canvas-accent-glow)';
+                setTimeout(() => { el.style.boxShadow = ''; }, 1400);
+              }
+            }}>
+              <Icon name={ins.icon} size={11}/>{ins.title}
+            </button>
+          ))}
         </div>
       )}
 
-      <ConfirmDialog
-        isOpen={showClearConfirm}
-        title="Clear canvas?"
-        message="This will permanently delete all insights on your canvas. This action can't be undone."
-        confirmLabel={isClearing ? 'Clearing…' : 'Clear canvas'}
-        cancelLabel="Cancel"
-        tone="danger"
-        onConfirm={handleClearCanvas}
-        onCancel={() => setShowClearConfirm(false)}
+      {/* TASKS view — flat list of every bullet across insights */}
+      {viewMode === 'tasks' && (() => {
+        const allTasks = filtered.flatMap(ins => ins.bullets.map((b, idx) => ({
+          ins, idx, text: b, status: taskStatusOf(ins.id, idx),
+        })));
+        const statusOrder = { open: 0, 'in-progress': 1, completed: 2, abandoned: 3 };
+        const sorted = [...allTasks].sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+        if (sorted.length === 0) {
+          return (
+            <div className="empty-cell">
+              <Icon name="task" size={28} style={{ color: 'var(--canvas-text-4)' }}/>
+              <div style={{ fontSize: 14, color: 'var(--canvas-text-2)', fontWeight: 500 }}>No tasks match this filter</div>
+              <button className="btn btn-ghost" onClick={() => setFilter('all')}>Show all</button>
+            </div>
+          );
+        }
+        return (
+          <div className="insights-tasks-list">
+            {sorted.map(({ ins, idx, text, status }) => {
+              const meta = TASK_STATUSES.find(s => s.id === status);
+              const menuKey = `tv::${ins.id}::${idx}`;
+              const menuOpen = openStatusMenu === menuKey;
+              return (
+                <div key={menuKey} className={`insights-task-row task-${status}`}>
+                  <button
+                    className="insight-task-check"
+                    style={{ color: meta.color, borderColor: meta.color + '60' }}
+                    onClick={() => setOpenStatusMenu(menuOpen ? null : menuKey)}
+                    title={`Status: ${meta.label}`}
+                  >
+                    {status === 'completed' && <Icon name="check" size={11}/>}
+                    {status === 'in-progress' && <span className="task-check-dot"/>}
+                    {status === 'abandoned' && <Icon name="x" size={10}/>}
+                  </button>
+                  <div className="insights-task-body">
+                    <button
+                      className="insights-task-section"
+                      onClick={() => {
+                        setViewMode('cards');
+                        setTimeout(() => {
+                          const el = document.getElementById(`insight-${ins.id}`);
+                          if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                        }, 60);
+                      }}
+                      title="Jump to this section"
+                    >
+                      <Icon name={ins.icon} size={10}/>{ins.title}
+                    </button>
+                    <span className="insights-task-text" dangerouslySetInnerHTML={{ __html: text }}/>
+                  </div>
+                  <button className="chip" onClick={() => sendToKanban(ins)} title="Send this section's open tasks to Kanban">
+                    <Icon name="task" size={11}/>Kanban
+                  </button>
+                  {menuOpen && (
+                    <div className="insight-status-menu" onMouseLeave={() => setOpenStatusMenu(null)}>
+                      {TASK_STATUSES.map(s => (
+                        <button key={s.id}
+                          className={status === s.id ? 'active' : ''}
+                          onClick={() => { setTaskStatus(ins.id, idx, s.id); setOpenStatusMenu(null); }}>
+                          <Icon name={s.icon} size={11} style={{ color: s.color }}/>
+                          {s.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })()}
+
+      {/* CARDS view (default) */}
+      {viewMode === 'cards' && (filtered.length === 0 ? (
+        <div className="empty-cell">
+          <Icon name="search" size={28} style={{ color: 'var(--canvas-text-4)' }}/>
+          <div style={{ fontSize: 14, color: 'var(--canvas-text-2)', fontWeight: 500 }}>No insights match this filter</div>
+          <button className="btn btn-ghost" onClick={() => setFilter('all')}>Show all</button>
+        </div>
+      ) : (
+        <div className="insight-grid">
+          {filtered.map(ins => {
+            const isExpanded = expanded.has(ins.id);
+            const isPinned = pinned.has(ins.id);
+            const tier = confidenceTier(ins.confidence);
+            const tint = CATEGORY_TINT[ins.category] || 'var(--canvas-surface-2)';
+            const fg = CATEGORY_FG[ins.category] || 'var(--canvas-accent)';
+            const rollup = insightRollup(ins);
+            return (
+              <div
+                key={ins.id}
+                id={`insight-${ins.id}`}
+                className={`insight ${isPinned ? 'is-pinned' : ''} tier-${tier} status-${rollup.state}`}
+              >
+                <div className="insight-head">
+                  <div className="insight-icon" style={{ background: tint, color: fg }}>
+                    <Icon name={ins.icon} size={16}/>
+                  </div>
+                  <div className="insight-title">{ins.title}</div>
+                  <ConfidenceRing value={ins.confidence}/>
+                </div>
+
+                {/* Per-card progress (rolls up the bullet tasks) */}
+                {rollup.total > 0 && (
+                  <div className="insight-progress">
+                    <div className="insight-progress-meta">
+                      <span className="insight-progress-count">{rollup.done}/{rollup.total} tasks</span>
+                      {rollup.state === 'completed' && <span className="insight-progress-badge done">✓ Resolved</span>}
+                      {rollup.state === 'abandoned' && <span className="insight-progress-badge abandoned">Abandoned</span>}
+                      {rollup.state === 'in-progress' && <span className="insight-progress-badge inprog">In progress</span>}
+                    </div>
+                    <div className="insight-progress-bar">
+                      <i className="ip-completed" style={{ width: `${(rollup.done / rollup.total) * 100}%` }}/>
+                      {rollup.inProg > 0 && <i className="ip-inprogress" style={{ width: `${(rollup.inProg / rollup.total) * 100}%` }}/>}
+                      {rollup.abandoned > 0 && <i className="ip-abandoned" style={{ width: `${(rollup.abandoned / rollup.total) * 100}%` }}/>}
+                    </div>
+                  </div>
+                )}
+
+                <div className="insight-body">
+                  <div>{ins.summary}</div>
+                  <ul className="insight-tasks">
+                    {ins.bullets.map((b, idx) => {
+                      const status = taskStatusOf(ins.id, idx);
+                      const meta = TASK_STATUSES.find(s => s.id === status);
+                      const menuOpen = openStatusMenu === `${ins.id}::${idx}`;
+                      return (
+                        <li key={idx} className={`insight-task task-${status}`}>
+                          <button
+                            className="insight-task-check"
+                            style={{ color: meta.color, borderColor: meta.color + '60' }}
+                            onClick={() => setOpenStatusMenu(menuOpen ? null : `${ins.id}::${idx}`)}
+                            title={`Status: ${meta.label}`}
+                          >
+                            {status === 'completed' && <Icon name="check" size={10}/>}
+                            {status === 'in-progress' && <span className="task-check-dot"/>}
+                            {status === 'abandoned' && <Icon name="x" size={9}/>}
+                          </button>
+                          <span className="insight-task-text" dangerouslySetInnerHTML={{ __html: b }}/>
+                          {menuOpen && (
+                            <div className="insight-status-menu" onMouseLeave={() => setOpenStatusMenu(null)}>
+                              {TASK_STATUSES.map(s => (
+                                <button key={s.id}
+                                  className={status === s.id ? 'active' : ''}
+                                  onClick={() => { setTaskStatus(ins.id, idx, s.id); setOpenStatusMenu(null); }}>
+                                  <Icon name={s.icon} size={11} style={{ color: s.color }}/>
+                                  {s.label}
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+
+                {/* Detail panel — quotes from sources, only when expanded */}
+                {isExpanded && ins.quotes && (
+                  <div className="insight-detail">
+                    <div className="insight-detail-head">Source quotes · {ins.sources} {ins.sources === 1 ? 'source' : 'sources'}</div>
+                    {ins.quotes.map((q, i) => (
+                      <div key={i} className="insight-quote">{q}</div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="insight-foot">
+                  <span className="insight-foot-meta">
+                    <Icon name="message" size={10}/> {ins.sources}
+                    <span className="insight-dot"/>
+                    updated {ins.updatedMinutesAgo}m ago
+                  </span>
+                </div>
+
+                <div className="insight-actions">
+                  <button className="chip" onClick={() => askFollowUp(ins)} title="Open this insight in a new chat session">
+                    <Icon name="message" size={11}/>Ask follow-up
+                  </button>
+                  <button className="chip" onClick={() => sendToKanban(ins)} title="Add all open tasks from this insight to your Kanban (To Do)">
+                    <Icon name="task" size={11}/>Add to Kanban
+                  </button>
+                  <button className="chip" onClick={() => toggleExpand(ins.id)}>
+                    <Icon name="expand" size={11}/>{isExpanded ? 'Collapse' : 'Source quotes'}
+                  </button>
+                  <button className={`chip ${isPinned ? 'pinned' : ''}`} onClick={() => togglePin(ins.id)}>
+                    <Icon name="pin" size={11}/>{isPinned ? 'Pinned' : 'Pin'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </>
+  );
+}
+
+// Small SVG ring used for the confidence indicator
+function ConfidenceRing({ value }) {
+  const r = 14;
+  const c = 2 * Math.PI * r;
+  const dash = c * (1 - value / 100);
+  const tier = confidenceTier(value);
+  const color = tier === 'high' ? '#10B981' : tier === 'med' ? '#F59E0B' : '#DC2626';
+  return (
+    <div className={`confidence-ring tier-${tier}`} title={`${value}% confidence (${tier})`}>
+      <svg width="32" height="32" viewBox="0 0 32 32">
+        <circle cx="16" cy="16" r={r} fill="none" stroke="var(--canvas-surface-3)" strokeWidth="3"/>
+        <circle cx="16" cy="16" r={r} fill="none" stroke={color} strokeWidth="3"
+          strokeDasharray={c} strokeDashoffset={dash} strokeLinecap="round"
+          transform="rotate(-90 16 16)"/>
+      </svg>
+      <span style={{ color }}>{value}</span>
+    </div>
+  );
+}
+
+function ToastStack() {
+  const [toasts, setToasts] = useState([]);
+  useEffect(() => {
+    const handler = (e) => {
+      const id = Date.now() + Math.random();
+      setToasts(t => [...t, { id, ...e.detail }]);
+      setTimeout(() => setToasts(t => t.filter(x => x.id !== id)), 3500);
+    };
+    window.addEventListener('canvas-toast', handler);
+    return () => window.removeEventListener('canvas-toast', handler);
+  }, []);
+  return (
+    <div className="toast-stack">
+      {toasts.map(t => (
+        <div key={t.id} className={`toast ${t.kind || 'success'}`}>
+          <Icon name={t.kind === 'critic' ? 'gavel' : t.kind === 'danger' ? 'alert' : 'check'} size={14}/>
+          <span>{t.msg}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+
+const CanvasPage = ({ user, authToken, onNavigateToHome, onNavigateToChat, onSignOut }) => {
+  const { theme } = useTheme();
+  useAppConfig();
+  // Insights is the only view available in this PR. Workspace + Documents land
+  // in follow-up PRs but the storage key + tab-switching plumbing stay so those
+  // PRs can extend without touching this file's structure.
+  const [view, setView] = useState(() => {
+    const saved = localStorage.getItem(VIEW_KEY);
+    return saved === 'insights' ? saved : 'insights';
+  });
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [tourForceShow, setTourForceShow] = useState(0);
+
+  // Shared widget-state store. Empty in this PR (no widgets yet); kept so the
+  // Insights "Send to Kanban" can pre-stage work for the next PR's Kanban widget.
+  const [widgetStates, setWidgetStates] = useState(() => {
+    try {
+      const saved = localStorage.getItem(STATES_KEY);
+      return saved ? JSON.parse(saved) : {};
+    } catch { return {}; }
+  });
+  useEffect(() => { localStorage.setItem(STATES_KEY, JSON.stringify(widgetStates)); }, [widgetStates]);
+  useEffect(() => { localStorage.setItem(VIEW_KEY, view); }, [view]);
+
+  // Apply canvas theme attribute on body for scoped styling
+  useEffect(() => {
+    document.body.dataset.canvasTheme = theme;
+    return () => { delete document.body.dataset.canvasTheme; };
+  }, [theme]);
+
+  // Critic widgets dispatch `canvas-open-in-chat` when the user wants real LLM history.
+  useEffect(() => {
+    const handler = () => onNavigateToChat && onNavigateToChat();
+    window.addEventListener('canvas-open-in-chat', handler);
+    return () => window.removeEventListener('canvas-open-in-chat', handler);
+  }, [onNavigateToChat]);
+
+  // ? opens the welcome tour for help (matches the icon in the topbar).
+  useEffect(() => {
+    const k = (e) => {
+      if (e.key === '?' && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
+        e.preventDefault();
+        setTourForceShow(n => n + 1);
+      }
+    };
+    window.addEventListener('keydown', k);
+    return () => window.removeEventListener('keydown', k);
+  }, []);
+
+  // Highlight a section when picked from the sidebar
+  const flashScrollTo = (selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    el.style.boxShadow = '0 0 0 2px var(--canvas-accent), 0 0 24px var(--canvas-accent-glow)';
+    setTimeout(() => { el.style.boxShadow = ''; }, 1400);
+  };
+
+  // Insights: list of sections — Daniel's feedback said sidebar should show sections here
+  const insightSections = useMemo(() => {
+    let taskMap = {};
+    try { taskMap = JSON.parse(localStorage.getItem(TASK_STATUS_KEY) || '{}'); } catch { /* ignore */ }
+    return INSIGHTS.map(ins => {
+      const states = ins.bullets.map((_, idx) => taskMap[taskKey(ins.id, idx)] || 'open');
+      const done = states.filter(s => s === 'completed').length;
+      return {
+        id: ins.id,
+        name: ins.title,
+        icon: ins.icon,
+        category: ins.category,
+        confidence: ins.confidence,
+        taskCount: ins.bullets.length,
+        doneCount: done,
+        onClick: () => flashScrollTo(`#insight-${ins.id}`),
+      };
+    });
+  }, [view, widgetStates]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="canvas-page-with-sidebar" data-canvas-theme={theme}>
+      <Sidebar
+        user={user}
+        authToken={authToken}
+        onSignOut={onSignOut}
+        onSidebarToggle={setIsSidebarCollapsed}
+        isMobileOpen={isMobileMenuOpen}
+        onMobileToggle={setIsMobileMenuOpen}
+        onNavigateToCanvas={() => {}}
+        onSelectSession={(id) => onNavigateToChat && onNavigateToChat(id)}
+        onNewChat={() => onNavigateToChat && onNavigateToChat()}
+        pageContext="canvas"
+        canvasSubview={view}
+        insightSections={insightSections}
       />
+      <div className={`canvas-main-area ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
+        <div className="canvas-app-shell">
+          <AppHeader
+            currentPage={`canvas-${view}`}
+            onNavigateToHome={onNavigateToHome}
+            onNavigateToChat={onNavigateToChat}
+            onNavigateToCanvas={(v) => setView(v || 'insights')}
+            onMobileMenu={() => setIsMobileMenuOpen(true)}
+          >
+            <button className="icon-btn" onClick={() => setTourForceShow(n => n + 1)} title="Show tour">
+              <HelpCircle size={18}/>
+            </button>
+          </AppHeader>
+          <div className="canvas-content">
+            {view === 'insights' && <InsightsView widgetStates={widgetStates} setWidgetStates={setWidgetStates} onNavigateToChat={onNavigateToChat}/>}
+          </div>
+        </div>
+      </div>
+      <ToastStack/>
+      <CanvasWelcomeTour key={tourForceShow} forceShow={tourForceShow > 0}/>
+      <ShortcutHint/>
     </div>
   );
 };
+
+// Subtle floating hint bar showing the help shortcut.
+// Auto-hides on small screens and after the first 12s, until the user hovers.
+function ShortcutHint() {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(false), 12000);
+    return () => clearTimeout(t);
+  }, []);
+  return (
+    <div
+      className={`canvas-shortcut-hint ${visible ? 'visible' : ''}`}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+    >
+      <span><kbd>?</kbd> help</span>
+      <span style={{ opacity: 0.5 }}>{MOD}K commands · coming soon</span>
+    </div>
+  );
+}
 
 export default CanvasPage;

--- a/phd-advisor-frontend/src/styles/CanvasPage.css
+++ b/phd-advisor-frontend/src/styles/CanvasPage.css
@@ -1,708 +1,3467 @@
-/* CanvasPage.css - PhD Canvas Page Styling */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
-.canvas-page {
-  min-height: 100vh;
+/* Layout: app sidebar + canvas main area (matches chat-page-with-sidebar pattern) */
+.canvas-page-with-sidebar {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
   background: var(--bg-gradient);
-  color: var(--text-primary);
-  padding: 2rem;
 }
-
-.canvas-page.print-view {
-  background: white;
-  color: black;
-  padding: 1rem;
-}
-
-/* Header Section */
-.canvas-header {
+.canvas-main-area {
+  flex: 1;
+  margin-left: 300px;
+  height: 100vh;
+  transition: margin-left 0.3s ease;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  margin-bottom: 2rem;
-  background: var(--bg-primary);
-  padding: 1.5rem;
-  border-radius: 16px;
-  border: 1px solid var(--border-primary);
-  box-shadow: var(--shadow-lg);
 }
-
-.canvas-header-top {
+.canvas-main-area.sidebar-collapsed { margin-left: 70px; }
+.canvas-app-shell {
+  flex: 1;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+@media (max-width: 768px) {
+  .canvas-main-area, .canvas-main-area.sidebar-collapsed { margin-left: 0; }
 }
 
-.print-view .canvas-header {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-secondary);
-}
-
-.header-left {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.back-button {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 10px 16px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 12px;
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: all 0.2s ease;
+/* PhD Canvas — color palette matched to the rest of the app
+   (Tailwind gray + indigo accent + violet "wedge" accent) */
+.canvas-page-with-sidebar {
+  --canvas-bg: #111827;
+  --canvas-bg-2: #0f172a;
+  --canvas-surface: #1F2937;
+  --canvas-surface-2: #374151;
+  --canvas-surface-3: #4B5563;
+  --canvas-border: #374151;
+  --canvas-border-2: #4B5563;
+  --canvas-text: #F9FAFB;
+  --canvas-text-2: #D1D5DB;
+  --canvas-text-3: #9CA3AF;
+  --canvas-text-4: #6B7280;
+  --canvas-accent: #818CF8;
+  --canvas-accent-dim: #4F46E5;
+  --canvas-accent-glow: rgba(129, 140, 248, 0.20);
+  --canvas-critic: #A78BFA;
+  --canvas-critic-dim: #7C3AED;
+  --canvas-critic-glow: rgba(167, 139, 250, 0.20);
+  --canvas-warn: #F59E0B;
+  --canvas-danger: #DC2626;
+  --canvas-ok: #10B981;
+  --canvas-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3);
+  --canvas-shadow-lg: 0 24px 60px rgba(0,0,0,0.55), 0 6px 16px rgba(0,0,0,0.4);
+  --canvas-r-sm: 6px;
+  --canvas-r-md: 10px;
+  --canvas-r-lg: 14px;
+  --canvas-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --canvas-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--canvas-text);
+  font-family: var(--canvas-sans);
   font-size: 14px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  -webkit-font-smoothing: antialiased;
 }
 
-.back-button:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+/* Light theme — matches the app's white + Tailwind-gray palette */
+.canvas-page-with-sidebar[data-canvas-theme="light"] {
+  --canvas-bg: #F9FAFB;        /* gray-50 */
+  --canvas-bg-2: #FFFFFF;
+  --canvas-surface: #FFFFFF;
+  --canvas-surface-2: #F3F4F6; /* gray-100 */
+  --canvas-surface-3: #E5E7EB; /* gray-200 */
+  --canvas-border: #E5E7EB;    /* gray-200 */
+  --canvas-border-2: #D1D5DB;  /* gray-300 */
+  --canvas-text: #111827;      /* gray-900 */
+  --canvas-text-2: #374151;    /* gray-700 */
+  --canvas-text-3: #6B7280;    /* gray-500 */
+  --canvas-text-4: #9CA3AF;    /* gray-400 */
+  --canvas-accent: #6366F1;    /* indigo-500 (matches accent-primary) */
+  --canvas-accent-dim: #C7D2FE;
+  --canvas-accent-glow: rgba(99, 102, 241, 0.15);
+  --canvas-critic: #8B5CF6;    /* violet-500 (matches accent-secondary) */
+  --canvas-critic-glow: rgba(139, 92, 246, 0.12);
+  --canvas-shadow: 0 4px 14px rgba(20, 30, 50, 0.08);
+  --canvas-shadow-lg: 0 18px 48px rgba(20, 30, 50, 0.16);
 }
 
-.print-view .back-button {
+.canvas-page-with-sidebar *, .canvas-modal-backdrop *, .toast-stack * { box-sizing: border-box; }
+
+/* Standardized motion tokens */
+.canvas-page-with-sidebar, .canvas-modal-backdrop {
+  --canvas-ease: cubic-bezier(0.2, 0, 0, 1);
+  --canvas-fast: 120ms var(--canvas-ease);
+  --canvas-base: 180ms var(--canvas-ease);
+  --canvas-slow: 280ms var(--canvas-ease);
+}
+
+/* Widgets fade + slight rise on mount */
+@keyframes canvas-widget-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+.canvas-page-with-sidebar .widget {
+  animation: canvas-widget-in 240ms var(--canvas-ease);
+}
+
+/* Smooth content view transitions */
+@keyframes canvas-view-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: none; }
+}
+.canvas-content > * {
+  animation: canvas-view-in 220ms var(--canvas-ease);
+}
+
+/* Improved focus rings — accent halo, no harsh outline */
+.canvas-page-with-sidebar :focus-visible,
+.canvas-modal-backdrop :focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--canvas-accent-glow);
+  border-radius: 4px;
+}
+.canvas-page-with-sidebar input:focus-visible,
+.canvas-page-with-sidebar textarea:focus-visible,
+.canvas-modal-backdrop input:focus-visible,
+.canvas-modal-backdrop textarea:focus-visible {
+  outline: none;
+  border-color: var(--canvas-accent);
+  box-shadow: 0 0 0 3px var(--canvas-accent-glow);
+}
+
+/* Respect users who don't want motion */
+@media (prefers-reduced-motion: reduce) {
+  .canvas-page-with-sidebar .widget,
+  .canvas-content > * { animation: none; }
+}
+
+.canvas-page-with-sidebar button {
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: inherit;
+}
+
+.canvas-page-with-sidebar input, .canvas-page-with-sidebar textarea, .canvas-page-with-sidebar select,
+.canvas-modal-backdrop input, .canvas-modal-backdrop textarea, .canvas-modal-backdrop select {
+  font-family: inherit;
+  color: inherit;
+}
+
+.canvas-page-with-sidebar ::selection { background: var(--canvas-accent-glow); color: var(--canvas-text); }
+
+/* Floating header — matches the .floating-header pattern used on ChatPage */
+.canvas-page-with-sidebar .floating-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(31, 41, 55, 0.95);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--canvas-border);
+  padding: 12px 24px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+}
+.canvas-page-with-sidebar .floating-header .header-right { justify-self: end; }
+.canvas-page-with-sidebar[data-canvas-theme="light"] .floating-header {
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+}
+
+.canvas-page-with-sidebar .header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.canvas-page-with-sidebar .header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.canvas-page-with-sidebar .mobile-menu-button {
   display: none;
-}
-
-.canvas-title-section {
-  display: flex;
-  flex-direction: column;
-}
-
-.canvas-title {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: 2rem;
-  font-weight: 700;
-  margin: 0;
-  margin-bottom: 0.25rem;
-  color: var(--text-primary);
-}
-
-.canvas-title-icon {
-  color: var(--feature-icon-color);
-}
-
-.canvas-subtitle {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 1rem;
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.canvas-powered-by {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--text-tertiary);
-  font-size: 12px;
-  text-decoration: none;
-  transition: opacity 0.2s ease;
-}
-
-.canvas-powered-by:hover {
-  opacity: 0.8;
-}
-
-.canvas-powered-by-logo {
-  height: 1em;
-  width: auto;
-  vertical-align: middle;
-}
-
-.print-view .header-actions {
-  display: none;
-}
-
-/* Icon-only buttons in canvas header */
-.canvas-icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: 40px;
   height: 40px;
-  padding: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 12px;
-  color: var(--text-primary);
+  border-radius: 10px;
+  border: none;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-2);
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.12s ease, box-shadow 0.18s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
-
-.canvas-icon-btn svg {
-  width: 18px;
-  height: 18px;
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .mobile-menu-button { display: flex; }
 }
-
-.canvas-icon-btn:hover:not(:disabled) {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.canvas-icon-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-
-/* Clear-canvas variant — destructive */
-.clear-canvas-btn {
-  color: #ef4444;
-  border-color: rgba(239, 68, 68, 0.35);
-}
-
-.clear-canvas-btn:hover:not(:disabled) {
-  background: #ef4444;
-  color: #ffffff;
-  border-color: #ef4444;
-  box-shadow: 0 4px 12px -2px rgba(239, 68, 68, 0.45);
-}
-
-[data-theme="dark"] .clear-canvas-btn {
-  color: #f87171;
-  border-color: rgba(248, 113, 113, 0.4);
-}
-
-[data-theme="dark"] .clear-canvas-btn:hover:not(:disabled) {
-  background: #ef4444;
-  color: #ffffff;
-  border-color: #ef4444;
-}
-
-.action-button {
+.canvas-page-with-sidebar .header-brand {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 10px 16px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 12px;
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 14px;
-  font-weight: 500;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  gap: 12px;
 }
-
-.action-button:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.action-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.action-icon.spinning {
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-/* Stats Section */
-.canvas-stats {
+.canvas-page-with-sidebar .brand-icon {
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, var(--canvas-accent), var(--canvas-critic));
+  border-radius: 10px;
   display: flex;
-  gap: 2rem;
-  margin-bottom: 2rem;
+  align-items: center;
   justify-content: center;
+  color: #fff;
 }
-
-.stat-item {
-  text-align: center;
-  background: var(--bg-primary);
-  padding: 1.5rem;
-  border-radius: 16px;
-  border: 1px solid var(--border-primary);
-  box-shadow: var(--shadow-md);
-  min-width: 140px;
-  transition: all 0.3s ease;
-}
-
-.stat-item:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-xl);
-}
-
-.print-view .stat-item {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-secondary);
-}
-
-.stat-number {
-  display: block;
-  font-size: 2rem;
+.canvas-page-with-sidebar .brand-text h1 {
+  font-size: 20px;
   font-weight: 700;
-  color: var(--accent-primary);
-  margin-bottom: 0.5rem;
+  color: var(--canvas-text);
+  margin: 0;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+.canvas-page-with-sidebar .brand-text p {
+  font-size: 13px;
+  color: var(--canvas-text-3);
+  margin: 2px 0 0;
+  line-height: 1;
+}
+.canvas-page-with-sidebar .theme-toggle .theme-icon { display: block; }
+
+/* When the tabs sit in ChatPage's flex .floating-header, absolutely-position
+   them so they center regardless of header-left/header-right widths. */
+.floating-header { position: sticky; }
+.floating-header > .chat-view-tabs {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+.canvas-tabs-mobile { display: none; }
+@media (max-width: 900px) {
+  .floating-header > .chat-view-tabs { display: none; }
+  .canvas-tabs-mobile {
+    display: inline-block;
+    background: var(--canvas-surface, var(--bg-tertiary, #f3f4f6));
+    border: 1px solid var(--canvas-border, var(--border-primary, #e5e7eb));
+    color: var(--canvas-text, var(--text-primary, #111827));
+    font-family: inherit;
+    font-size: 13px;
+    padding: 6px 10px;
+    border-radius: 7px;
+  }
 }
 
-.print-view .stat-number {
-  color: var(--text-secondary);
-}
-
-.stat-label {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-}
-
-/* Content Section */
-.canvas-content {
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.empty-canvas {
-  text-align: center;
-  padding: 4rem 2rem;
-  color: var(--text-secondary);
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.empty-canvas-icon {
-  width: 4rem;
-  height: 4rem;
-  margin-bottom: 1rem;
-  color: var(--text-tertiary);
-}
-
-.empty-canvas h2 {
-  margin-bottom: 1rem;
-  color: var(--text-primary);
-}
-
-.empty-canvas p {
-  margin-bottom: 1.5rem;
-  line-height: 1.6;
-}
-
-.start-chatting-button {
-  padding: 16px 32px;
-  background: var(--accent-gradient);
-  color: white;
-  border: none;
-  border-radius: 12px;
-  font-size: 1.1rem;
-  font-weight: 600;
+/* Shared view-tabs pill bar — used on both Canvas and Chat pages.
+   Uses canvas vars first, falls back to app global vars on Chat. */
+.canvas-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--canvas-surface, var(--bg-tertiary, #f3f4f6));
+  padding: 3px;
+  border-radius: 8px;
+  border: 1px solid var(--canvas-border, var(--border-primary, #e5e7eb));
+  justify-self: center;
   cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: var(--shadow-md);
+}
+.canvas-tabs .tab {
+  padding: 6px 14px;
+  font-size: 13px;
+  color: var(--canvas-text-2, var(--text-secondary, #6b7280));
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.canvas-tabs .tab:hover { color: var(--canvas-text, var(--text-primary, #111827)); }
+.canvas-tabs .tab.active {
+  background: var(--canvas-surface-3, var(--bg-primary, #fff));
+  color: var(--canvas-text, var(--text-primary, #111827));
+  box-shadow: inset 0 0 0 1px var(--canvas-border-2, var(--border-secondary, #d1d5db));
+}
+.canvas-tabs .tab .badge {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  background: var(--canvas-accent-glow);
+  color: var(--canvas-accent);
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.02em;
 }
 
-.start-chatting-button:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-xl);
+.canvas-page-with-sidebar .topbar-spacer { flex: 1; }
+
+.canvas-page-with-sidebar .icon-btn,
+.canvas-modal-backdrop .icon-btn {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  color: var(--canvas-text-2);
+  transition: background .12s, color .12s;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  background: none;
+}
+.canvas-page-with-sidebar .icon-btn:hover,
+.canvas-modal-backdrop .icon-btn:hover { background: var(--canvas-surface); color: var(--canvas-text); }
+
+.canvas-page-with-sidebar .btn,
+.canvas-modal-backdrop .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 12px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  background: var(--canvas-surface-2);
+  border: 1px solid var(--canvas-border-2);
+  color: var(--canvas-text);
+  transition: all .12s;
+  font-family: inherit;
+  cursor: pointer;
+}
+.canvas-page-with-sidebar .btn:hover,
+.canvas-modal-backdrop .btn:hover { background: var(--canvas-surface-3); border-color: var(--canvas-border-2); }
+.canvas-page-with-sidebar .btn-primary,
+.canvas-modal-backdrop .btn-primary {
+  background: var(--canvas-accent);
+  color: #FFFFFF;
+  border-color: var(--canvas-accent);
+  font-weight: 600;
+}
+.canvas-page-with-sidebar .btn-primary:hover,
+.canvas-modal-backdrop .btn-primary:hover { background: var(--canvas-accent-dim); border-color: var(--canvas-accent-dim); filter: brightness(1.05); box-shadow: 0 0 0 3px var(--canvas-accent-glow); }
+.canvas-page-with-sidebar .btn-critic,
+.canvas-modal-backdrop .btn-critic {
+  background: var(--canvas-critic);
+  color: #FFFFFF;
+  border-color: var(--canvas-critic);
+  font-weight: 600;
+}
+.canvas-page-with-sidebar .btn-critic:hover,
+.canvas-modal-backdrop .btn-critic:hover { filter: brightness(1.08); box-shadow: 0 0 0 3px var(--canvas-critic-glow); }
+.canvas-page-with-sidebar .btn-ghost,
+.canvas-modal-backdrop .btn-ghost { background: transparent; border-color: transparent; color: var(--canvas-text-2); }
+.canvas-page-with-sidebar .btn-ghost:hover,
+.canvas-modal-backdrop .btn-ghost:hover { background: var(--canvas-surface); color: var(--canvas-text); border-color: transparent; }
+.canvas-page-with-sidebar .btn-danger:hover,
+.canvas-modal-backdrop .btn-danger:hover { background: rgba(240,106,106,0.12); border-color: rgba(240,106,106,0.4); color: var(--canvas-danger); }
+
+.canvas-page-with-sidebar .btn:disabled,
+.canvas-modal-backdrop .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Content */
+.canvas-content {
+  padding: 24px 28px 80px;
+  max-width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  background: var(--canvas-bg);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .canvas-content { background: var(--canvas-bg); }
+
+.canvas-page-with-sidebar .page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+.canvas-page-with-sidebar .page-title { font-size: 28px; font-weight: 700; letter-spacing: -0.02em; margin: 0; color: var(--canvas-text); }
+.canvas-page-with-sidebar .page-sub { color: var(--canvas-text-3); font-size: 13px; margin-top: 6px; }
+.canvas-page-with-sidebar .page-meta {
+  font-family: var(--canvas-mono);
+  font-size: 11px;
+  color: var(--canvas-text-3);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.canvas-page-with-sidebar .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--canvas-ok);
+  box-shadow: 0 0 8px var(--canvas-ok);
 }
 
-/* Sections */
-.sections-container {
+/* ----- Insights view ----- */
+.canvas-page-with-sidebar .insights-stats {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  padding: 14px 18px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 10px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .insights-stats {
+  background: #ffffff;
+  border-color: rgba(15, 15, 15, 0.06);
+}
+.canvas-page-with-sidebar .insights-stat {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  align-items: flex-start;
+  gap: 1px;
+  min-width: 70px;
+}
+.canvas-page-with-sidebar .insights-stat-value {
+  font-family: var(--canvas-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--canvas-text);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.canvas-page-with-sidebar .insights-stat-label {
+  font-size: 11px;
+  color: var(--canvas-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+.canvas-page-with-sidebar .insights-stat-update {
+  font-size: 11px;
+  color: var(--canvas-text-3);
+  font-family: var(--canvas-mono);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.canvas-section {
-  background: var(--bg-primary);
-  border-radius: 16px;
-  border: 1px solid var(--border-primary);
-  box-shadow: var(--shadow-md);
+.canvas-page-with-sidebar .insights-filters {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.canvas-page-with-sidebar .insights-pinned-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  margin-bottom: 14px;
+  background: var(--canvas-accent-glow);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+.canvas-page-with-sidebar .insights-pinned-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--canvas-text);
+  cursor: pointer;
+  transition: all .12s;
+}
+.canvas-page-with-sidebar .insights-pinned-pill:hover {
+  border-color: var(--canvas-accent);
+  color: var(--canvas-accent);
+}
+
+/* Cards vs Tasks view toggle on the Insights view */
+.canvas-page-with-sidebar .insights-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-bottom: 12px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  padding: 3px;
+}
+.canvas-page-with-sidebar .insights-view-toggle button {
+  background: transparent;
+  border: none;
+  padding: 5px 12px;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--canvas-text-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.canvas-page-with-sidebar .insights-view-toggle button:hover { color: var(--canvas-text); }
+.canvas-page-with-sidebar .insights-view-toggle button.active {
+  background: var(--canvas-surface-3);
+  color: var(--canvas-text);
+  box-shadow: inset 0 0 0 1px var(--canvas-border-2);
+}
+
+/* Flat task list view */
+.canvas-page-with-sidebar .insights-tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.canvas-page-with-sidebar .insights-task-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  position: relative;
+  transition: background .12s, border-color .12s;
+}
+.canvas-page-with-sidebar .insights-task-row:hover {
+  border-color: var(--canvas-border-2);
+}
+.canvas-page-with-sidebar .insights-task-row.task-completed { opacity: 0.7; }
+.canvas-page-with-sidebar .insights-task-row.task-abandoned { opacity: 0.5; }
+.canvas-page-with-sidebar .insights-task-row.task-completed:hover,
+.canvas-page-with-sidebar .insights-task-row.task-abandoned:hover { opacity: 0.95; }
+.canvas-page-with-sidebar .insights-task-row .insight-task-check { margin-top: 4px; }
+.canvas-page-with-sidebar .insights-task-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.canvas-page-with-sidebar .insights-task-section {
+  background: transparent;
+  border: none;
+  color: var(--canvas-text-3);
+  font-family: var(--canvas-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+.canvas-page-with-sidebar .insights-task-section:hover { color: var(--canvas-accent); }
+.canvas-page-with-sidebar .insights-task-text {
+  font-size: 13px;
+  color: var(--canvas-text);
+  line-height: 1.5;
+}
+.canvas-page-with-sidebar .insights-task-row.task-completed .insights-task-text,
+.canvas-page-with-sidebar .insights-task-row.task-abandoned .insights-task-text {
+  text-decoration: line-through;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .insights-task-text strong { color: var(--canvas-text); }
+
+/* Per-card progress bar — replaces the old single status pill */
+.canvas-page-with-sidebar .insight-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 0 4px;
+}
+.canvas-page-with-sidebar .insight-progress-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--canvas-mono);
+  font-size: 10.5px;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .insight-progress-count { font-weight: 600; }
+.canvas-page-with-sidebar .insight-progress-badge {
+  font-family: var(--canvas-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.canvas-page-with-sidebar .insight-progress-badge.done { background: rgba(16,185,129,0.15); color: #10B981; }
+.canvas-page-with-sidebar .insight-progress-badge.inprog { background: rgba(59,130,246,0.15); color: #3B82F6; }
+.canvas-page-with-sidebar .insight-progress-badge.abandoned { background: var(--canvas-surface-2); color: var(--canvas-text-4); }
+
+.canvas-page-with-sidebar .insight-progress-bar {
+  height: 5px;
+  background: var(--canvas-surface-2);
+  border-radius: 3px;
   overflow: hidden;
-  transition: all 0.3s ease;
+  display: flex;
+}
+.canvas-page-with-sidebar .insight-progress-bar > i {
+  display: block;
+  height: 100%;
+  transition: width .25s;
+}
+.canvas-page-with-sidebar .insight-progress-bar .ip-completed { background: #10B981; }
+.canvas-page-with-sidebar .insight-progress-bar .ip-inprogress { background: #3B82F6; }
+.canvas-page-with-sidebar .insight-progress-bar .ip-abandoned  { background: var(--canvas-text-4); }
+
+/* Per-bullet tasks inside the body */
+.canvas-page-with-sidebar .insight-tasks {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.canvas-page-with-sidebar .insight-task {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: 13px;
+  color: var(--canvas-text-2);
+  line-height: 1.5;
+  position: relative;
+}
+.canvas-page-with-sidebar .insight-task.task-completed .insight-task-text {
+  text-decoration: line-through;
+  color: var(--canvas-text-3);
+  opacity: 0.7;
+}
+.canvas-page-with-sidebar .insight-task.task-abandoned .insight-task-text {
+  text-decoration: line-through;
+  color: var(--canvas-text-4);
+  opacity: 0.5;
+}
+.canvas-page-with-sidebar .insight-task.task-in-progress .insight-task-text {
+  color: var(--canvas-text);
+  font-weight: 500;
+}
+.canvas-page-with-sidebar .insight-task-text { flex: 1; }
+.canvas-page-with-sidebar .insight-task-text strong { color: var(--canvas-text); }
+.canvas-page-with-sidebar .insight-task-check {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1.5px solid currentColor;
+  background: transparent;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  margin-top: 2px;
+  transition: background .12s;
+}
+.canvas-page-with-sidebar .insight-task-check:hover {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar .insight-task.task-completed .insight-task-check {
+  background: #10B981;
+  color: #fff;
+}
+.canvas-page-with-sidebar .insight-task.task-abandoned .insight-task-check {
+  background: var(--canvas-text-4);
+  color: #fff;
+}
+.canvas-page-with-sidebar .task-check-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
-.canvas-section:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-xl);
+/* Sidebar row for a fully-done section gets struck through */
+.sidebar .csm-row-done .csm-row-label {
+  text-decoration: line-through;
+  color: var(--text-tertiary, #9CA3AF);
+}
+.sidebar .csm-row-done .csm-row-meta {
+  color: #10B981;
+  font-weight: 600;
 }
 
-.print-view .canvas-section {
-  background: white;
-  border: 1px solid var(--border-secondary);
-  color: black;
-  page-break-inside: avoid;
-  margin-bottom: 1rem;
+/* Insight status pill + menu */
+.canvas-page-with-sidebar .insight-status-wrap {
+  position: relative;
+}
+.canvas-page-with-sidebar .insight-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background .12s;
+}
+.canvas-page-with-sidebar .insight-status-pill:hover {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar .insight-status-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 5;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 7px;
+  box-shadow: var(--canvas-shadow-lg);
+  padding: 4px;
+  min-width: 150px;
+  display: flex;
+  flex-direction: column;
+}
+.canvas-page-with-sidebar .insight-status-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--canvas-text);
+  cursor: pointer;
+  text-align: left;
+}
+.canvas-page-with-sidebar .insight-status-menu button:hover {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar .insight-status-menu button.active {
+  background: var(--canvas-accent-glow);
+  color: var(--canvas-accent);
+  font-weight: 600;
 }
 
-.section-header {
+/* Card-level status mutes the body when completed/abandoned */
+.canvas-page-with-sidebar .insight.status-completed .insight-body,
+.canvas-page-with-sidebar .insight.status-completed .insight-foot {
+  opacity: 0.65;
+}
+.canvas-page-with-sidebar .insight.status-abandoned {
+  opacity: 0.5;
+}
+.canvas-page-with-sidebar .insight.status-abandoned:hover { opacity: 0.85; }
+
+/* Progress bar in stats — segmented for status mix */
+.canvas-page-with-sidebar .insights-stat-progress {
+  flex: 1;
+  min-width: 180px;
+  max-width: 280px;
+  gap: 4px;
+}
+.canvas-page-with-sidebar .insights-progress-bar {
+  height: 6px;
+  width: 100%;
+  background: var(--canvas-surface-2);
+  border-radius: 3px;
+  overflow: hidden;
+  display: flex;
+}
+.canvas-page-with-sidebar .insights-progress-bar > i {
+  display: block;
+  height: 100%;
+  transition: width .3s;
+}
+.canvas-page-with-sidebar .insights-progress-bar .ip-completed { background: #10B981; }
+.canvas-page-with-sidebar .insights-progress-bar .ip-inprogress { background: #3B82F6; }
+.canvas-page-with-sidebar .insights-progress-bar .ip-abandoned  { background: var(--canvas-text-4); }
+
+/* Confidence ring */
+.canvas-page-with-sidebar .confidence-ring {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.canvas-page-with-sidebar .confidence-ring span {
+  position: absolute;
+  font-family: var(--canvas-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+}
+
+/* Insight card refinements */
+.canvas-page-with-sidebar .insight {
+  transition: border-color .15s, transform .15s, box-shadow .15s;
+}
+.canvas-page-with-sidebar .insight:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.08);
+}
+.canvas-page-with-sidebar .insight.is-pinned {
+  border-color: var(--canvas-accent);
+  background: var(--canvas-surface);
+  box-shadow: 0 0 0 1px var(--canvas-accent-glow);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .insight.is-pinned {
+  background: #ffffff;
+}
+
+/* Insight footer (source count + updated time) */
+.canvas-page-with-sidebar .insight-foot {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
+  padding: 6px 0 0;
+  font-size: 11px;
+  color: var(--canvas-text-3);
 }
-
-.section-header:hover {
-  background: var(--bg-secondary);
-}
-
-.print-view .section-header:hover {
-  background: var(--bg-tertiary);
-}
-
-.section-header-content {
-  display: flex;
+.canvas-page-with-sidebar .insight-foot-meta {
+  display: inline-flex;
   align-items: center;
-  gap: 1rem;
-  flex: 1;
+  gap: 6px;
+  font-family: var(--canvas-mono);
+}
+.canvas-page-with-sidebar .insight-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--canvas-text-4);
 }
 
-.section-icon {
-  width: 2rem;
-  height: 2rem;
-  color: var(--feature-icon-color);
+/* Expanded source-quotes panel */
+.canvas-page-with-sidebar .insight-detail {
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: var(--canvas-bg-2);
+  border-left: 2px solid var(--canvas-accent);
+  border-radius: 0 6px 6px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  animation: canvas-view-in 180ms var(--canvas-ease);
 }
-
-.print-view .section-icon {
-  color: var(--text-secondary);
+.canvas-page-with-sidebar[data-canvas-theme="light"] .insight-detail {
+  background: rgba(99, 102, 241, 0.04);
 }
-
-.section-titles {
-  flex: 1;
-}
-
-.section-title {
-  margin: 0 0 0.25rem 0;
-  font-size: 1.3rem;
+.canvas-page-with-sidebar .insight-detail-head {
+  font-size: 10.5px;
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--canvas-accent);
   font-weight: 600;
-  color: var(--text-primary);
 }
-
-.section-description {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-}
-
-.section-meta {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  font-size: 0.9rem;
-}
-
-.insight-count {
-  background: var(--feature-bg);
-  color: var(--accent-primary);
-  padding: 0.25rem 0.75rem;
-  border-radius: 20px;
-  font-weight: 500;
-}
-
-[data-theme="dark"] .insight-count {
-  background: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
-}
-
-.print-view .insight-count {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-
-.expand-arrow {
-  transition: transform 0.3s ease;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.expand-arrow.expanded {
-  transform: rotate(180deg);
-}
-
-.section-content {
-  padding: 0 1.5rem 1.5rem 1.5rem;
-  border-top: 1px solid var(--border-primary);
-}
-
-.print-view .section-content {
-  border-top: 1px solid var(--border-secondary);
-}
-
-.empty-section {
-  text-align: center;
-  padding: 2rem;
-  color: var(--text-tertiary);
-}
-
-.empty-icon {
-  width: 2rem;
-  height: 2rem;
-  margin-bottom: 1rem;
+.canvas-page-with-sidebar .insight-quote {
+  font-size: 12.5px;
+  color: var(--canvas-text-2);
+  line-height: 1.5;
+  font-style: italic;
 }
 
 /* Insights */
-.insights-grid {
+.canvas-page-with-sidebar .insight-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+@media (max-width: 1100px) {
+  .canvas-page-with-sidebar .insight-grid { grid-template-columns: 1fr; }
 }
 
-.insight-card {
-  background: var(--bg-secondary);
-  border-radius: 12px;
-  padding: 1.25rem;
-  border: 1px solid var(--border-primary);
-  transition: all 0.3s ease;
-}
-
-.insight-card:hover {
-  background: var(--bg-tertiary);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
-}
-
-.print-view .insight-card {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-secondary);
-  color: black;
-  break-inside: avoid;
-}
-
-.insight-content {
-  margin-bottom: 1rem;
-  line-height: 1.5;
-  font-size: 0.95rem;
-  color: var(--text-primary);
-}
-
-.empty-canvas-actions {
+.canvas-page-with-sidebar .insight {
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: var(--canvas-r-md);
+  padding: 16px 18px;
   display: flex;
-  gap: 12px;
-  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  transition: border-color .15s;
+}
+.canvas-page-with-sidebar .insight:hover { border-color: var(--canvas-border-2); }
+.canvas-page-with-sidebar[data-canvas-theme="light"] .insight { box-shadow: 0 1px 2px rgba(20,30,50,0.03); }
+
+.canvas-page-with-sidebar .insight-head {
+  display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  margin-top: 1.75rem;
+  gap: 10px;
+}
+.canvas-page-with-sidebar .insight-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: var(--canvas-surface-2);
+  display: grid;
+  place-items: center;
+  color: var(--canvas-accent);
+}
+.canvas-page-with-sidebar .insight-title { font-weight: 600; font-size: 14px; flex: 1; color: var(--canvas-text); }
+.canvas-page-with-sidebar .confidence {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--canvas-mono);
+  font-size: 11px;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .conf-bar {
+  width: 36px;
+  height: 4px;
+  background: var(--canvas-surface-3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .conf-bar { background: #e7ebf2; }
+.canvas-page-with-sidebar .conf-bar > i {
+  display: block;
+  height: 100%;
+  background: var(--canvas-accent);
+  border-radius: 2px;
 }
 
-.empty-canvas-btn {
+.canvas-page-with-sidebar .insight-body { color: var(--canvas-text-2); font-size: 13px; }
+.canvas-page-with-sidebar .insight-body ul { margin: 6px 0 0; padding-left: 18px; }
+.canvas-page-with-sidebar .insight-body li { margin-bottom: 4px; }
+.canvas-page-with-sidebar .insight-body li::marker { color: var(--canvas-text-4); }
+.canvas-page-with-sidebar .insight-body strong { color: var(--canvas-text); font-weight: 600; }
+
+.canvas-page-with-sidebar .insight-actions {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding-top: 10px;
+  border-top: 1px dashed var(--canvas-border);
+  margin-top: 4px;
+}
+.canvas-page-with-sidebar .chip,
+.canvas-modal-backdrop .chip {
+  font-size: 11px;
+  padding: 4px 9px;
+  border-radius: 5px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-2);
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
-  height: 46px;
-  padding: 0 22px;
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: -0.005em;
+  gap: 5px;
+  transition: background .12s, color .12s;
+  border: none;
   cursor: pointer;
-  transition: transform 0.18s cubic-bezier(0.4, 0, 0.2, 1),
-              box-shadow 0.22s ease,
-              background 0.18s ease,
-              border-color 0.18s ease,
-              color 0.18s ease;
+}
+.canvas-page-with-sidebar .chip:hover { background: var(--canvas-surface-3); color: var(--canvas-text); }
+.canvas-page-with-sidebar .chip.pinned { background: var(--canvas-accent-glow); color: var(--canvas-accent); }
+
+/* Workspace grid */
+.canvas-page-with-sidebar .workspace {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 18px;
+  align-items: start;
+}
+/* Notion-inspired widget treatment: hairline borders, generous padding,
+   no hard chrome — the content is the page, the frame is barely there. */
+.canvas-page-with-sidebar .widget {
+  background: var(--canvas-surface);
   border: 1px solid transparent;
-}
-
-.empty-canvas-btn .empty-canvas-btn-arrow {
-  transition: transform 0.18s ease;
-}
-
-.empty-canvas-btn:hover .empty-canvas-btn-arrow {
-  transform: translateX(3px);
-}
-
-.empty-canvas-btn:active {
-  transform: translateY(1px);
-}
-
-/* Primary — Start Chatting */
-.empty-canvas-btn.primary {
-  background: var(--accent-gradient);
-  color: #ffffff;
-  box-shadow: 0 6px 18px -6px rgba(99, 102, 241, 0.55),
-              inset 0 1px 0 rgba(255, 255, 255, 0.18);
-}
-
-.empty-canvas-btn.primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 28px -8px rgba(99, 102, 241, 0.7),
-              inset 0 1px 0 rgba(255, 255, 255, 0.25);
-}
-
-/* Secondary — Process Existing Chats */
-.empty-canvas-btn.secondary {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  border-color: var(--border-primary);
-}
-
-.empty-canvas-btn.secondary:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
-  color: var(--accent-primary);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px -6px rgba(0, 0, 0, 0.15);
-}
-
-[data-theme="dark"] .empty-canvas-btn.secondary {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: var(--text-primary);
-}
-
-[data-theme="dark"] .empty-canvas-btn.secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: var(--accent-primary);
-  color: #ffffff;
-}
-
-.inline-loading-spinner {
+  border-radius: 6px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  min-height: 200px;
+  position: relative;
+  overflow: hidden;
+  transition: background .15s, border-color .15s, box-shadow .15s;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .widget {
+  background: #FFFFFF;
+  border-color: rgba(15, 15, 15, 0.06);
+}
+.canvas-page-with-sidebar .widget.size-S { grid-column: span 2; }
+.canvas-page-with-sidebar .widget.size-M { grid-column: span 3; }
+.canvas-page-with-sidebar .widget.size-L { grid-column: span 6; }
+.canvas-page-with-sidebar .widget.dragging { opacity: 0.4; }
+.canvas-page-with-sidebar .widget.drag-over {
+  box-shadow: 0 0 0 2px var(--canvas-accent), 0 4px 14px var(--canvas-accent-glow);
+}
+.canvas-page-with-sidebar .widget:hover {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .widget:hover {
+  background: rgba(0, 0, 0, 0.015);
+  border-color: rgba(15, 15, 15, 0.08);
+}
+.canvas-page-with-sidebar .widget.critic { border-color: rgba(167, 139, 250, 0.18); }
+.canvas-page-with-sidebar[data-canvas-theme="light"] .widget.critic { border-color: rgba(139, 92, 246, 0.18); }
+.canvas-page-with-sidebar .widget.critic:hover { border-color: var(--canvas-critic); }
+
+/* Preserve 3-S / 2-M / 1-L per row at every desktop width.
+   On phones (≤768px) just stack everything full-width for readability. */
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .workspace { grid-template-columns: 1fr; }
+  .canvas-page-with-sidebar .widget.size-S,
+  .canvas-page-with-sidebar .widget.size-M,
+  .canvas-page-with-sidebar .widget.size-L { grid-column: 1 / -1; }
+}
+
+/* Notion-style header: drag grip is hover-only, title is plain text. */
+.canvas-page-with-sidebar .widget-head {
+  display: flex;
   align-items: center;
+  gap: 8px;
+  padding: 14px 16px 8px;
+  cursor: grab;
+}
+.canvas-page-with-sidebar .widget-head:active { cursor: grabbing; }
+.canvas-page-with-sidebar .widget-head .drag-grip {
+  color: var(--canvas-text-4);
+  display: grid;
+  place-items: center;
+  width: 14px;
+  opacity: 0;
+  transition: opacity .15s;
+}
+.canvas-page-with-sidebar .widget:hover .widget-head .drag-grip { opacity: 0.6; }
+.canvas-page-with-sidebar .widget-icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .widget.critic .widget-icon { color: var(--canvas-critic); }
+.canvas-page-with-sidebar .widget-title {
+  font-weight: 600;
+  font-size: 13.5px;
+  flex: 1;
+  letter-spacing: -0.005em;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .widget-tag,
+.canvas-modal-backdrop .widget-tag {
+  font-size: 9.5px;
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--canvas-critic-glow);
+  color: var(--canvas-critic);
+  font-weight: 600;
+}
+.canvas-modal-backdrop .widget-tag-enhanced {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10B981;
+}
+.canvas-modal-backdrop .widget-tag-chat {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3B82F6;
+}
+.canvas-page-with-sidebar .widget-actions { display: flex; gap: 1px; opacity: 0; transition: opacity .12s; }
+.canvas-page-with-sidebar .widget:hover .widget-actions { opacity: 1; }
+.canvas-page-with-sidebar .widget-actions .icon-btn { width: 24px; height: 24px; }
+.canvas-page-with-sidebar .widget-actions .icon-btn svg { width: 14px; height: 14px; }
+.canvas-page-with-sidebar .size-pill {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-3);
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.canvas-page-with-sidebar .size-pill:hover { background: var(--canvas-surface-3); color: var(--canvas-text); }
+
+.canvas-page-with-sidebar .widget-body {
+  padding: 4px 16px 18px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+/* Preset picker (shown above the empty workspace) */
+.canvas-page-with-sidebar .canvas-presets {
+  margin-bottom: 18px;
+}
+.canvas-page-with-sidebar .canvas-presets-head {
+  margin-bottom: 10px;
+}
+.canvas-page-with-sidebar .canvas-presets-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .canvas-presets-sub {
+  font-size: 12.5px;
+  color: var(--canvas-text-3);
+  margin-top: 2px;
+}
+.canvas-page-with-sidebar .canvas-presets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+.canvas-page-with-sidebar .canvas-preset-card {
+  background: transparent;
+  border: 1px solid rgba(15, 15, 15, 0.10);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  gap: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background .15s, border-color .15s;
+  font-family: inherit;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .canvas-preset-card {
+  border-color: rgba(15, 15, 15, 0.12);
+}
+.canvas-page-with-sidebar .canvas-preset-card:hover {
+  background: var(--canvas-surface-2);
+  border-color: rgba(15, 15, 15, 0.15);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .canvas-preset-card:hover {
+  background: rgba(0, 0, 0, 0.025);
+}
+.canvas-page-with-sidebar .canvas-preset-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-2);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  font-size: 16px;
+}
+.canvas-page-with-sidebar .canvas-preset-content { flex: 1; min-width: 0; }
+.canvas-page-with-sidebar .canvas-preset-name { font-size: 13.5px; font-weight: 600; color: var(--canvas-text); }
+.canvas-page-with-sidebar .canvas-preset-desc { font-size: 11.5px; color: var(--canvas-text-3); margin-top: 3px; line-height: 1.45; }
+.canvas-page-with-sidebar .canvas-preset-meta {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: var(--canvas-text-4);
+  margin-top: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.canvas-page-with-sidebar .empty-cell {
+  border: 1.5px dashed var(--canvas-border-2);
+  border-radius: var(--canvas-r-md);
+  padding: 28px 24px;
+  text-align: center;
+  color: var(--canvas-text-3);
+  font-size: 13px;
+  grid-column: span 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255,255,255,0.01);
+}
+
+/* Inputs / forms (scoped) */
+.canvas-page-with-sidebar .input, .canvas-page-with-sidebar .textarea, .canvas-page-with-sidebar .select,
+.canvas-modal-backdrop .input, .canvas-modal-backdrop .textarea, .canvas-modal-backdrop .select {
   width: 100%;
-  margin: 1.25rem 0;
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 7px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--canvas-text);
+  transition: border-color .12s, box-shadow .12s;
+}
+.canvas-page-with-sidebar .input:focus, .canvas-page-with-sidebar .textarea:focus, .canvas-page-with-sidebar .select:focus,
+.canvas-modal-backdrop .input:focus, .canvas-modal-backdrop .textarea:focus, .canvas-modal-backdrop .select:focus {
+  outline: none;
+  border-color: var(--canvas-accent);
+  box-shadow: 0 0 0 3px var(--canvas-accent-glow);
+}
+.canvas-page-with-sidebar .textarea, .canvas-modal-backdrop .textarea { resize: vertical; min-height: 80px; font-family: inherit; line-height: 1.5; }
+.canvas-page-with-sidebar .label, .canvas-modal-backdrop .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--canvas-text-3); font-weight: 600; }
+
+.canvas-page-with-sidebar[data-canvas-theme="light"] .input,
+.canvas-page-with-sidebar[data-canvas-theme="light"] .textarea,
+.canvas-page-with-sidebar[data-canvas-theme="light"] .select,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .input,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .textarea,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .select {
+  background: #fff;
 }
 
-.inline-loading-spinner .spinning {
-  animation: spin 2s linear infinite;
-  width: 2rem;
-  height: 2rem;
-  color: var(--accent-primary);
+/* Modal backdrop — rendered at the body level, so it gets its own theme vars */
+.canvas-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.7);
+  backdrop-filter: blur(6px);
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 40px 20px;
+  animation: canvas-fade-in .15s ease;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --canvas-bg: #111827;
+  --canvas-bg-2: #0f172a;
+  --canvas-surface: #1F2937;
+  --canvas-surface-2: #374151;
+  --canvas-surface-3: #4B5563;
+  --canvas-border: #374151;
+  --canvas-border-2: #4B5563;
+  --canvas-text: #F9FAFB;
+  --canvas-text-2: #D1D5DB;
+  --canvas-text-3: #9CA3AF;
+  --canvas-text-4: #6B7280;
+  --canvas-accent: #818CF8;
+  --canvas-accent-dim: #4F46E5;
+  --canvas-accent-glow: rgba(129, 140, 248, 0.20);
+  --canvas-critic: #A78BFA;
+  --canvas-critic-glow: rgba(167, 139, 250, 0.20);
+  --canvas-warn: #F59E0B;
+  --canvas-danger: #DC2626;
+  --canvas-ok: #10B981;
+  --canvas-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --canvas-shadow-lg: 0 24px 60px rgba(0,0,0,0.55), 0 6px 16px rgba(0,0,0,0.4);
+  color: var(--canvas-text);
+}
+body[data-canvas-theme="light"] .canvas-modal-backdrop {
+  background: rgba(17, 24, 39, 0.35);
+  --canvas-bg: #F9FAFB;
+  --canvas-bg-2: #FFFFFF;
+  --canvas-surface: #FFFFFF;
+  --canvas-surface-2: #F3F4F6;
+  --canvas-surface-3: #E5E7EB;
+  --canvas-border: #E5E7EB;
+  --canvas-border-2: #D1D5DB;
+  --canvas-text: #111827;
+  --canvas-text-2: #374151;
+  --canvas-text-3: #6B7280;
+  --canvas-text-4: #9CA3AF;
+  --canvas-accent: #6366F1;
+  --canvas-accent-dim: #C7D2FE;
+  --canvas-accent-glow: rgba(99, 102, 241, 0.15);
+  --canvas-critic: #8B5CF6;
+  --canvas-critic-glow: rgba(139, 92, 246, 0.12);
+  --canvas-shadow-lg: 0 18px 48px rgba(20, 30, 50, 0.16);
+}
+@keyframes canvas-fade-in { from { opacity: 0 } to { opacity: 1 } }
+
+.canvas-modal {
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 14px;
+  width: 100%;
+  max-width: 560px;
+  max-height: 88vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--canvas-shadow-lg);
+  animation: canvas-scale-in .18s cubic-bezier(.22,.9,.3,1);
+}
+.canvas-modal.wide { max-width: 760px; }
+.canvas-modal.huge { max-width: 920px; }
+.canvas-modal.canvas-tour { max-width: 480px; }
+@keyframes canvas-scale-in { from { opacity: 0; transform: translateY(8px) scale(0.98) } to { opacity: 1; transform: none } }
+
+.canvas-modal .modal-head {
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid var(--canvas-border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.canvas-modal .modal-title { font-weight: 600; font-size: 15px; flex: 1; letter-spacing: -0.005em; color: var(--canvas-text); }
+.canvas-modal .modal-sub { color: var(--canvas-text-3); font-size: 12px; margin-top: 2px; }
+.canvas-modal .modal-body { padding: 18px 22px; overflow-y: auto; flex: 1; }
+.canvas-modal .modal-foot {
+  padding: 14px 22px;
+  border-top: 1px solid var(--canvas-border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  background: var(--canvas-bg-2);
 }
 
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+.canvas-modal .modal-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: var(--canvas-accent-glow);
+  color: var(--canvas-accent);
+  display: grid;
+  place-items: center;
+}
+.canvas-modal .modal-icon.critic { background: var(--canvas-critic-glow); color: var(--canvas-critic); }
+
+.canvas-modal-backdrop .form-grid { display: grid; gap: 12px; }
+.canvas-modal-backdrop .form-grid.two { grid-template-columns: 1fr 1fr; }
+.canvas-modal-backdrop .form-row { display: flex; flex-direction: column; gap: 6px; }
+
+/* Widget palette */
+.canvas-modal-backdrop .palette-search { padding: 4px 0 16px; position: sticky; top: 0; background: var(--canvas-surface); z-index: 2; }
+.canvas-modal-backdrop .palette-cats {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.canvas-modal-backdrop .palette-cat {
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-2);
+  border: 1px solid var(--canvas-border);
+  cursor: pointer;
+  font-family: inherit;
+}
+.canvas-modal-backdrop .palette-cat:hover { color: var(--canvas-text); }
+.canvas-modal-backdrop .palette-cat.active { background: var(--canvas-accent-glow); color: var(--canvas-accent); border-color: var(--canvas-accent); }
+.canvas-modal-backdrop .palette-cat.critic.active { background: var(--canvas-critic-glow); color: var(--canvas-critic); border-color: var(--canvas-critic); }
+.canvas-modal-backdrop .palette-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.canvas-modal-backdrop .palette-item {
+  background: var(--canvas-surface-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 9px;
+  padding: 12px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  cursor: pointer;
+  text-align: left;
+  transition: all .12s;
+  font-family: inherit;
+  color: var(--canvas-text);
+}
+.canvas-modal-backdrop .palette-item:hover {
+  background: var(--canvas-surface-3);
+  border-color: var(--canvas-border-2);
+  transform: translateY(-1px);
+}
+.canvas-modal-backdrop .palette-item.added { opacity: 0.4; cursor: default; }
+.canvas-modal-backdrop .palette-item.added:hover { transform: none; }
+.canvas-modal-backdrop .palette-item.critic { border-left: 2px solid var(--canvas-critic); }
+.canvas-modal-backdrop .palette-item .pi-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+  background: var(--canvas-surface-3);
+  display: grid;
+  place-items: center;
+  color: var(--canvas-accent);
+  flex-shrink: 0;
+}
+.canvas-modal-backdrop .palette-item.critic .pi-icon { color: var(--canvas-critic); }
+.canvas-modal-backdrop .palette-item .pi-content { flex: 1; min-width: 0; }
+.canvas-modal-backdrop .palette-item .pi-title { font-size: 13px; font-weight: 600; display: flex; align-items: center; gap: 6px; color: var(--canvas-text); }
+.canvas-modal-backdrop .palette-item .pi-desc { font-size: 11.5px; color: var(--canvas-text-3); margin-top: 2px; line-height: 1.4; }
+.canvas-modal-backdrop .palette-item .pi-added {
+  font-size: 10px;
+  font-family: var(--canvas-mono);
+  color: var(--canvas-accent);
+  background: var(--canvas-accent-glow);
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
-.insight-footer {
+/* Bibliography widget */
+.canvas-page-with-sidebar .bib-list { display: flex; flex-direction: column; gap: 6px; max-height: 320px; overflow-y: auto; }
+.canvas-page-with-sidebar .bib-cite { color: var(--canvas-text); font-weight: 500; line-height: 1.4; }
+.canvas-page-with-sidebar .bib-meta { font-family: var(--canvas-mono); font-size: 10px; color: var(--canvas-text-3); display: flex; gap: 8px; }
+.canvas-page-with-sidebar .bib-meta .key { color: var(--canvas-accent); }
+
+.canvas-page-with-sidebar .format-tabs { display: flex; gap: 2px; background: var(--canvas-surface-2); padding: 2px; border-radius: 6px; }
+.canvas-page-with-sidebar .format-tab {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  padding: 3px 7px;
+  border-radius: 4px;
+  color: var(--canvas-text-3);
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+.canvas-page-with-sidebar .format-tab.active { background: var(--canvas-surface-3); color: var(--canvas-text); }
+
+/* Kanban widget */
+.canvas-page-with-sidebar .kanban {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+}
+.canvas-page-with-sidebar .kan-col {
+  background: var(--canvas-bg-2);
+  border-radius: 7px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  border: 1px solid var(--canvas-border);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .kan-col { background: #f3f5f9; }
+.canvas-page-with-sidebar .kan-col.drag-target { background: var(--canvas-accent-glow); border-color: var(--canvas-accent); }
+.canvas-page-with-sidebar .kan-col-head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--canvas-text-3);
   display: flex;
   justify-content: space-between;
-  font-size: 0.8rem;
-  color: var(--text-tertiary);
+  font-weight: 600;
+  padding: 0 2px 4px;
+}
+.canvas-page-with-sidebar .kan-col-head .count { font-family: var(--canvas-mono); }
+.canvas-page-with-sidebar .kan-card {
+  background: var(--canvas-surface-2);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 6px;
+  padding: 7px 9px;
+  font-size: 12px;
+  cursor: grab;
+  line-height: 1.35;
+  position: relative;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .kan-card { background: #fff; box-shadow: 0 1px 2px rgba(20,30,50,0.04); }
+.canvas-page-with-sidebar .kan-card:active { cursor: grabbing; }
+.canvas-page-with-sidebar .kan-card:hover { background: var(--canvas-surface-3); }
+.canvas-page-with-sidebar .kan-card.dragging { opacity: 0.4; }
+.canvas-page-with-sidebar .kan-card .priority-bar {
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 2px;
+  border-radius: 2px;
+}
+.canvas-page-with-sidebar .kan-card.high .priority-bar { background: var(--canvas-danger); }
+.canvas-page-with-sidebar .kan-card.med .priority-bar { background: var(--canvas-warn); }
+.canvas-page-with-sidebar .kan-card.low .priority-bar { background: var(--canvas-text-4); }
+.canvas-page-with-sidebar .kan-card .kan-title { padding-left: 6px; }
+.canvas-page-with-sidebar .kan-card .kan-meta {
+  font-family: var(--canvas-mono);
+  font-size: 9.5px;
+  color: var(--canvas-text-3);
+  margin-top: 4px;
+  padding-left: 6px;
+  display: flex;
+  gap: 6px;
 }
 
-.insight-source {
-  font-weight: 500;
-  color: var(--accent-primary);
+.canvas-page-with-sidebar .add-tiny {
+  font-size: 11px;
+  color: var(--canvas-text-3);
+  padding: 4px 6px;
+  border-radius: 4px;
+  text-align: left;
+  border: 1px dashed transparent;
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
 }
+.canvas-page-with-sidebar .add-tiny:hover { color: var(--canvas-accent); border-color: var(--canvas-border); background: var(--canvas-surface); }
 
-.print-view .insight-source {
-  color: var(--text-secondary);
+/* Pomodoro */
+.canvas-page-with-sidebar .pomo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+  flex: 1;
+  justify-content: center;
 }
-
-/* Loading State */
-.canvas-loading {
+.canvas-page-with-sidebar .pomo-ring {
+  width: 130px;
+  height: 130px;
+  position: relative;
+}
+.canvas-page-with-sidebar .pomo-ring svg { transform: rotate(-90deg); }
+.canvas-page-with-sidebar .pomo-ring .track { stroke: var(--canvas-surface-3); }
+.canvas-page-with-sidebar[data-canvas-theme="light"] .pomo-ring .track { stroke: #e7ebf2; }
+.canvas-page-with-sidebar .pomo-ring .fill {
+  stroke: var(--canvas-accent);
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 6px var(--canvas-accent-glow));
+  transition: stroke-dashoffset .4s ease;
+}
+.canvas-page-with-sidebar .pomo-ring.break .fill { stroke: var(--canvas-ok); filter: drop-shadow(0 0 6px rgba(16,185,129,0.4)); }
+.canvas-page-with-sidebar .pomo-time {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
-  background: var(--bg-gradient);
-  color: var(--text-primary);
+  font-family: var(--canvas-mono);
+}
+.canvas-page-with-sidebar .pomo-time .t { font-size: 26px; font-weight: 600; color: var(--canvas-text); letter-spacing: -0.02em; }
+.canvas-page-with-sidebar .pomo-time .l { font-size: 10px; color: var(--canvas-text-3); text-transform: uppercase; letter-spacing: 0.08em; margin-top: 2px; }
+.canvas-page-with-sidebar .pomo-controls { display: flex; gap: 6px; }
+.canvas-page-with-sidebar .pomo-stats {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: var(--canvas-text-3);
+  display: flex;
+  gap: 14px;
+}
+.canvas-page-with-sidebar .pomo-stats b { color: var(--canvas-accent); font-weight: 500; }
+
+/* Writing tracker */
+.canvas-page-with-sidebar .write-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.canvas-page-with-sidebar .stat {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  padding: 9px 11px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .stat { background: #fff; }
+.canvas-page-with-sidebar .stat .stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--canvas-text-3); font-weight: 600; }
+.canvas-page-with-sidebar .stat .stat-value { font-family: var(--canvas-mono); font-size: 18px; font-weight: 600; color: var(--canvas-text); margin-top: 3px; letter-spacing: -0.02em; }
+.canvas-page-with-sidebar .stat .stat-sub { font-size: 10.5px; color: var(--canvas-text-3); margin-top: 2px; }
+.canvas-page-with-sidebar .stat .stat-value.accent { color: var(--canvas-accent); }
+
+.canvas-page-with-sidebar .spark { width: 100%; height: 56px; }
+.canvas-page-with-sidebar .spark .area { fill: var(--canvas-accent-glow); }
+.canvas-page-with-sidebar .spark .line { stroke: var(--canvas-accent); fill: none; stroke-width: 1.5; }
+.canvas-page-with-sidebar .spark .dot-today { fill: var(--canvas-accent); }
+.canvas-page-with-sidebar .spark .grid { stroke: var(--canvas-border); stroke-dasharray: 2 3; }
+
+.canvas-page-with-sidebar .progress {
+  height: 6px;
+  background: var(--canvas-surface-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .progress { background: #e7ebf2; }
+.canvas-page-with-sidebar .progress > i {
+  display: block;
+  height: 100%;
+  background: var(--canvas-accent);
+  border-radius: 3px;
+  transition: width .3s;
 }
 
-.loading-spinner {
-  width: 3rem;
-  height: 3rem;
-  border: 3px solid var(--border-primary);
-  border-top: 3px solid var(--accent-primary);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-bottom: 1rem;
+/* Deadlines */
+.canvas-page-with-sidebar .dl-list { display: flex; flex-direction: column; gap: 6px; }
+.canvas-page-with-sidebar .dl-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
 }
-
-/* Print Styles */
-.print-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: white;
-  padding: 1rem;
+.canvas-page-with-sidebar[data-canvas-theme="light"] .dl-row { background: #fff; }
+.canvas-page-with-sidebar .dl-row:hover { border-color: var(--canvas-border-2); }
+.canvas-page-with-sidebar .dl-day {
+  font-family: var(--canvas-mono);
+  font-size: 11px;
+  font-weight: 600;
+  width: 56px;
   text-align: center;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  border-top: 1px solid var(--border-primary);
+  padding: 6px 0;
+  border-radius: 5px;
+  background: var(--canvas-surface-2);
+  flex-shrink: 0;
+  line-height: 1.1;
+  color: var(--canvas-text-2);
+}
+.canvas-page-with-sidebar .dl-day.urgent { background: rgba(220,38,38,0.15); color: var(--canvas-danger); }
+.canvas-page-with-sidebar .dl-day.warn { background: rgba(245,158,11,0.15); color: var(--canvas-warn); }
+.canvas-page-with-sidebar .dl-day .num { font-size: 16px; display: block; }
+.canvas-page-with-sidebar .dl-day .lbl { font-size: 9px; text-transform: uppercase; letter-spacing: 0.06em; }
+.canvas-page-with-sidebar .dl-info { flex: 1; min-width: 0; }
+.canvas-page-with-sidebar .dl-title { font-size: 12.5px; font-weight: 500; color: var(--canvas-text); }
+.canvas-page-with-sidebar .dl-sub { font-family: var(--canvas-mono); font-size: 10px; color: var(--canvas-text-3); margin-top: 2px; }
+
+/* Budget */
+.canvas-page-with-sidebar .budget-bar {
+  height: 8px;
+  background: var(--canvas-surface-2);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  margin: 6px 0 12px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .budget-bar { background: #e7ebf2; }
+.canvas-page-with-sidebar .budget-bar > i { display: block; height: 100%; }
+.canvas-page-with-sidebar .budget-list { display: flex; flex-direction: column; gap: 6px; }
+.canvas-page-with-sidebar .budget-row {
+  display: grid;
+  grid-template-columns: 12px 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  font-size: 12px;
+  padding: 5px 0;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .budget-row .swatch { width: 8px; height: 8px; border-radius: 2px; }
+.canvas-page-with-sidebar .budget-row .amt { font-family: var(--canvas-mono); color: var(--canvas-text-2); }
+.canvas-page-with-sidebar .budget-row .pct { font-family: var(--canvas-mono); color: var(--canvas-text-3); font-size: 10.5px; width: 36px; text-align: right; }
+
+/* Reviewer 2 widget */
+.canvas-page-with-sidebar .critic-prompt {
+  font-size: 12px;
+  color: var(--canvas-text-2);
+  background: var(--canvas-bg-2);
+  border: 1px dashed var(--canvas-critic-glow);
+  border-radius: 7px;
+  padding: 10px 12px;
+  font-style: italic;
+  line-height: 1.5;
+}
+.canvas-page-with-sidebar .critic-meter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--canvas-mono);
+  font-size: 10.5px;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .critic-meter .bar {
+  flex: 1;
+  height: 4px;
+  background: var(--canvas-surface-2);
+  border-radius: 2px;
+  position: relative;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .critic-meter .bar { background: #e7ebf2; }
+.canvas-page-with-sidebar .critic-meter .bar > i {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  background: linear-gradient(90deg, var(--canvas-ok), var(--canvas-warn) 50%, var(--canvas-critic));
+  border-radius: 2px;
 }
 
-@media print {
-  .canvas-page {
-    background: white !important;
-    color: black !important;
-    padding: 0.5rem !important;
-  }
+.canvas-page-with-sidebar .review,
+.canvas-modal-backdrop .review {
+  background: var(--canvas-bg-2);
+  border-left: 3px solid var(--canvas-critic);
+  padding: 10px 12px;
+  border-radius: 0 6px 6px 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .review,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .review { background: #fff; }
+.canvas-page-with-sidebar .review .review-tag,
+.canvas-modal-backdrop .review .review-tag {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: var(--canvas-critic);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 4px;
+  display: block;
+}
 
-  .back-button,
-  .header-actions {
+/* Devil's Advocate */
+.canvas-page-with-sidebar .devil-list,
+.canvas-modal-backdrop .devil-list { display: flex; flex-direction: column; gap: 6px; }
+.canvas-page-with-sidebar .devil-item,
+.canvas-modal-backdrop .devil-item {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  padding: 9px 11px;
+  font-size: 12px;
+  position: relative;
+  padding-left: 30px;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .devil-item,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .devil-item { background: #fff; }
+.canvas-page-with-sidebar .devil-item::before,
+.canvas-modal-backdrop .devil-item::before {
+  content: '◆';
+  position: absolute;
+  left: 11px;
+  top: 9px;
+  color: var(--canvas-critic);
+  font-size: 10px;
+}
+.canvas-page-with-sidebar .devil-item .lbl,
+.canvas-modal-backdrop .devil-item .lbl {
+  font-family: var(--canvas-mono);
+  font-size: 9.5px;
+  color: var(--canvas-critic);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 3px;
+}
+
+/* Scope realism */
+.canvas-page-with-sidebar .realism { display: flex; flex-direction: column; gap: 10px; }
+.canvas-page-with-sidebar .realism-verdict {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-critic-glow);
+  border-radius: 9px;
+  padding: 12px 14px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .realism-verdict { background: #fff; }
+.canvas-page-with-sidebar .verdict-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.canvas-page-with-sidebar .verdict-score {
+  font-family: var(--canvas-mono);
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--canvas-critic);
+  letter-spacing: -0.02em;
+}
+.canvas-page-with-sidebar .verdict-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--canvas-text-2);
+  font-weight: 600;
+}
+.canvas-page-with-sidebar .realism-row,
+.canvas-modal-backdrop .realism-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  padding: 5px 0;
+}
+.canvas-page-with-sidebar .realism-row .label-cell,
+.canvas-modal-backdrop .realism-row .label-cell { width: 100px; color: var(--canvas-text-2); font-size: 11.5px; }
+.canvas-page-with-sidebar .realism-row .gauge,
+.canvas-modal-backdrop .realism-row .gauge {
+  flex: 1;
+  height: 4px;
+  background: var(--canvas-surface-2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .gauge,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .gauge,
+body[data-canvas-theme="light"] .canvas-modal-backdrop .critic-meter .bar { background: #e7ebf2; }
+.canvas-page-with-sidebar .realism-row .gauge i,
+.canvas-modal-backdrop .realism-row .gauge i { display: block; height: 100%; background: var(--canvas-critic); border-radius: 2px; }
+.canvas-page-with-sidebar .realism-row .val,
+.canvas-modal-backdrop .realism-row .val { font-family: var(--canvas-mono); font-size: 10.5px; color: var(--canvas-text-3); width: 30px; text-align: right; }
+
+/* Notes / generic row */
+.canvas-page-with-sidebar .note-list { display: flex; flex-direction: column; gap: 6px; max-height: 280px; overflow-y: auto; }
+.canvas-page-with-sidebar .note-row {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: relative;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .note-row { background: #fff; }
+.canvas-page-with-sidebar .note-row:hover { border-color: var(--canvas-border-2); }
+.canvas-page-with-sidebar .note-row .note-text { font-size: 12.5px; color: var(--canvas-text); line-height: 1.45; word-break: break-word; }
+.canvas-page-with-sidebar .note-row .note-meta { font-family: var(--canvas-mono); font-size: 9.5px; color: var(--canvas-text-3); display: flex; gap: 8px; }
+.canvas-page-with-sidebar .note-row .row-actions,
+.canvas-page-with-sidebar .dl-row .row-actions { position: absolute; top: 6px; right: 6px; display: flex; gap: 1px; opacity: 0; transition: opacity .12s; }
+.canvas-page-with-sidebar .note-row:hover .row-actions,
+.canvas-page-with-sidebar .dl-row:hover .row-actions { opacity: 1; }
+.canvas-page-with-sidebar .row-actions .icon-btn { width: 22px; height: 22px; }
+.canvas-page-with-sidebar .row-actions .icon-btn svg { width: 12px; height: 12px; }
+.canvas-page-with-sidebar .tag-pill { display: inline-block; font-family: var(--canvas-mono); font-size: 9.5px; padding: 1px 6px; border-radius: 3px; background: var(--canvas-accent-glow); color: var(--canvas-accent); text-transform: uppercase; letter-spacing: 0.06em; }
+
+/* ----- Deliverables view ----- */
+
+/* Paper / document mode — three-column layout that collapses on narrow screens */
+.canvas-page-with-sidebar .deliverable-grid {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr) 240px;
+  gap: 16px;
+  align-items: start;
+}
+.canvas-page-with-sidebar .deliverable-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: sticky;
+  top: 0;
+}
+
+/* Slides mode — thumbs on left, big canvas in middle, panel on right */
+.canvas-page-with-sidebar .deliverable-slides-grid {
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr) 240px;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 1280px) {
+  .canvas-page-with-sidebar .deliverable-slides-grid { grid-template-columns: 140px minmax(0, 1fr); }
+  .canvas-page-with-sidebar .deliverable-slides-grid > .deliverable-insertables { display: none; }
+}
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .deliverable-slides-grid { grid-template-columns: 1fr; }
+  .canvas-page-with-sidebar .slide-thumbs { display: none; }
+}
+
+/* Slide thumbnails column */
+.canvas-page-with-sidebar .slide-thumbs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: sticky;
+  top: 0;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.canvas-page-with-sidebar .slide-thumb {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+.canvas-page-with-sidebar .slide-thumb-num {
+  width: 18px;
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: var(--canvas-text-3);
+  padding-top: 4px;
+  flex-shrink: 0;
+  text-align: right;
+}
+.canvas-page-with-sidebar .slide-thumb-canvas {
+  flex: 1;
+  background: #fff;
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 4px;
+  aspect-ratio: 16 / 9;
+  padding: 5px 6px;
+  overflow: hidden;
+  color: #111;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  transition: all .15s;
+}
+.canvas-page-with-sidebar .slide-thumb:hover .slide-thumb-canvas {
+  border-color: var(--canvas-accent);
+  transform: translateY(-1px);
+}
+.canvas-page-with-sidebar .slide-thumb.active .slide-thumb-canvas {
+  border: 2px solid var(--canvas-accent);
+  box-shadow: 0 0 0 2px var(--canvas-accent-glow);
+  padding: 4px 5px;
+}
+.canvas-page-with-sidebar .slide-thumb.active .slide-thumb-num { color: var(--canvas-accent); font-weight: 700; }
+.canvas-page-with-sidebar .slide-thumb-title {
+  font-size: 8px;
+  font-weight: 700;
+  color: #1a1a1a;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.canvas-page-with-sidebar .slide-thumb-body {
+  font-size: 6.5px;
+  color: #555;
+  line-height: 1.25;
+  overflow: hidden;
+  flex: 1;
+}
+
+/* Big slide canvas */
+.canvas-page-with-sidebar .slide-canvas-wrap {
+  background: var(--canvas-surface-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 10px;
+  padding: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.canvas-page-with-sidebar .slide-canvas {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16 / 9;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.18), 0 4px 10px rgba(0,0,0,0.10);
+  padding: 36px 44px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #111;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar .slide-canvas::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, var(--canvas-accent), var(--canvas-critic));
+}
+.canvas-page-with-sidebar .slide-canvas-title {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+  line-height: 1.15;
+}
+.canvas-page-with-sidebar .slide-canvas-body {
+  flex: 1;
+  font-size: 15px;
+  color: #1f2937;
+  line-height: 1.55;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar .slide-canvas-body ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.canvas-page-with-sidebar .slide-canvas-body ul li {
+  position: relative;
+  padding-left: 22px;
+}
+.canvas-page-with-sidebar .slide-canvas-body ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 9px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--canvas-accent);
+}
+.canvas-page-with-sidebar .slide-paragraph {
+  font-size: 17px;
+  line-height: 1.6;
+}
+.canvas-page-with-sidebar .slide-placeholder {
+  color: #9ca3af;
+  font-style: italic;
+  font-size: 14px;
+}
+.canvas-page-with-sidebar .slide-canvas-footer {
+  position: absolute;
+  bottom: 14px;
+  right: 18px;
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: #9ca3af;
+}
+
+/* Section-check pill (used in both modes) */
+.canvas-page-with-sidebar .check-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-3);
+  font-family: var(--canvas-sans);
+}
+.canvas-page-with-sidebar .check-pill[data-passed="true"] {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10B981;
+}
+
+/* Document-page preview (Google Docs feel) */
+.canvas-page-with-sidebar .doc-page {
+  background: #ffffff;
+  color: #1a1a1a;
+  padding: 56px 72px;
+  border-radius: 4px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.10), 0 1px 4px rgba(0,0,0,0.06);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+}
+.canvas-page-with-sidebar .doc-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 24px;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+.canvas-page-with-sidebar .doc-h2 {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 24px 0 8px;
+  color: #0f172a;
+}
+.canvas-page-with-sidebar .doc-body { font-size: 14px; line-height: 1.7; color: #1f2937; }
+.canvas-page-with-sidebar .doc-body p { margin: 0 0 12px; }
+.canvas-page-with-sidebar .doc-body strong { color: #0f172a; }
+.canvas-page-with-sidebar .doc-section { margin-bottom: 8px; }
+
+/* Paper-page preview (Overleaf feel — serif, two-column body) */
+.canvas-page-with-sidebar .paper-page {
+  background: #fdfbf7;
+  color: #1a1a1a;
+  padding: 64px 72px;
+  border-radius: 4px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.10), 0 1px 4px rgba(0,0,0,0.06);
+  font-family: 'Georgia', 'Times New Roman', serif;
+  max-width: 820px;
+  margin: 0 auto;
+  width: 100%;
+}
+.canvas-page-with-sidebar .paper-page-head {
+  text-align: center;
+  border-bottom: 1px solid #d1d5db;
+  padding-bottom: 16px;
+  margin-bottom: 22px;
+}
+.canvas-page-with-sidebar .paper-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #0f172a;
+}
+.canvas-page-with-sidebar .paper-byline {
+  font-size: 12px;
+  color: #6b7280;
+  font-style: italic;
+  margin-top: 6px;
+}
+.canvas-page-with-sidebar .paper-h2 {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0f172a;
+  margin: 22px 0 8px;
+}
+.canvas-page-with-sidebar .paper-body { font-size: 13px; line-height: 1.65; color: #1f2937; text-align: justify; }
+.canvas-page-with-sidebar .paper-body p { margin: 0 0 10px; text-indent: 1.5em; }
+.canvas-page-with-sidebar .paper-body p:first-child { text-indent: 0; }
+.canvas-page-with-sidebar .paper-empty { color: #9ca3af; font-style: italic; font-size: 12px; }
+.canvas-page-with-sidebar .paper-section { margin-bottom: 4px; }
+
+/* ----- Canvas-mode app sidebar menu (Insights / Workspace / Deliverables) ----- */
+/* These rules live in the *app* sidebar (not the canvas-page-with-sidebar scope)
+   because they apply to .sidebar from components.css when the user is on canvas. */
+.canvas-sidebar-menu {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.canvas-sidebar-menu .no-sessions {
+  padding: 18px 12px;
+  font-size: 12px;
+  color: var(--text-tertiary, #9CA3AF);
+  text-align: center;
+}
+
+/* --- Workspace: widget groups --- */
+.canvas-sidebar-menu .csm-group { display: flex; flex-direction: column; gap: 1px; margin-bottom: 4px; }
+.canvas-sidebar-menu .csm-group-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--text-tertiary, #9CA3AF);
+  cursor: pointer;
+}
+.canvas-sidebar-menu .csm-group-head:hover { background: var(--bg-secondary, #f3f4f6); color: var(--text-secondary, #6b7280); }
+.dark .canvas-sidebar-menu .csm-group-head:hover { background: var(--bg-secondary-dark, #374151); }
+.canvas-sidebar-menu .csm-group-name { flex: 1; text-align: left; }
+.canvas-sidebar-menu .csm-group-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--text-tertiary, #9CA3AF);
+}
+.canvas-sidebar-menu .csm-group-body { display: flex; flex-direction: column; gap: 1px; padding: 2px 0 6px 8px; }
+
+/* --- Deliverables: project blocks --- */
+.canvas-sidebar-menu .csm-project {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border-radius: 6px;
+  margin-bottom: 4px;
+}
+.canvas-sidebar-menu .csm-project.active { background: rgba(99, 102, 241, 0.06); }
+.dark .canvas-sidebar-menu .csm-project.active { background: rgba(129, 140, 248, 0.10); }
+.canvas-sidebar-menu .csm-project-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+  text-align: left;
+}
+.canvas-sidebar-menu .csm-project-head:hover { background: var(--bg-secondary, #f3f4f6); }
+.dark .canvas-sidebar-menu .csm-project-head { color: var(--text-primary-dark, #f9fafb); }
+.dark .canvas-sidebar-menu .csm-project-head:hover { background: var(--bg-secondary-dark, #374151); }
+.canvas-sidebar-menu .csm-project.active .csm-project-name { color: var(--accent-primary, #6366F1); font-weight: 600; }
+.canvas-sidebar-menu .csm-project-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.canvas-sidebar-menu .csm-versions {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--text-tertiary, #9CA3AF);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-secondary, #f3f4f6);
+}
+.dark .canvas-sidebar-menu .csm-versions { background: var(--bg-secondary-dark, #374151); }
+.canvas-sidebar-menu .csm-project-body {
+  padding: 2px 0 8px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+/* --- Shared row (used in groups and project bodies) --- */
+.canvas-sidebar-menu .csm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px 5px 6px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 12.5px;
+  color: var(--text-secondary, #6b7280);
+  text-align: left;
+  cursor: pointer;
+}
+.canvas-sidebar-menu .csm-row:hover {
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+}
+.dark .canvas-sidebar-menu .csm-row { color: var(--text-secondary-dark, #9ca3af); }
+.dark .canvas-sidebar-menu .csm-row:hover { background: var(--bg-secondary-dark, #374151); color: var(--text-primary-dark, #f9fafb); }
+.canvas-sidebar-menu .csm-row.critic { color: #8B5CF6; }
+.dark .canvas-sidebar-menu .csm-row.critic { color: #A78BFA; }
+.canvas-sidebar-menu .csm-row-bullet {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.45;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+.canvas-sidebar-menu .csm-row-icon { font-size: 11px; opacity: 0.85; }
+.canvas-sidebar-menu .csm-row-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.canvas-sidebar-menu .csm-row-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  color: var(--text-tertiary, #9CA3AF);
+}
+.canvas-sidebar-menu .csm-row-foot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  color: var(--text-tertiary, #9CA3AF);
+  cursor: default;
+}
+.canvas-sidebar-menu .csm-row-foot:hover { background: transparent; color: var(--text-tertiary, #9CA3AF); }
+
+/* Chevron rotates open/closed */
+.canvas-sidebar-menu .csm-chevron {
+  transition: transform 0.15s ease;
+  color: var(--text-tertiary, #9CA3AF);
+}
+.canvas-sidebar-menu .csm-chevron.open { transform: rotate(90deg); }
+
+/* ----- Deliverable project tabs (Overleaf-style multi-draft) ----- */
+.canvas-page-with-sidebar .deliverable-projects {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--canvas-border);
+}
+.canvas-page-with-sidebar .deliverable-project-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--canvas-text-2);
+  font-family: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.canvas-page-with-sidebar .deliverable-project-tab:hover {
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .deliverable-project-tab.active {
+  background: var(--canvas-surface-2);
+  border-color: var(--canvas-border);
+  color: var(--canvas-text);
+  font-weight: 600;
+}
+.canvas-page-with-sidebar .deliverable-new-project { position: relative; }
+.canvas-page-with-sidebar .deliverable-new-project summary {
+  list-style: none;
+  cursor: pointer;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .deliverable-new-project summary::-webkit-details-marker { display: none; }
+.canvas-page-with-sidebar .deliverable-new-project[open] summary { background: var(--canvas-surface-2); color: var(--canvas-text); }
+
+/* Auto-save indicator next to the project title */
+.canvas-page-with-sidebar .save-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--canvas-text-3);
+  font-family: var(--canvas-mono);
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--canvas-surface-2);
+  transition: background .2s, color .2s;
+}
+.canvas-page-with-sidebar .save-indicator-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--canvas-ok);
+  box-shadow: 0 0 6px rgba(16, 185, 129, 0.4);
+  transition: background .2s;
+}
+.canvas-page-with-sidebar .save-indicator.saving {
+  background: var(--canvas-accent-glow);
+  color: var(--canvas-accent);
+}
+.canvas-page-with-sidebar .save-indicator.saving .save-indicator-dot {
+  background: var(--canvas-accent);
+  animation: save-pulse 0.6s ease infinite;
+}
+@keyframes save-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.85); }
+}
+
+/* Editable project title — looks like the page-title but is an input */
+.canvas-page-with-sidebar .page-title-editable {
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 100%;
+  font-family: inherit;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+  padding: 2px 0;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .page-title-editable:focus {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin: 0 -6px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .page-title-editable:focus {
+  background: rgba(0, 0, 0, 0.025);
+}
+
+/* Version history dropdown panel */
+.canvas-page-with-sidebar .deliverable-history {
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  padding: 6px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.canvas-page-with-sidebar .deliverable-history-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px 8px;
+  font-size: 11px;
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--canvas-text-3);
+  border-bottom: 1px solid var(--canvas-border);
+  margin-bottom: 4px;
+}
+.canvas-page-with-sidebar .deliverable-history-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--canvas-text-2);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.canvas-page-with-sidebar .deliverable-history-row:hover {
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text);
+}
+
+/* Slash menu (block-insert popover) */
+.canvas-page-with-sidebar .slash-menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  z-index: 30;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 8px;
+  box-shadow: var(--canvas-shadow-lg);
+  padding: 4px;
+  min-width: 240px;
+  max-height: 280px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.canvas-page-with-sidebar .slash-menu-head {
+  font-size: 10px;
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--canvas-text-4);
+  padding: 6px 8px 4px;
+}
+.canvas-page-with-sidebar .slash-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 12.5px;
+  color: var(--canvas-text);
+  text-align: left;
+  cursor: pointer;
+}
+.canvas-page-with-sidebar .slash-menu button:hover,
+.canvas-page-with-sidebar .slash-menu button.active {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar .slash-menu-kind {
+  font-family: var(--canvas-mono);
+  font-size: 9.5px;
+  color: var(--canvas-text-4);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Poster mode — 4-quadrant grid, banners on top and bottom */
+.canvas-page-with-sidebar .poster-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 10px;
+  padding: 18px;
+}
+.canvas-page-with-sidebar .poster-banner { grid-column: 1 / -1; }
+.canvas-page-with-sidebar .poster-panel {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 8px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .poster-panel {
+  background: #ffffff;
+  border-color: rgba(15, 15, 15, 0.08);
+}
+.canvas-page-with-sidebar .poster-panel-head {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--canvas-accent);
+  border-bottom: 2px solid var(--canvas-accent-glow);
+  padding-bottom: 6px;
+}
+.canvas-page-with-sidebar .poster-panel textarea {
+  flex: 1;
+  min-height: 120px;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--canvas-text);
+  padding: 0;
+}
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .poster-grid { grid-template-columns: 1fr; }
+}
+
+/* ----- Rich editor block (click-to-edit + floating toolbar + LaTeX math) ----- */
+.canvas-page-with-sidebar .rich-block {
+  position: relative;
+  margin-top: 4px;
+}
+
+.canvas-page-with-sidebar .rich-toolbar {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  padding: 4px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 8px;
+  box-shadow: var(--canvas-shadow-lg);
+  z-index: 20;
+  animation: canvas-view-in 140ms var(--canvas-ease);
+}
+.canvas-page-with-sidebar .rich-toolbar button {
+  background: transparent;
+  border: none;
+  width: 30px;
+  height: 28px;
+  border-radius: 4px;
+  display: grid;
+  place-items: center;
+  color: var(--canvas-text-2);
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.canvas-page-with-sidebar .rich-toolbar button:hover {
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text);
+}
+
+/* Rendered block (idle state — looks like real document text) */
+.canvas-page-with-sidebar .rich-rendered {
+  cursor: text;
+  padding: 4px 0;
+  border-radius: 4px;
+  transition: background .12s;
+  outline: none;
+}
+.canvas-page-with-sidebar .rich-rendered:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .rich-rendered:hover {
+  background: rgba(0, 0, 0, 0.02);
+}
+.canvas-page-with-sidebar .rich-rendered:focus-visible {
+  background: rgba(0, 0, 0, 0.025);
+  box-shadow: 0 0 0 2px var(--canvas-accent-glow);
+}
+.canvas-page-with-sidebar .rich-placeholder {
+  color: var(--canvas-text-4);
+  font-style: italic;
+}
+
+/* Inside the rendered block: typography matching the page */
+.canvas-page-with-sidebar .rich-rendered > * { margin: 0; }
+.canvas-page-with-sidebar .rich-rendered > * + * { margin-top: 12px; }
+.canvas-page-with-sidebar .rich-rendered p {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .rich-rendered.serif p {
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: 14.5px;
+  line-height: 1.7;
+  text-align: justify;
+}
+.canvas-page-with-sidebar .rich-rendered h1,
+.canvas-page-with-sidebar .rich-rendered h2,
+.canvas-page-with-sidebar .rich-rendered h3,
+.canvas-page-with-sidebar .rich-rendered h4 {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--canvas-text);
+  margin-top: 16px;
+}
+.canvas-page-with-sidebar .rich-rendered h1 { font-size: 24px; }
+.canvas-page-with-sidebar .rich-rendered h2 { font-size: 19px; }
+.canvas-page-with-sidebar .rich-rendered h3 { font-size: 16px; }
+.canvas-page-with-sidebar .rich-rendered ul,
+.canvas-page-with-sidebar .rich-rendered ol {
+  padding-left: 22px;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .rich-rendered.serif ul,
+.canvas-page-with-sidebar .rich-rendered.serif ol {
+  font-family: 'Georgia', serif;
+  font-size: 14.5px;
+}
+.canvas-page-with-sidebar .rich-rendered li { margin-bottom: 4px; }
+.canvas-page-with-sidebar .rich-rendered blockquote {
+  border-left: 3px solid var(--canvas-accent);
+  padding: 4px 14px;
+  color: var(--canvas-text-2);
+  margin-left: 0;
+  background: rgba(99, 102, 241, 0.04);
+  border-radius: 0 4px 4px 0;
+}
+.canvas-page-with-sidebar .rich-rendered code {
+  background: var(--canvas-surface-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--canvas-mono);
+  font-size: 13px;
+}
+.canvas-page-with-sidebar .rich-rendered pre {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 6px;
+  padding: 12px;
+  overflow-x: auto;
+  font-family: var(--canvas-mono);
+  font-size: 13px;
+}
+.canvas-page-with-sidebar .rich-rendered pre code { background: none; padding: 0; }
+.canvas-page-with-sidebar .rich-rendered a {
+  color: var(--canvas-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.canvas-page-with-sidebar .rich-rendered strong { color: var(--canvas-text); font-weight: 700; }
+.canvas-page-with-sidebar .rich-rendered em { color: var(--canvas-text); }
+.canvas-page-with-sidebar .rich-rendered img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin: 8px 0;
+  display: block;
+}
+
+/* KaTeX math overrides — match document text size */
+.canvas-page-with-sidebar .rich-rendered .katex {
+  font-size: 1.05em;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .rich-rendered .katex-display {
+  margin: 16px 0;
+  padding: 8px 12px;
+  background: var(--canvas-bg-2);
+  border-radius: 6px;
+  overflow-x: auto;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .rich-rendered .katex-display {
+  background: rgba(0, 0, 0, 0.025);
+}
+
+/* ----- Real LaTeX editor (CodeMirror + LaTeX.js) ----- */
+.canvas-page-with-sidebar .paper-editor-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 7px;
+  padding: 3px;
+  margin-bottom: 14px;
+}
+.canvas-page-with-sidebar .paper-editor-toggle-label {
+  font-size: 10.5px;
+  color: var(--canvas-text-4);
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 8px 0 6px;
+}
+.canvas-page-with-sidebar .paper-editor-toggle button {
+  background: transparent;
+  border: none;
+  padding: 4px 11px;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--canvas-text-3);
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.canvas-page-with-sidebar .paper-editor-toggle button:hover { color: var(--canvas-text); }
+.canvas-page-with-sidebar .paper-editor-toggle button.active {
+  background: var(--canvas-surface-3);
+  color: var(--canvas-text);
+  box-shadow: inset 0 0 0 1px var(--canvas-border-2);
+}
+
+.canvas-page-with-sidebar .latex-editor {
+  display: flex;
+  flex-direction: column;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.canvas-page-with-sidebar .latex-editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--canvas-border);
+  background: var(--canvas-bg-2);
+}
+.canvas-page-with-sidebar .latex-editor-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  border-radius: 5px;
+  padding: 2px;
+}
+.canvas-page-with-sidebar .latex-editor-mode button {
+  background: transparent;
+  border: none;
+  padding: 3px 10px;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 11.5px;
+  color: var(--canvas-text-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+}
+.canvas-page-with-sidebar .latex-editor-mode button.active {
+  background: var(--canvas-surface-3);
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .latex-editor-mode button:hover { color: var(--canvas-text); }
+
+.canvas-page-with-sidebar .latex-editor-panes {
+  display: grid;
+  min-height: 520px;
+  height: 70vh;
+  max-height: 800px;
+}
+.canvas-page-with-sidebar .latex-editor-panes.mode-split { grid-template-columns: 1fr 1fr; }
+.canvas-page-with-sidebar .latex-editor-panes.mode-source,
+.canvas-page-with-sidebar .latex-editor-panes.mode-preview { grid-template-columns: 1fr; }
+
+.canvas-page-with-sidebar .latex-source-pane {
+  border-right: 1px solid var(--canvas-border);
+  overflow: hidden;
+}
+.canvas-page-with-sidebar .latex-source-pane .cm-editor {
+  height: 100%;
+  font-size: 13px;
+}
+.canvas-page-with-sidebar .latex-source-pane .cm-scroller {
+  font-family: var(--canvas-mono);
+}
+.canvas-page-with-sidebar .latex-editor-panes.mode-preview .latex-source-pane,
+.canvas-page-with-sidebar .latex-editor-panes.mode-source ~ .latex-preview-pane {
+  display: none;
+}
+
+.canvas-page-with-sidebar .latex-preview-pane {
+  background: #fdfbf7;
+  color: #1a1a1a;
+  overflow-y: auto;
+  padding: 40px 56px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  position: relative;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .latex-preview-pane { background: #fdfbf7; }
+.canvas-page-with-sidebar .latex-preview-body {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.canvas-page-with-sidebar .latex-preview-body h1,
+.canvas-page-with-sidebar .latex-preview-body h2,
+.canvas-page-with-sidebar .latex-preview-body h3 {
+  font-family: 'Georgia', serif;
+  color: #0f172a;
+}
+.canvas-page-with-sidebar .latex-preview-body p {
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: #1f2937;
+  text-align: justify;
+}
+.canvas-page-with-sidebar .latex-preview-error {
+  display: flex;
+  gap: 10px;
+  padding: 10px 14px;
+  margin: 0 auto 14px;
+  max-width: 720px;
+  background: rgba(220, 38, 38, 0.08);
+  border-left: 3px solid var(--canvas-danger);
+  border-radius: 4px;
+  color: var(--canvas-danger);
+}
+
+@media (max-width: 900px) {
+  .canvas-page-with-sidebar .latex-editor-panes.mode-split { grid-template-columns: 1fr; }
+  .canvas-page-with-sidebar .latex-editor-panes.mode-split .latex-source-pane { border-right: none; border-bottom: 1px solid var(--canvas-border); }
+}
+
+/* ----- Notion-style single-surface deliverable editor ----- */
+.canvas-page-with-sidebar .notion-deliverable-grid {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr) 240px;
+  gap: 28px;
+  align-items: start;
+}
+@media (max-width: 1280px) {
+  .canvas-page-with-sidebar .notion-deliverable-grid { grid-template-columns: 200px minmax(0, 1fr); }
+  .canvas-page-with-sidebar .notion-deliverable-grid > .deliverable-insertables { display: none; }
+}
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .notion-deliverable-grid { grid-template-columns: 1fr; }
+  .canvas-page-with-sidebar .notion-toc { display: none; }
+}
+
+/* Subtle TOC */
+.canvas-page-with-sidebar .notion-toc {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  position: sticky;
+  top: 0;
+  padding: 4px 0;
+}
+.canvas-page-with-sidebar .notion-toc-label {
+  font-size: 11px;
+  color: var(--canvas-text-4);
+  font-weight: 500;
+  padding: 4px 6px 8px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.canvas-page-with-sidebar .notion-toc-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 5px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--canvas-text-2);
+  text-align: left;
+  transition: background .12s, color .12s;
+}
+.canvas-page-with-sidebar .notion-toc-link:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-toc-link:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+.canvas-page-with-sidebar .notion-toc-link.active {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--canvas-text);
+  font-weight: 500;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-toc-link.active {
+  background: rgba(0, 0, 0, 0.05);
+}
+.canvas-page-with-sidebar .notion-toc-link-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.canvas-page-with-sidebar .notion-toc-link-count {
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  color: var(--canvas-text-4);
+}
+
+/* The page itself */
+.canvas-page-with-sidebar .notion-page-wrap {
+  display: flex;
+  justify-content: center;
+}
+.canvas-page-with-sidebar .notion-page {
+  background: var(--canvas-surface);
+  width: 100%;
+  max-width: 760px;
+  padding: 60px 80px;
+  border-radius: 4px;
+  color: var(--canvas-text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-page {
+  background: #ffffff;
+  border: 1px solid rgba(15, 15, 15, 0.06);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+.canvas-page-with-sidebar .notion-page.serif {
+  font-family: 'Georgia', 'Times New Roman', serif;
+}
+.canvas-page-with-sidebar .notion-page-wrap.paper .notion-page {
+  background: #fdfbf7;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-page-wrap.paper .notion-page {
+  background: #fdfbf7;
+}
+.canvas-page-with-sidebar .notion-page-title {
+  font-size: 40px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .notion-page-meta {
+  font-size: 12.5px;
+  color: var(--canvas-text-3);
+  margin: 0 0 36px;
+}
+
+.canvas-page-with-sidebar .notion-block {
+  margin: 24px 0;
+  position: relative;
+}
+.canvas-page-with-sidebar .notion-h2 {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  margin: 0 0 8px;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .notion-h2.serif {
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+.canvas-page-with-sidebar .notion-hint {
+  font-size: 13.5px;
+  color: var(--canvas-text-4);
+  font-style: italic;
+  margin: 4px 0 6px;
+}
+
+/* The textarea, styled as Notion body text */
+.canvas-page-with-sidebar .notion-text {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  padding: 4px 0;
+  margin: 0;
+  font-family: inherit;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--canvas-text);
+  overflow: hidden;
+  min-height: 28px;
+}
+.canvas-page-with-sidebar .notion-text.serif {
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: 14.5px;
+  line-height: 1.7;
+}
+.canvas-page-with-sidebar .notion-text::placeholder {
+  color: var(--canvas-text-4);
+}
+.canvas-page-with-sidebar .notion-text:focus {
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 3px;
+  padding: 4px 6px;
+  margin: 0 -6px;
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-text:focus {
+  background: rgba(0, 0, 0, 0.025);
+}
+
+/* Inline meta (check pills + word count) sits below the block */
+.canvas-page-with-sidebar .notion-block-meta {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Notion-style callout box for AI suggestions */
+.canvas-page-with-sidebar .notion-callout {
+  margin-top: 12px;
+  background: rgba(99, 102, 241, 0.06);
+  border-radius: 4px;
+  padding: 14px 16px;
+  display: flex;
+  gap: 10px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .notion-callout {
+  background: rgba(99, 102, 241, 0.07);
+}
+.canvas-page-with-sidebar .notion-callout > svg {
+  color: var(--canvas-accent);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.canvas-page-with-sidebar .notion-callout-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--canvas-accent);
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+/* Export dropdown — uses native <details> for zero-state-management */
+.canvas-page-with-sidebar .canvas-export-menu summary {
+  list-style: none;
+}
+.canvas-page-with-sidebar .canvas-export-menu summary::-webkit-details-marker {
+  display: none;
+}
+.canvas-page-with-sidebar .canvas-export-menu[open] summary {
+  filter: brightness(1.05);
+}
+.canvas-page-with-sidebar .canvas-export-menu-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border-2);
+  border-radius: 6px;
+  box-shadow: var(--canvas-shadow-lg);
+  padding: 4px;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  z-index: 30;
+}
+.canvas-page-with-sidebar .canvas-export-menu-list button {
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 7px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .canvas-export-menu-list button:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .canvas-export-menu-list button:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+/* Old paper/doc preview styles can stay below for the slides bottom-info case */
+
+/* Responsive breakpoints for paper/document mode */
+@media (max-width: 1280px) {
+  .canvas-page-with-sidebar .deliverable-grid { grid-template-columns: 160px minmax(0, 1fr); }
+  .canvas-page-with-sidebar .deliverable-grid > .deliverable-insertables { display: none; }
+}
+@media (max-width: 768px) {
+  .canvas-page-with-sidebar .deliverable-grid { grid-template-columns: 1fr; }
+  .canvas-page-with-sidebar .doc-page,
+  .canvas-page-with-sidebar .paper-page { padding: 32px 24px; }
+}
+
+/* Insertable row in the right rail of Deliverables */
+.canvas-page-with-sidebar .canvas-insert-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--canvas-text);
+  transition: background .12s;
+}
+.canvas-page-with-sidebar .canvas-insert-row:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.canvas-page-with-sidebar[data-canvas-theme="light"] .canvas-insert-row:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* PhD Journey milestone rows */
+.canvas-page-with-sidebar .phd-milestone {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background .12s;
+}
+.canvas-page-with-sidebar .phd-milestone:hover { background: var(--canvas-surface-2); }
+.canvas-page-with-sidebar .phd-milestone-check {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1.5px solid var(--canvas-text-4);
+  background: transparent;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  margin-top: 2px;
+  color: #fff;
+  transition: background .12s, border-color .12s;
+}
+.canvas-page-with-sidebar .phd-milestone.milestone-in-progress .phd-milestone-check {
+  background: #3B82F6;
+  border-color: #3B82F6;
+}
+.canvas-page-with-sidebar .phd-milestone.milestone-completed .phd-milestone-check {
+  background: #10B981;
+  border-color: #10B981;
+}
+.canvas-page-with-sidebar .phd-milestone-body { flex: 1; min-width: 0; }
+.canvas-page-with-sidebar .phd-milestone-label {
+  font-size: 13px;
+  color: var(--canvas-text);
+  font-weight: 500;
+  line-height: 1.4;
+}
+.canvas-page-with-sidebar .phd-milestone.milestone-completed .phd-milestone-label {
+  text-decoration: line-through;
+  color: var(--canvas-text-3);
+}
+.canvas-page-with-sidebar .phd-milestone-hint {
+  font-size: 11.5px;
+  color: var(--canvas-text-4);
+  font-style: italic;
+  margin-top: 2px;
+}
+.canvas-page-with-sidebar .phd-milestone-note {
+  font-size: 11.5px;
+  color: var(--canvas-text-2);
+  margin-top: 2px;
+}
+
+/* PhD Resources link rows */
+.canvas-page-with-sidebar .phd-resource-link {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 8px;
+  background: transparent;
+  border-radius: 5px;
+  text-decoration: none;
+  color: var(--canvas-text);
+  transition: background .12s;
+}
+.canvas-page-with-sidebar .phd-resource-link:hover {
+  background: var(--canvas-surface-2);
+}
+.canvas-page-with-sidebar .phd-resource-name {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--canvas-accent);
+}
+.canvas-page-with-sidebar .phd-resource-desc {
+  font-size: 11px;
+  color: var(--canvas-text-3);
+}
+
+/* "Coming soon" stub widget — roadmap-preview card, not a dead end */
+.canvas-page-with-sidebar .widget-stub {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 4px 8px;
+}
+.canvas-page-with-sidebar .widget-stub-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-3);
+  display: grid;
+  place-items: center;
+}
+.canvas-page-with-sidebar .widget-stub-tag {
+  font-size: 9.5px;
+  font-family: var(--canvas-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--canvas-text-4);
+  font-weight: 600;
+  margin-top: 8px;
+}
+.canvas-page-with-sidebar .widget-stub-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--canvas-text);
+}
+.canvas-page-with-sidebar .widget-stub-desc {
+  font-size: 12px;
+  color: var(--canvas-text-3);
+  line-height: 1.5;
+}
+.canvas-page-with-sidebar .widget-stub-plan {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: var(--canvas-text-3);
+  line-height: 1.6;
+}
+.canvas-page-with-sidebar .widget-stub-plan li::marker { color: var(--canvas-accent); }
+
+/* Shared empty-state block inside widgets (Notion-style: airy, single CTA) */
+.canvas-page-with-sidebar .widget-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 28px 16px;
+  text-align: center;
+  color: var(--canvas-text-3);
+  flex: 1;
+}
+.canvas-page-with-sidebar .widget-empty-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--canvas-surface-2);
+  color: var(--canvas-text-3);
+  display: grid;
+  place-items: center;
+  margin-bottom: 4px;
+}
+.canvas-page-with-sidebar .widget-empty-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--canvas-text-2);
+}
+.canvas-page-with-sidebar .widget-empty-hint {
+  font-size: 12px;
+  color: var(--canvas-text-3);
+  max-width: 240px;
+  line-height: 1.5;
+}
+.canvas-page-with-sidebar .widget-empty-action {
+  margin-top: 8px;
+}
+
+/* Cross-widget drop overlay — shows over the target widget body during drag */
+.canvas-page-with-sidebar .canvas-drop-overlay {
+  position: absolute;
+  inset: -4px;
+  background: var(--canvas-accent-glow);
+  border: 2px dashed var(--canvas-accent);
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--canvas-accent);
+  z-index: 5;
+  pointer-events: none;
+}
+.canvas-page-with-sidebar .canvas-drop-active { outline: none; }
+
+/* Compact markdown rendering inside note rows */
+.canvas-page-with-sidebar .canvas-md p { margin: 0 0 4px; }
+.canvas-page-with-sidebar .canvas-md p:last-child { margin-bottom: 0; }
+.canvas-page-with-sidebar .canvas-md h1,
+.canvas-page-with-sidebar .canvas-md h2,
+.canvas-page-with-sidebar .canvas-md h3 { font-size: 13px; margin: 4px 0 2px; font-weight: 600; }
+.canvas-page-with-sidebar .canvas-md ul,
+.canvas-page-with-sidebar .canvas-md ol { margin: 4px 0; padding-left: 18px; }
+.canvas-page-with-sidebar .canvas-md li { margin-bottom: 2px; }
+.canvas-page-with-sidebar .canvas-md code {
+  background: var(--canvas-surface-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--canvas-mono);
+  font-size: 11.5px;
+}
+.canvas-page-with-sidebar .canvas-md pre {
+  background: var(--canvas-bg-2);
+  border: 1px solid var(--canvas-border);
+  border-radius: 5px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  font-family: var(--canvas-mono);
+  font-size: 11.5px;
+  margin: 4px 0;
+}
+.canvas-page-with-sidebar .canvas-md pre code { background: none; padding: 0; }
+.canvas-page-with-sidebar .canvas-md a { color: var(--canvas-accent); text-decoration: underline; text-underline-offset: 2px; }
+.canvas-page-with-sidebar .canvas-md strong { color: var(--canvas-text); font-weight: 600; }
+.canvas-page-with-sidebar .canvas-md blockquote {
+  border-left: 2px solid var(--canvas-accent);
+  margin: 4px 0;
+  padding: 2px 10px;
+  color: var(--canvas-text-2);
+}
+
+/* Edit-in-place */
+.canvas-page-with-sidebar .inline-input {
+  background: transparent;
+  border: 1px solid var(--canvas-accent);
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: inherit;
+  color: var(--canvas-text);
+  font-family: inherit;
+  width: 100%;
+  outline: none;
+}
+
+/* Print: just the Notion page itself, no chrome */
+@media print {
+  .canvas-sidebar,
+  .canvas-page-with-sidebar .floating-header,
+  .canvas-page-with-sidebar .canvas-tabs,
+  .canvas-page-with-sidebar .notion-toc,
+  .canvas-page-with-sidebar .deliverable-insertables,
+  .canvas-page-with-sidebar .canvas-shortcut-hint,
+  .canvas-page-with-sidebar .page-header > div:last-child,
+  .toast-stack,
+  .canvas-modal-backdrop {
     display: none !important;
   }
-
-  .canvas-section {
-    page-break-inside: avoid;
-    margin-bottom: 1rem;
+  .canvas-page-with-sidebar,
+  .canvas-main-area,
+  .canvas-app-shell,
+  .canvas-content,
+  .canvas-page-with-sidebar .notion-deliverable-grid,
+  .canvas-page-with-sidebar .notion-page-wrap {
+    display: block !important;
+    overflow: visible !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #ffffff !important;
+    color: #000 !important;
   }
-
-  .insight-card {
-    break-inside: avoid;
+  .canvas-page-with-sidebar .notion-page {
+    background: #ffffff !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    max-width: none !important;
   }
+  .canvas-page-with-sidebar .notion-page-title { font-size: 28px; color: #000 !important; }
+  .canvas-page-with-sidebar .notion-h2 { color: #000 !important; }
+  .canvas-page-with-sidebar .notion-text { color: #000 !important; padding: 0 !important; margin: 0 !important; }
+  .canvas-page-with-sidebar .check-pill,
+  .canvas-page-with-sidebar .notion-callout { display: none !important; }
 }
 
-/* Mobile Responsive */
-@media (max-width: 768px) {
-  .canvas-page {
-    padding: 1rem;
-  }
-
-  .canvas-header {
-    flex-direction: column;
-    gap: 1rem;
-    align-items: stretch;
-  }
-
-  .header-left {
-    justify-content: center;
-  }
-
-  .canvas-stats {
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .insights-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .canvas-title {
-    font-size: 1.5rem;
-  }
-
-  .stat-item {
-    min-width: auto;
-  }
+/* Floating shortcut hint — subtle, hides itself, hover-revealed */
+.canvas-shortcut-hint {
+  position: fixed;
+  bottom: 16px;
+  right: 20px;
+  z-index: 50;
+  display: flex;
+  gap: 14px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--canvas-surface);
+  border: 1px solid var(--canvas-border);
+  box-shadow: var(--canvas-shadow);
+  font-size: 11.5px;
+  color: var(--canvas-text-3);
+  font-family: 'Inter', sans-serif;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.25s var(--canvas-ease), transform 0.25s var(--canvas-ease);
+  pointer-events: none;
 }
-
-/* Canvas Copyright Footer */
-.canvas-copyright-footer {
-  padding: 24px;
+.canvas-shortcut-hint.visible {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+.canvas-shortcut-hint:not(.visible):hover {
+  opacity: 0.6;
+  transform: none;
+  pointer-events: auto;
+}
+.canvas-shortcut-hint kbd {
+  display: inline-block;
+  font-family: var(--canvas-mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--canvas-surface-2);
+  border: 1px solid var(--canvas-border-2);
+  color: var(--canvas-text-2);
+  margin-right: 2px;
+  min-width: 14px;
   text-align: center;
-  border-top: 1px solid var(--border-light, #e5e7eb);
-  margin-top: 32px;
 }
+@media (max-width: 768px) {
+  .canvas-shortcut-hint { display: none; }
+}
+
+/* Toast */
+.toast-stack {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+.toast-stack .toast {
+  background: #374151;
+  border: 1px solid #4B5563;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3);
+  animation: canvas-toast-in .25s cubic-bezier(.22,.9,.3,1);
+  pointer-events: auto;
+  color: #F9FAFB;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+body[data-canvas-theme="light"] .toast-stack .toast {
+  background: #FFFFFF;
+  color: #111827;
+  border-color: #D1D5DB;
+  box-shadow: 0 18px 48px rgba(20, 30, 50, 0.16);
+}
+.toast-stack .toast.success { border-left: 3px solid #10B981; }
+.toast-stack .toast.critic { border-left: 3px solid #A78BFA; }
+.toast-stack .toast.danger { border-left: 3px solid #DC2626; }
+@keyframes canvas-toast-in { from { opacity: 0; transform: translateY(8px) } to { opacity: 1; transform: none } }
+
+/* Spinner */
+.canvas-page-with-sidebar .spinner,
+.canvas-modal-backdrop .spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--canvas-surface-3);
+  border-top-color: var(--canvas-accent);
+  border-radius: 50%;
+  animation: canvas-spin .8s linear infinite;
+}
+.canvas-page-with-sidebar .spinner.critic,
+.canvas-modal-backdrop .spinner.critic { border-top-color: var(--canvas-critic); }
+@keyframes canvas-spin { to { transform: rotate(360deg) } }
+
+/* Scrollbar */
+.canvas-page-with-sidebar *::-webkit-scrollbar,
+.canvas-modal-backdrop *::-webkit-scrollbar { width: 8px; height: 8px; }
+.canvas-page-with-sidebar *::-webkit-scrollbar-track,
+.canvas-modal-backdrop *::-webkit-scrollbar-track { background: transparent; }
+.canvas-page-with-sidebar *::-webkit-scrollbar-thumb,
+.canvas-modal-backdrop *::-webkit-scrollbar-thumb { background: var(--canvas-border-2); border-radius: 4px; }
+.canvas-page-with-sidebar *::-webkit-scrollbar-thumb:hover,
+.canvas-modal-backdrop *::-webkit-scrollbar-thumb:hover { background: var(--canvas-text-3); }
+


### PR DESCRIPTION
# Description
Third of three PRs splitting the canvas-upgrade work. **Base: canvas/WorkspaceUpdate (PR 2)** — review after PR 1 and PR 2 merge, then rebase onto main.

## What's in this PR
- Documents (formerly Deliverables) drafting view
- Multi-project document editor with template-based sections
- Notion-style slash commands, version history, KaTeX math
- Multiple templates: paper, slides, poster, CV, GRFP, IRB protocol, meeting prep, dissertation formatting, faculty hunt
- Real LaTeX editor: CodeMirror 6 (stex syntax) + LaTeX.js (HTML preview) + LaTeX-Online API (real pdflatex PDF compilation)
- Documents tab in shared AppHeader (also restores the Workspace tab markup that was dropped in PR 2)
- New deps: @codemirror/legacy-modes, @uiw/react-codemirror, katex, latex.js, rehype-katex, remark-math

## Test plan
- Switch to Documents tab -> template picker shows
- Create a new doc from any template -> sections appear
- Type / in a section -> slash command menu opens
- LaTeX widget renders math inline
- Version history captures saves
- arXiv search returns results
- Switching projects in sidebar updates the active doc
- LaTeX editor (CodeMirror) syntax-highlights stex
- LaTeX preview renders via LaTeX.js
# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->