### PR TITLE
persist advisor responses to db in /chat-stream endpoint.

### DIFF
--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -130,7 +130,7 @@ async def chat_stream(
                         PersistMessage(
                             type="advisor",
                             persona_id="orchestrator",
-                            persona_name="Orchestrator",
+                            advisorName="Orchestrator",
                             content=tool_result.text,
                         ),
                     )
@@ -233,7 +233,7 @@ async def chat_stream(
                         PersistMessage(
                             type="advisor",
                             persona_id=result["persona_id"],
-                            persona_name=result["persona_name"],
+                            advisorName=result["persona_name"],
                             content=result["response"],
                             used_documents=result.get("used_documents", False),
                             document_chunks_used=result.get("document_chunks_used", 0),
@@ -421,7 +421,7 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
                     PersistMessage(
                         type="advisor",
                         persona_id=persona_data["persona_id"],
-                        persona_name=persona_data["persona_name"],
+                        advisorName=persona_data["persona_name"],
                         content=persona_data["response"],
                         isExpansion=True,
                     ),
@@ -438,7 +438,7 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
                     PersistMessage(
                         type="advisor",
                         persona_id=result["persona_id"],
-                        persona_name=result["persona_name"],
+                        advisorName=result["persona_name"],
                         content=result["response"],
                         isExpansion=True,
                     ),
@@ -498,6 +498,7 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                     content=reply.user_input,
                     replyTo={
                         "advisorId": reply.advisor_id,
+                        "advisorName": chat_orchestrator.get_persona(reply.advisor_id).name,
                         "messageId": reply.original_message_id,
                     },
                 ),
@@ -531,7 +532,7 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                     PersistMessage(
                         type="advisor",
                         persona_id=persona_data["persona_id"],
-                        persona_name=persona_data["persona_name"],
+                        advisorName=persona_data["persona_name"],
                         content=persona_data["response"],
                         isReply=True,
                     ),
@@ -550,7 +551,7 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                     PersistMessage(
                         type="advisor",
                         persona_id=result["persona_id"],
-                        persona_name=result["persona_name"],
+                        advisorName=result["persona_name"],
                         content=result["response"],
                         isReply=True,
                     ),

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -452,18 +452,30 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
                 "response": result["response"]
             }
         else:
+            error_content = "Sorry, I received an unexpected response format. Please try again."
+            if input.chat_session_id:
+                await persist_message(
+                    input.chat_session_id,
+                    PersistMessage(type="error", content=error_content),
+                )
             return {
                 "persona": "System",
-                "response": "I'm having trouble generating a response right now. Please try again."
+                "response": error_content,
             }
             
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error in chat_with_specific_advisor: {e}")
+        error_content = "Sorry, I encountered an error while expanding the message. Please try again."
+        if input.chat_session_id:
+            await persist_message(
+                input.chat_session_id,
+                PersistMessage(type="error", content=error_content),
+            )
         return {
             "persona": "System",
-            "response": "I'm having trouble generating a response right now. Please try again."
+            "response": error_content,
         }
 
 @router.post("/reply-to-advisor")
@@ -564,10 +576,16 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
         raise
     except Exception as e:
         logger.error(f"Error in reply_to_advisor: {e}")
+        error_content = "Sorry, I encountered an error with your reply. Please try again."
+        if reply.chat_session_id:
+            await persist_message(
+                reply.chat_session_id,
+                PersistMessage(type="error", content=error_content),
+            )
         return {
             "type": "error",
             "persona": "System",
-            "response": "I'm having trouble generating a reply right now. Please try again."
+            "response": error_content,
         }
 
 @router.post("/ask/")

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -427,8 +427,11 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
         if persona_id not in chat_orchestrator.personas:
             raise HTTPException(status_code=404, detail=f"Persona '{persona_id}' not found")
 
-        # Use async session management
-        session_id = await get_or_create_session_for_request_async(request)
+        # Handle session management for existing chats
+        if input.chat_session_id:
+            session_id = f"chat_{input.chat_session_id}"
+        else:
+            session_id = await get_or_create_session_for_request_async(request)
 
         if input.chat_session_id:
             await persist_message(

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -27,6 +27,7 @@ session_manager = get_session_manager()
 # Enhanced data models
 class UserInput(BaseModel):
     user_input: str
+    chat_session_id: Optional[str] = None
 
 class ChatMessage(BaseModel):
     user_input: str
@@ -428,7 +429,16 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
 
         # Use async session management
         session_id = await get_or_create_session_for_request_async(request)
-        
+
+        if input.chat_session_id:
+            await persist_message(
+                input.chat_session_id,
+                build_user_persist_message(
+                    content=input.user_input,
+                    isExpandRequest=True,
+                ),
+            )
+
         result = await chat_orchestrator.chat_with_persona(
             user_input=input.user_input,
             persona_id=persona_id,
@@ -438,12 +448,32 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
         # Handle response structure
         if result.get("type") == "single_persona_response" and "persona" in result:
             persona_data = result["persona"]
+            if input.chat_session_id:
+                await persist_message(
+                    input.chat_session_id,
+                    build_advisor_persist_message(
+                        persona_id=persona_data["persona_id"],
+                        persona_name=persona_data["persona_name"],
+                        content=persona_data["response"],
+                        isExpansion=True,
+                    ),
+                )
             return {
                 "persona": persona_data["persona_name"],
                 "persona_id": persona_data["persona_id"],
                 "response": persona_data["response"]
             }
         elif "persona_id" in result and "response" in result:
+            if input.chat_session_id:
+                await persist_message(
+                    input.chat_session_id,
+                    build_advisor_persist_message(
+                        persona_id=result["persona_id"],
+                        persona_name=result["persona_name"],
+                        content=result["response"],
+                        isExpansion=True,
+                    ),
+                )
             return {
                 "persona": result["persona_name"],
                 "persona_id": result["persona_id"],

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -64,6 +64,20 @@ class ChatStreamLine(BaseModel):
         return json.dumps(self.model_dump(mode="json"), ensure_ascii=False) + "\n"
 
 
+def build_user_persist_message(
+    content: str,
+    **extra,
+) -> Dict[str, Any]:
+    """Build the dict persisted to MongoDB for a user message."""
+    msg = {
+        "id": str(ObjectId()),
+        "type": "user",
+        "content": content,
+    }
+    msg.update(extra)
+    return msg
+
+
 def build_advisor_persist_message(
     persona_id: str,
     persona_name: str,
@@ -119,11 +133,10 @@ async def chat_stream(
             # Append user message to in-memory session and persist to MongoDB
             session.append_message("user", message.user_input)
             if message.chat_session_id:
-                await persist_message(message.chat_session_id, {
-                    "id": str(ObjectId()),
-                    "type": "user",
-                    "content": message.user_input,
-                })
+                await persist_message(
+                    message.chat_session_id,
+                    build_user_persist_message(content=message.user_input),
+                )
 
             if await chat_orchestrator.needs_clarification_improved(session, message.user_input):
                 clar = await chat_orchestrator.generate_contextual_clarification(message.user_input)
@@ -465,7 +478,19 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
             session_id = await get_or_create_session_for_request_async(request)
         
         session = session_manager.get_session(session_id)
-        
+
+        if reply.chat_session_id:
+            await persist_message(
+                reply.chat_session_id,
+                build_user_persist_message(
+                    content=reply.user_input,
+                    replyTo={
+                        "advisorId": reply.advisor_id,
+                        "messageId": reply.original_message_id,
+                    },
+                ),
+            )
+
         # Find the original message being replied to for context
         original_message = None
         if reply.original_message_id:
@@ -488,6 +513,16 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
         # Handle response structure
         if result.get("type") == "single_persona_response" and "persona" in result:
             persona_data = result["persona"]
+            if reply.chat_session_id:
+                await persist_message(
+                    reply.chat_session_id,
+                    build_advisor_persist_message(
+                        persona_id=persona_data["persona_id"],
+                        persona_name=persona_data["persona_name"],
+                        content=persona_data["response"],
+                        isReply=True,
+                    ),
+                )
             return {
                 "type": "advisor_reply",
                 "persona": persona_data["persona_name"],
@@ -496,6 +531,16 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                 "original_message_id": reply.original_message_id
             }
         elif "persona_id" in result and "response" in result:
+            if reply.chat_session_id:
+                await persist_message(
+                    reply.chat_session_id,
+                    build_advisor_persist_message(
+                        persona_id=result["persona_id"],
+                        persona_name=result["persona_name"],
+                        content=result["response"],
+                        isReply=True,
+                    ),
+                )
             return {
                 "type": "advisor_reply",
                 "persona": result["persona_name"],

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -17,7 +17,7 @@ from app.core.bootstrap import chat_orchestrator
 from app.core.database import get_database
 from app.core.persona_filter import get_available_persona_ids
 from app.core.session_manager import get_session_manager
-from app.models.user import PersistMessage, User
+from app.models.user import PersistMessage, ReplyToRef, User
 
 logger = logging.getLogger(__name__)
 
@@ -496,11 +496,11 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                 PersistMessage(
                     type="user",
                     content=reply.user_input,
-                    replyTo={
-                        "advisorId": reply.advisor_id,
-                        "advisorName": chat_orchestrator.get_persona(reply.advisor_id).name,
-                        "messageId": reply.original_message_id,
-                    },
+                    replyTo=ReplyToRef(
+                        advisorId=reply.advisor_id,
+                        advisorName=chat_orchestrator.get_persona(reply.advisor_id).name,
+                        messageId=reply.original_message_id,
+                    ),
                 ),
             )
 

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -102,6 +102,9 @@ async def chat_stream(
                     message.chat_session_id,
                     PersistMessage(type="user", content=message.user_input),
                 )
+                yield ChatStreamLine(
+                    type="progress", data={"phase": "received"},
+                ).to_ndjson()
 
             if await chat_orchestrator.needs_clarification_improved(session, message.user_input):
                 clar = await chat_orchestrator.generate_contextual_clarification(message.user_input)
@@ -535,6 +538,11 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                         advisorName=persona_data["persona_name"],
                         content=persona_data["response"],
                         isReply=True,
+                        replyTo=ReplyToRef(
+                            advisorId=reply.advisor_id,
+                            advisorName=persona_data["persona_name"],
+                            messageId=reply.original_message_id,
+                        ),
                     ),
                 )
             return {
@@ -554,6 +562,11 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
                         advisorName=result["persona_name"],
                         content=result["response"],
                         isReply=True,
+                        replyTo=ReplyToRef(
+                            advisorId=reply.advisor_id,
+                            advisorName=result["persona_name"],
+                            messageId=reply.original_message_id,
+                        ),
                     ),
                 )
             return {

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -17,7 +17,7 @@ from app.core.bootstrap import chat_orchestrator
 from app.core.database import get_database
 from app.core.persona_filter import get_available_persona_ids
 from app.core.session_manager import get_session_manager
-from app.models.user import User
+from app.models.user import PersistMessage, User
 
 logger = logging.getLogger(__name__)
 
@@ -65,42 +65,6 @@ class ChatStreamLine(BaseModel):
         return json.dumps(self.model_dump(mode="json"), ensure_ascii=False) + "\n"
 
 
-def build_user_persist_message(
-    content: str,
-    **extra,
-) -> Dict[str, Any]:
-    """Build the dict persisted to MongoDB for a user message."""
-    msg = {
-        "id": str(ObjectId()),
-        "type": "user",
-        "content": content,
-    }
-    msg.update(extra)
-    return msg
-
-
-def build_advisor_persist_message(
-    persona_id: str,
-    persona_name: str,
-    content: str,
-    used_documents: bool = False,
-    document_chunks_used: int = 0,
-    **extra,
-) -> Dict[str, Any]:
-    """Build the dict persisted to MongoDB for an advisor/orchestrator response."""
-    msg = {
-        "id": str(ObjectId()),
-        "type": "advisor",
-        "persona_id": persona_id,
-        "advisorName": persona_name,
-        "content": content,
-        "used_documents": used_documents,
-        "document_chunks_used": document_chunks_used,
-    }
-    msg.update(extra)
-    return msg
-
-
 @router.post("/chat-stream")
 async def chat_stream(
     message: ChatMessage,
@@ -136,7 +100,7 @@ async def chat_stream(
             if message.chat_session_id:
                 await persist_message(
                     message.chat_session_id,
-                    build_user_persist_message(content=message.user_input),
+                    PersistMessage(type="user", content=message.user_input),
                 )
 
             if await chat_orchestrator.needs_clarification_improved(session, message.user_input):
@@ -163,7 +127,8 @@ async def chat_stream(
                 if message.chat_session_id:
                     await persist_message(
                         message.chat_session_id,
-                        build_advisor_persist_message(
+                        PersistMessage(
+                            type="advisor",
                             persona_id="orchestrator",
                             persona_name="Orchestrator",
                             content=tool_result.text,
@@ -265,7 +230,8 @@ async def chat_stream(
                 if message.chat_session_id:
                     await persist_message(
                         message.chat_session_id,
-                        build_advisor_persist_message(
+                        PersistMessage(
+                            type="advisor",
                             persona_id=result["persona_id"],
                             persona_name=result["persona_name"],
                             content=result["response"],
@@ -436,7 +402,8 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
         if input.chat_session_id:
             await persist_message(
                 input.chat_session_id,
-                build_user_persist_message(
+                PersistMessage(
+                    type="user",
                     content=input.user_input,
                     isExpandRequest=True,
                 ),
@@ -454,7 +421,8 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
             if input.chat_session_id:
                 await persist_message(
                     input.chat_session_id,
-                    build_advisor_persist_message(
+                    PersistMessage(
+                        type="advisor",
                         persona_id=persona_data["persona_id"],
                         persona_name=persona_data["persona_name"],
                         content=persona_data["response"],
@@ -470,7 +438,8 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
             if input.chat_session_id:
                 await persist_message(
                     input.chat_session_id,
-                    build_advisor_persist_message(
+                    PersistMessage(
+                        type="advisor",
                         persona_id=result["persona_id"],
                         persona_name=result["persona_name"],
                         content=result["response"],
@@ -515,7 +484,8 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
         if reply.chat_session_id:
             await persist_message(
                 reply.chat_session_id,
-                build_user_persist_message(
+                PersistMessage(
+                    type="user",
                     content=reply.user_input,
                     replyTo={
                         "advisorId": reply.advisor_id,
@@ -549,7 +519,8 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
             if reply.chat_session_id:
                 await persist_message(
                     reply.chat_session_id,
-                    build_advisor_persist_message(
+                    PersistMessage(
+                        type="advisor",
                         persona_id=persona_data["persona_id"],
                         persona_name=persona_data["persona_name"],
                         content=persona_data["response"],
@@ -567,7 +538,8 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
             if reply.chat_session_id:
                 await persist_message(
                     reply.chat_session_id,
-                    build_advisor_persist_message(
+                    PersistMessage(
+                        type="advisor",
                         persona_id=result["persona_id"],
                         persona_name=result["persona_name"],
                         content=result["response"],

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -64,6 +64,28 @@ class ChatStreamLine(BaseModel):
         return json.dumps(self.model_dump(mode="json"), ensure_ascii=False) + "\n"
 
 
+def build_advisor_persist_message(
+    persona_id: str,
+    persona_name: str,
+    content: str,
+    used_documents: bool = False,
+    document_chunks_used: int = 0,
+    **extra,
+) -> Dict[str, Any]:
+    """Build the dict persisted to MongoDB for an advisor/orchestrator response."""
+    msg = {
+        "id": str(ObjectId()),
+        "type": "advisor",
+        "persona_id": persona_id,
+        "advisorName": persona_name,
+        "content": content,
+        "used_documents": used_documents,
+        "document_chunks_used": document_chunks_used,
+    }
+    msg.update(extra)
+    return msg
+
+
 @router.post("/chat-stream")
 async def chat_stream(
     message: ChatMessage,
@@ -122,7 +144,17 @@ async def chat_stream(
             # directly and skip persona generation.
             tool_result = await chat_orchestrator.get_tool_response(message.user_input)
             if tool_result.used_tool:
+                # Append user message to in-memory session and persist to MongoDB
                 session.append_message("orchestrator", tool_result.text)
+                if message.chat_session_id:
+                    await persist_message(
+                        message.chat_session_id,
+                        build_advisor_persist_message(
+                            persona_id="orchestrator",
+                            persona_name="Orchestrator",
+                            content=tool_result.text,
+                        ),
+                    )
                 yield ChatStreamLine(
                     type="advisor",
                     data={
@@ -216,6 +248,17 @@ async def chat_stream(
 
             for _ in range(len(tasks)):
                 result = await done_queue.get()
+                if message.chat_session_id:
+                    await persist_message(
+                        message.chat_session_id,
+                        build_advisor_persist_message(
+                            persona_id=result["persona_id"],
+                            persona_name=result["persona_name"],
+                            content=result["response"],
+                            used_documents=result.get("used_documents", False),
+                            document_chunks_used=result.get("document_chunks_used", 0),
+                        ),
+                    )
                 line = ChatStreamLine(
                     type="advisor",
                     data={

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -393,11 +393,8 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
         if persona_id not in chat_orchestrator.personas:
             raise HTTPException(status_code=404, detail=f"Persona '{persona_id}' not found")
 
-        # Handle session management for existing chats
-        if input.chat_session_id:
-            session_id = f"chat_{input.chat_session_id}"
-        else:
-            session_id = await get_or_create_session_for_request_async(request)
+        # Use async session management
+        session_id = await get_or_create_session_for_request_async(request)
 
         if input.chat_session_id:
             await persist_message(

--- a/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
@@ -19,9 +19,6 @@ class UpdateChatSessionRequest(BaseModel):
     title: Optional[str] = None
     messages: Optional[List[dict]] = None
 
-class SaveMessageRequest(BaseModel):
-    session_id: str
-    message: dict
 
 async def persist_message(session_id: str, message: PersistMessage):
     """Write a single message to a MongoDB chat session."""
@@ -246,51 +243,6 @@ async def update_chat_session(
             detail="Could not update chat session"
         )
 
-# TODO: Deprecate this endpoint – the frontend no longer calls it.
-#       All message persistence is now handled by the backend endpoints
-#       (/chat-stream, /reply-to-advisor, /chat/{persona_id}, /upload-document).
-@router.post("/chat-sessions/{session_id}/messages")
-async def save_message_to_session(
-    session_id: str,
-    request: SaveMessageRequest,
-    current_user: User = Depends(get_current_active_user)
-):
-    """
-    Add a message to a chat session.
-    @param session_id: MongoDB ObjectId of the chat session
-    @param request: SaveMessageRequest with the message dict
-    @param current_user: Authenticated user from dependency injection
-    @return: Dict with a confirmation message
-    """
-    try:
-        db = get_database()
-        
-        # Verify session belongs to user
-        session_data = await db.chat_sessions.find_one({
-            "_id": ObjectId(session_id),
-            "user_id": current_user.id,
-            "is_active": True
-        })
-        
-        if not session_data:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Chat session not found"
-            )
-        
-        await persist_message(session_id, request.message)
-        
-        return {"message": "Message saved successfully"}
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error saving message: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Could not save message"
-        )
-    
 
 
 @router.delete("/chat-sessions")

--- a/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from typing import List, Optional
 from datetime import datetime
 from bson import ObjectId
-from app.models.user import User, ChatSession, ChatSessionResponse
+from app.models.user import User, ChatSession, ChatSessionResponse, PersistMessage
 from app.core.auth import get_current_active_user
 from app.core.database import get_database
 from pydantic import BaseModel
@@ -23,10 +23,10 @@ class SaveMessageRequest(BaseModel):
     session_id: str
     message: dict
 
-async def persist_message(session_id: str, message: dict):
+async def persist_message(session_id: str, message: PersistMessage):
     """Write a single message to a MongoDB chat session."""
     db = get_database()
-    msg = message.copy()
+    msg = message.model_dump(exclude_none=True)
     if "timestamp" not in msg:
         msg["timestamp"] = datetime.utcnow().isoformat()
     await db.chat_sessions.update_one(

--- a/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat_sessions.py
@@ -246,6 +246,9 @@ async def update_chat_session(
             detail="Could not update chat session"
         )
 
+# TODO: Deprecate this endpoint – the frontend no longer calls it.
+#       All message persistence is now handled by the backend endpoints
+#       (/chat-stream, /reply-to-advisor, /chat/{persona_id}, /upload-document).
 @router.post("/chat-sessions/{session_id}/messages")
 async def save_message_to_session(
     session_id: str,

--- a/multi_llm_chatbot_backend/app/api/routes/documents.py
+++ b/multi_llm_chatbot_backend/app/api/routes/documents.py
@@ -9,6 +9,7 @@ from app.utils.chat_summary import generate_summary_from_messages, parse_summary
 from app.utils.file_export import prepare_export_response, generate_pdf_file_from_blocks
 from app.core.session_manager import get_session_manager
 from app.core.bootstrap import chat_orchestrator
+from app.api.routes.chat_sessions import persist_message
 from app.core.auth import get_current_active_user
 from app.core.database import get_database
 from app.models.user import User
@@ -216,6 +217,13 @@ async def upload_document(
             "system", 
             f"Document uploaded: '{doc_title}' ({file.filename}) - {rag_result['chunks_created']} sections processed, ~{rag_result['total_tokens']} tokens analyzed. You can now ask questions about this document by referencing it by name."
         )
+
+        if chat_session_id:
+            await persist_message(chat_session_id, {
+                "id": str(ObjectId()),
+                "type": "document_upload",
+                "content": f"Document uploaded: {file.filename} ({rag_result['chunks_created']} sections processed)",
+            })
 
         # Return session info for frontend tracking
         return {

--- a/multi_llm_chatbot_backend/app/api/routes/documents.py
+++ b/multi_llm_chatbot_backend/app/api/routes/documents.py
@@ -12,7 +12,7 @@ from app.core.bootstrap import chat_orchestrator
 from app.api.routes.chat_sessions import persist_message
 from app.core.auth import get_current_active_user
 from app.core.database import get_database
-from app.models.user import User
+from app.models.user import PersistMessage, User
 from bson import ObjectId
 import logging
 import re
@@ -219,11 +219,10 @@ async def upload_document(
         )
 
         if chat_session_id:
-            await persist_message(chat_session_id, {
-                "id": str(ObjectId()),
-                "type": "document_upload",
-                "content": f"Document uploaded: {file.filename} ({rag_result['chunks_created']} sections processed)",
-            })
+            await persist_message(chat_session_id, PersistMessage(
+                type="document_upload",
+                content=f"Document uploaded: {file.filename} ({rag_result['chunks_created']} sections processed)",
+            ))
 
         # Return session info for frontend tracking
         return {

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr, Field, ConfigDict
+from pydantic import BaseModel, EmailStr, Field, ConfigDict, model_validator
 from typing import Literal, Optional, List, Any
 from datetime import datetime
 from bson import ObjectId
@@ -67,6 +67,13 @@ MessageType = Literal[
 ]
 
 
+class ReplyToRef(BaseModel):
+    """Reference to the advisor message being replied to."""
+    advisorId: str
+    advisorName: str
+    messageId: str
+
+
 class PersistMessage(BaseModel):
     """Schema for a single message stored in a ChatSession's messages array."""
     id: str = Field(default_factory=lambda: str(ObjectId()))
@@ -78,15 +85,25 @@ class PersistMessage(BaseModel):
     advisorName: Optional[str] = None
     used_documents: bool = False
     document_chunks_used: int = 0
-    # Error-specific
-    code: Optional[str] = None
     # Clarification-specific
     suggestions: Optional[List[str]] = None
     # Reply/expand metadata
     isReply: bool = False
     isExpansion: bool = False
     isExpandRequest: bool = False
-    replyTo: Optional[dict] = None
+    replyTo: Optional[ReplyToRef] = None
+
+    @model_validator(mode='after')
+    def check_type_constraints(self):
+        if self.type == 'advisor':
+            if not self.persona_id:
+                raise ValueError("persona_id is required for advisor messages")
+            if not self.advisorName:
+                raise ValueError("advisorName is required for advisor messages")
+        elif self.type == 'clarification':
+            if not self.suggestions:
+                raise ValueError("a non-empty suggestions list is required for clarification messages")
+        return self
 
 
 class ChatSession(BaseModel):

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, EmailStr, Field, ConfigDict
-from typing import Optional, List, Any
+from typing import Literal, Optional, List, Any
 from datetime import datetime
 from bson import ObjectId
 
@@ -62,6 +62,33 @@ class UserResponse(BaseModel):
     created_at: datetime
     last_login: Optional[datetime] = None
 
+MessageType = Literal[
+    "user", "advisor", "error", "clarification", "document_upload", "system",
+]
+
+
+class PersistMessage(BaseModel):
+    """Schema for a single message stored in a ChatSession's messages array."""
+    id: str = Field(default_factory=lambda: str(ObjectId()))
+    type: MessageType
+    content: str
+    timestamp: Optional[str] = None
+    # Advisor-specific
+    persona_id: Optional[str] = None
+    persona_name: Optional[str] = None
+    used_documents: bool = False
+    document_chunks_used: int = 0
+    # Error-specific
+    code: Optional[str] = None
+    # Clarification-specific
+    suggestions: Optional[List[str]] = None
+    # Reply/expand metadata
+    isReply: bool = False
+    isExpansion: bool = False
+    isExpandRequest: bool = False
+    replyTo: Optional[dict] = None
+
+
 class ChatSession(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -72,7 +99,7 @@ class ChatSession(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     user_id: PyObjectId
     title: str
-    messages: List[dict] = []
+    messages: List[PersistMessage] = []
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     is_active: bool = True

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -105,6 +105,12 @@ class PersistMessage(BaseModel):
                 raise ValueError("a non-empty suggestions list is required for clarification messages")
         return self
 
+    @model_validator(mode='after')
+    def check_reply_metadata(self):
+        if self.isReply and not self.replyTo:
+            raise ValueError("replyTo is required when isReply is True")
+        return self
+
 
 class ChatSession(BaseModel):
     model_config = ConfigDict(

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -75,7 +75,7 @@ class PersistMessage(BaseModel):
     timestamp: Optional[str] = None
     # Advisor-specific
     persona_id: Optional[str] = None
-    persona_name: Optional[str] = None
+    advisorName: Optional[str] = None
     used_documents: bool = False
     document_chunks_used: int = 0
     # Error-specific

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_sessions.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_sessions.py
@@ -12,14 +12,12 @@ from fastapi import HTTPException
 from app.api.routes.chat_sessions import (  # noqa: E402
     CreateChatSessionRequest,
     UpdateChatSessionRequest,
-    SaveMessageRequest,
     persist_message,
     create_chat_session,
     get_user_chat_sessions,
     get_chat_sessions_count,
     get_chat_session,
     update_chat_session,
-    save_message_to_session,
     delete_all_chat_sessions,
     delete_chat_session,
 )
@@ -298,48 +296,6 @@ class TestUpdateChatSession(unittest.TestCase):
 # POST /chat-sessions/{session_id}/messages
 # ------------------------------------------------------------------
 
-
-@patch("app.api.routes.chat_sessions.get_database")
-class TestSaveMessageToSession(unittest.TestCase):
-
-    def test_saves_message_to_valid_session(self, mock_get_db):
-        db = _mock_db()
-        db.chat_sessions.find_one.return_value = _make_session_doc()
-        mock_get_db.return_value = db
-
-        user = _make_fake_user()
-        req = SaveMessageRequest(
-            session_id=str(FAKE_SESSION_ID),
-            message={"type": "user", "content": "test"},
-        )
-
-        result = asyncio.run(
-            save_message_to_session(
-                session_id=str(FAKE_SESSION_ID), request=req, current_user=user
-            )
-        )
-
-        self.assertEqual(result["message"], "Message saved successfully")
-
-    def test_returns_404_for_nonexistent_session(self, mock_get_db):
-        db = _mock_db()
-        db.chat_sessions.find_one.return_value = None
-        mock_get_db.return_value = db
-
-        user = _make_fake_user()
-        req = SaveMessageRequest(
-            session_id=str(FAKE_SESSION_ID),
-            message={"type": "user", "content": "test"},
-        )
-
-        with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(
-                save_message_to_session(
-                    session_id=str(FAKE_SESSION_ID), request=req, current_user=user
-                )
-            )
-
-        self.assertEqual(ctx.exception.status_code, 404)
 
 
 # ------------------------------------------------------------------

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_sessions.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_sessions.py
@@ -23,7 +23,7 @@ from app.api.routes.chat_sessions import (  # noqa: E402
     delete_all_chat_sessions,
     delete_chat_session,
 )
-from app.models.user import User  # noqa: E402
+from app.models.user import PersistMessage, User  # noqa: E402
 
 FAKE_USER_ID = ObjectId()
 OTHER_USER_ID = ObjectId()
@@ -92,7 +92,7 @@ class TestPersistMessage(unittest.TestCase):
         db = _mock_db()
         mock_get_db.return_value = db
 
-        msg = {"type": "user", "content": "hello"}
+        msg = PersistMessage(type="user", content="hello")
         asyncio.run(persist_message(str(FAKE_SESSION_ID), msg))
 
         args = db.chat_sessions.update_one.call_args
@@ -105,7 +105,7 @@ class TestPersistMessage(unittest.TestCase):
         db = _mock_db()
         mock_get_db.return_value = db
 
-        msg = {"type": "user", "content": "hi", "timestamp": "2025-01-01T00:00:00"}
+        msg = PersistMessage(type="user", content="hi", timestamp="2025-01-01T00:00:00")
         asyncio.run(persist_message(str(FAKE_SESSION_ID), msg))
 
         pushed = db.chat_sessions.update_one.call_args[0][1]["$push"]["messages"]

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -104,6 +104,17 @@ class TestBuildAdvisorPersistMessage(unittest.TestCase):
         self.assertEqual(msg["content"], "Tool output here")
         self.assertEqual(msg["type"], "advisor")
 
+    def test_expansion_flag_included(self):
+        msg = build_advisor_persist_message(
+            persona_id="theorist",
+            persona_name="Dr. Theory",
+            content="Here is a deeper explanation...",
+            isExpansion=True,
+        )
+        self.assertEqual(msg["type"], "advisor")
+        self.assertTrue(msg["isExpansion"])
+        self.assertEqual(msg["persona_id"], "theorist")
+
 
 # ------------------------------------------------------------------
 # build_user_persist_message
@@ -152,3 +163,11 @@ class TestBuildUserPersistMessage(unittest.TestCase):
     def test_plain_message_has_no_replyTo(self):
         msg = build_user_persist_message(content="hello")
         self.assertNotIn("replyTo", msg)
+
+    def test_expand_request_shape(self):
+        msg = build_user_persist_message(
+            content="Please expand on your previous response...",
+            isExpandRequest=True,
+        )
+        self.assertEqual(msg["type"], "user")
+        self.assertTrue(msg["isExpandRequest"])

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -83,8 +83,12 @@ class TestAdvisorPersistMessage(unittest.TestCase):
             advisorName="X",
             content="c",
             isReply=True,
+            replyTo=ReplyToRef(
+                advisorId="y", advisorName="Y", messageId="msg_1",
+            ),
         )
         self.assertTrue(msg.isReply)
+        self.assertIsNotNone(msg.replyTo)
 
     def test_orchestrator_message_shape(self):
         msg = PersistMessage(
@@ -242,3 +246,14 @@ class TestPersistMessageValidators(unittest.TestCase):
         from pydantic import ValidationError
         with self.assertRaises(ValidationError):
             PersistMessage(type="clarification", content="Need more info", suggestions=[])
+
+    def test_reply_without_reply_to_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(
+                type="advisor",
+                persona_id="x",
+                advisorName="X",
+                content="c",
+                isReply=True,
+            )

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -4,17 +4,25 @@ from bson import ObjectId
 
 # The conftest stubs ``app.api.routes.chat`` with a MagicMock so that other
 # test modules can import ``app.api.routes`` without booting the LLM stack.
-# Pop the stub so we can import the real helper, then leave the real module
+# Pop the stub so we can import the real helpers, then leave the real module
 # in sys.modules so it doesn't interfere with other test files.
 import sys
 
 sys.modules.pop("app.api.routes.chat", None)
 
-from app.api.routes.chat import build_advisor_persist_message  # noqa: E402
+from app.api.routes.chat import (  # noqa: E402
+    build_advisor_persist_message,
+    build_user_persist_message,
+)
 
 
 REQUIRED_FIELDS = {"id", "type", "persona_id", "advisorName", "content",
                     "used_documents", "document_chunks_used"}
+
+
+# ------------------------------------------------------------------
+# build_advisor_persist_message
+# ------------------------------------------------------------------
 
 
 class TestBuildAdvisorPersistMessage(unittest.TestCase):
@@ -95,3 +103,52 @@ class TestBuildAdvisorPersistMessage(unittest.TestCase):
         self.assertEqual(msg["advisorName"], "Orchestrator")
         self.assertEqual(msg["content"], "Tool output here")
         self.assertEqual(msg["type"], "advisor")
+
+
+# ------------------------------------------------------------------
+# build_user_persist_message
+# ------------------------------------------------------------------
+
+USER_REQUIRED_FIELDS = {"id", "type", "content"}
+
+
+class TestBuildUserPersistMessage(unittest.TestCase):
+
+    def test_includes_required_fields(self):
+        msg = build_user_persist_message(content="hello")
+        self.assertTrue(USER_REQUIRED_FIELDS.issubset(msg.keys()),
+                        f"Missing fields: {USER_REQUIRED_FIELDS - msg.keys()}")
+
+    def test_type_is_user(self):
+        msg = build_user_persist_message(content="hello")
+        self.assertEqual(msg["type"], "user")
+
+    def test_content_preserved(self):
+        msg = build_user_persist_message(content="Tell me more")
+        self.assertEqual(msg["content"], "Tell me more")
+
+    def test_id_is_valid_objectid_string(self):
+        msg = build_user_persist_message(content="hello")
+        ObjectId(msg["id"])
+
+    def test_each_call_generates_unique_id(self):
+        ids = {
+            build_user_persist_message(content="hello")["id"]
+            for _ in range(10)
+        }
+        self.assertEqual(len(ids), 10)
+
+    def test_reply_to_metadata_included(self):
+        msg = build_user_persist_message(
+            content="I disagree",
+            replyTo={
+                "advisorId": "methodologist",
+                "messageId": "msg_123",
+            },
+        )
+        self.assertEqual(msg["replyTo"]["advisorId"], "methodologist")
+        self.assertEqual(msg["replyTo"]["messageId"], "msg_123")
+
+    def test_plain_message_has_no_replyTo(self):
+        msg = build_user_persist_message(content="hello")
+        self.assertNotIn("replyTo", msg)

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -2,172 +2,212 @@ import unittest
 
 from bson import ObjectId
 
-# The conftest stubs ``app.api.routes.chat`` with a MagicMock so that other
-# test modules can import ``app.api.routes`` without booting the LLM stack.
-# Pop the stub so we can import the real helpers, then leave the real module
-# in sys.modules so it doesn't interfere with other test files.
-import sys
-
-sys.modules.pop("app.api.routes.chat", None)
-
-from app.api.routes.chat import (  # noqa: E402
-    build_advisor_persist_message,
-    build_user_persist_message,
-)
-
-
-REQUIRED_FIELDS = {"id", "type", "persona_id", "advisorName", "content",
-                    "used_documents", "document_chunks_used"}
+from app.models.user import PersistMessage
 
 
 # ------------------------------------------------------------------
-# build_advisor_persist_message
+# PersistMessage – advisor type
 # ------------------------------------------------------------------
 
 
-class TestBuildAdvisorPersistMessage(unittest.TestCase):
+ADVISOR_REQUIRED_FIELDS = {"id", "type", "persona_id", "persona_name", "content",
+                           "used_documents", "document_chunks_used"}
+
+
+class TestAdvisorPersistMessage(unittest.TestCase):
 
     def test_includes_all_required_fields(self):
-        msg = build_advisor_persist_message(
+        msg = PersistMessage(
+            type="advisor",
             persona_id="advisor_a",
             persona_name="Advisor A",
             content="Some advice.",
-        )
-        self.assertTrue(REQUIRED_FIELDS.issubset(msg.keys()),
-                        f"Missing fields: {REQUIRED_FIELDS - msg.keys()}")
+        ).model_dump(exclude_none=True)
+        self.assertTrue(ADVISOR_REQUIRED_FIELDS.issubset(msg.keys()),
+                        f"Missing fields: {ADVISOR_REQUIRED_FIELDS - msg.keys()}")
 
     def test_type_is_advisor(self):
-        msg = build_advisor_persist_message(
-            persona_id="x", persona_name="X", content="c",
+        msg = PersistMessage(
+            type="advisor", persona_id="x", persona_name="X", content="c",
         )
-        self.assertEqual(msg["type"], "advisor")
+        self.assertEqual(msg.type, "advisor")
 
-    def test_maps_persona_name_to_advisorName(self):
-        msg = build_advisor_persist_message(
+    def test_persona_name_stored(self):
+        msg = PersistMessage(
+            type="advisor",
             persona_id="methodologist",
             persona_name="Dr. Method",
             content="content",
         )
-        self.assertEqual(msg["advisorName"], "Dr. Method")
-        self.assertEqual(msg["persona_id"], "methodologist")
+        self.assertEqual(msg.persona_name, "Dr. Method")
+        self.assertEqual(msg.persona_id, "methodologist")
 
     def test_defaults_for_document_fields(self):
-        msg = build_advisor_persist_message(
-            persona_id="x", persona_name="X", content="c",
+        msg = PersistMessage(
+            type="advisor", persona_id="x", persona_name="X", content="c",
         )
-        self.assertFalse(msg["used_documents"])
-        self.assertEqual(msg["document_chunks_used"], 0)
+        self.assertFalse(msg.used_documents)
+        self.assertEqual(msg.document_chunks_used, 0)
 
     def test_explicit_document_fields(self):
-        msg = build_advisor_persist_message(
+        msg = PersistMessage(
+            type="advisor",
             persona_id="x",
             persona_name="X",
             content="c",
             used_documents=True,
             document_chunks_used=5,
         )
-        self.assertTrue(msg["used_documents"])
-        self.assertEqual(msg["document_chunks_used"], 5)
+        self.assertTrue(msg.used_documents)
+        self.assertEqual(msg.document_chunks_used, 5)
 
     def test_id_is_valid_objectid_string(self):
-        msg = build_advisor_persist_message(
-            persona_id="x", persona_name="X", content="c",
+        msg = PersistMessage(
+            type="advisor", persona_id="x", persona_name="X", content="c",
         )
-        ObjectId(msg["id"])  # raises if invalid
+        ObjectId(msg.id)
 
     def test_each_call_generates_unique_id(self):
         ids = {
-            build_advisor_persist_message(
-                persona_id="x", persona_name="X", content="c",
-            )["id"]
+            PersistMessage(
+                type="advisor", persona_id="x", persona_name="X", content="c",
+            ).id
             for _ in range(10)
         }
         self.assertEqual(len(ids), 10)
 
-    def test_extra_kwargs_included(self):
-        msg = build_advisor_persist_message(
+    def test_reply_flag(self):
+        msg = PersistMessage(
+            type="advisor",
             persona_id="x",
             persona_name="X",
             content="c",
             isReply=True,
         )
-        self.assertTrue(msg["isReply"])
+        self.assertTrue(msg.isReply)
 
     def test_orchestrator_message_shape(self):
-        msg = build_advisor_persist_message(
+        msg = PersistMessage(
+            type="advisor",
             persona_id="orchestrator",
             persona_name="Orchestrator",
             content="Tool output here",
         )
-        self.assertEqual(msg["persona_id"], "orchestrator")
-        self.assertEqual(msg["advisorName"], "Orchestrator")
-        self.assertEqual(msg["content"], "Tool output here")
-        self.assertEqual(msg["type"], "advisor")
+        self.assertEqual(msg.persona_id, "orchestrator")
+        self.assertEqual(msg.persona_name, "Orchestrator")
+        self.assertEqual(msg.content, "Tool output here")
+        self.assertEqual(msg.type, "advisor")
 
-    def test_expansion_flag_included(self):
-        msg = build_advisor_persist_message(
+    def test_expansion_flag(self):
+        msg = PersistMessage(
+            type="advisor",
             persona_id="theorist",
             persona_name="Dr. Theory",
             content="Here is a deeper explanation...",
             isExpansion=True,
         )
-        self.assertEqual(msg["type"], "advisor")
-        self.assertTrue(msg["isExpansion"])
-        self.assertEqual(msg["persona_id"], "theorist")
+        self.assertEqual(msg.type, "advisor")
+        self.assertTrue(msg.isExpansion)
+        self.assertEqual(msg.persona_id, "theorist")
 
 
 # ------------------------------------------------------------------
-# build_user_persist_message
+# PersistMessage – user type
 # ------------------------------------------------------------------
+
 
 USER_REQUIRED_FIELDS = {"id", "type", "content"}
 
 
-class TestBuildUserPersistMessage(unittest.TestCase):
+class TestUserPersistMessage(unittest.TestCase):
 
     def test_includes_required_fields(self):
-        msg = build_user_persist_message(content="hello")
+        msg = PersistMessage(type="user", content="hello").model_dump(exclude_none=True)
         self.assertTrue(USER_REQUIRED_FIELDS.issubset(msg.keys()),
                         f"Missing fields: {USER_REQUIRED_FIELDS - msg.keys()}")
 
     def test_type_is_user(self):
-        msg = build_user_persist_message(content="hello")
-        self.assertEqual(msg["type"], "user")
+        msg = PersistMessage(type="user", content="hello")
+        self.assertEqual(msg.type, "user")
 
     def test_content_preserved(self):
-        msg = build_user_persist_message(content="Tell me more")
-        self.assertEqual(msg["content"], "Tell me more")
+        msg = PersistMessage(type="user", content="Tell me more")
+        self.assertEqual(msg.content, "Tell me more")
 
     def test_id_is_valid_objectid_string(self):
-        msg = build_user_persist_message(content="hello")
-        ObjectId(msg["id"])
+        msg = PersistMessage(type="user", content="hello")
+        ObjectId(msg.id)
 
     def test_each_call_generates_unique_id(self):
         ids = {
-            build_user_persist_message(content="hello")["id"]
+            PersistMessage(type="user", content="hello").id
             for _ in range(10)
         }
         self.assertEqual(len(ids), 10)
 
-    def test_reply_to_metadata_included(self):
-        msg = build_user_persist_message(
+    def test_reply_to_metadata(self):
+        msg = PersistMessage(
+            type="user",
             content="I disagree",
             replyTo={
                 "advisorId": "methodologist",
                 "messageId": "msg_123",
             },
         )
-        self.assertEqual(msg["replyTo"]["advisorId"], "methodologist")
-        self.assertEqual(msg["replyTo"]["messageId"], "msg_123")
+        self.assertEqual(msg.replyTo["advisorId"], "methodologist")
+        self.assertEqual(msg.replyTo["messageId"], "msg_123")
 
     def test_plain_message_has_no_replyTo(self):
-        msg = build_user_persist_message(content="hello")
+        msg = PersistMessage(type="user", content="hello").model_dump(exclude_none=True)
         self.assertNotIn("replyTo", msg)
 
     def test_expand_request_shape(self):
-        msg = build_user_persist_message(
+        msg = PersistMessage(
+            type="user",
             content="Please expand on your previous response...",
             isExpandRequest=True,
         )
-        self.assertEqual(msg["type"], "user")
-        self.assertTrue(msg["isExpandRequest"])
+        self.assertEqual(msg.type, "user")
+        self.assertTrue(msg.isExpandRequest)
+
+
+# ------------------------------------------------------------------
+# PersistMessage – error type
+# ------------------------------------------------------------------
+
+
+class TestErrorPersistMessage(unittest.TestCase):
+
+    def test_type_is_error(self):
+        msg = PersistMessage(type="error", content="Something went wrong")
+        self.assertEqual(msg.type, "error")
+
+    def test_error_code(self):
+        msg = PersistMessage(
+            type="error",
+            content="No advisors available",
+            code="NO_ADVISORS_AVAILABLE",
+        )
+        self.assertEqual(msg.code, "NO_ADVISORS_AVAILABLE")
+
+    def test_error_without_code(self):
+        msg = PersistMessage(type="error", content="Generic error")
+        self.assertIsNone(msg.code)
+
+
+# ------------------------------------------------------------------
+# PersistMessage – type validation
+# ------------------------------------------------------------------
+
+
+class TestPersistMessageTypeValidation(unittest.TestCase):
+
+    def test_rejects_invalid_type(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="bogus", content="hello")
+
+    def test_all_valid_types_accepted(self):
+        for t in ("user", "advisor", "error", "clarification", "document_upload", "system"):
+            msg = PersistMessage(type=t, content="test")
+            self.assertEqual(msg.type, t)

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -2,7 +2,7 @@ import unittest
 
 from bson import ObjectId
 
-from app.models.user import PersistMessage
+from app.models.user import PersistMessage, ReplyToRef
 
 
 # ------------------------------------------------------------------
@@ -149,13 +149,15 @@ class TestUserPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="user",
             content="I disagree",
-            replyTo={
-                "advisorId": "methodologist",
-                "messageId": "msg_123",
-            },
+            replyTo=ReplyToRef(
+                advisorId="methodologist",
+                advisorName="Dr. Method",
+                messageId="msg_123",
+            ),
         )
-        self.assertEqual(msg.replyTo["advisorId"], "methodologist")
-        self.assertEqual(msg.replyTo["messageId"], "msg_123")
+        self.assertEqual(msg.replyTo.advisorId, "methodologist")
+        self.assertEqual(msg.replyTo.advisorName, "Dr. Method")
+        self.assertEqual(msg.replyTo.messageId, "msg_123")
 
     def test_plain_message_has_no_replyTo(self):
         msg = PersistMessage(type="user", content="hello").model_dump(exclude_none=True)
@@ -182,18 +184,6 @@ class TestErrorPersistMessage(unittest.TestCase):
         msg = PersistMessage(type="error", content="Something went wrong")
         self.assertEqual(msg.type, "error")
 
-    def test_error_code(self):
-        msg = PersistMessage(
-            type="error",
-            content="No advisors available",
-            code="NO_ADVISORS_AVAILABLE",
-        )
-        self.assertEqual(msg.code, "NO_ADVISORS_AVAILABLE")
-
-    def test_error_without_code(self):
-        msg = PersistMessage(type="error", content="Generic error")
-        self.assertIsNone(msg.code)
-
 
 # ------------------------------------------------------------------
 # PersistMessage – type validation
@@ -208,6 +198,47 @@ class TestPersistMessageTypeValidation(unittest.TestCase):
             PersistMessage(type="bogus", content="hello")
 
     def test_all_valid_types_accepted(self):
-        for t in ("user", "advisor", "error", "clarification", "document_upload", "system"):
-            msg = PersistMessage(type=t, content="test")
+        valid = {
+            "user": {},
+            "advisor": {"persona_id": "x", "advisorName": "X"},
+            "error": {},
+            "clarification": {"suggestions": ["Try this"]},
+            "document_upload": {},
+            "system": {},
+        }
+        for t, kwargs in valid.items():
+            msg = PersistMessage(type=t, content="test", **kwargs)
             self.assertEqual(msg.type, t)
+
+
+# ------------------------------------------------------------------
+# PersistMessage – model validators
+# ------------------------------------------------------------------
+
+
+class TestPersistMessageValidators(unittest.TestCase):
+
+    def test_advisor_without_persona_id_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="advisor", advisorName="X", content="c")
+
+    def test_advisor_without_advisor_name_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="advisor", persona_id="x", content="c")
+
+    def test_advisor_without_both_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="advisor", content="c")
+
+    def test_clarification_without_suggestions_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="clarification", content="Need more info")
+
+    def test_clarification_with_empty_suggestions_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            PersistMessage(type="clarification", content="Need more info", suggestions=[])

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -10,7 +10,7 @@ from app.models.user import PersistMessage
 # ------------------------------------------------------------------
 
 
-ADVISOR_REQUIRED_FIELDS = {"id", "type", "persona_id", "persona_name", "content",
+ADVISOR_REQUIRED_FIELDS = {"id", "type", "persona_id", "advisorName", "content",
                            "used_documents", "document_chunks_used"}
 
 
@@ -20,7 +20,7 @@ class TestAdvisorPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="advisor",
             persona_id="advisor_a",
-            persona_name="Advisor A",
+            advisorName="Advisor A",
             content="Some advice.",
         ).model_dump(exclude_none=True)
         self.assertTrue(ADVISOR_REQUIRED_FIELDS.issubset(msg.keys()),
@@ -28,23 +28,23 @@ class TestAdvisorPersistMessage(unittest.TestCase):
 
     def test_type_is_advisor(self):
         msg = PersistMessage(
-            type="advisor", persona_id="x", persona_name="X", content="c",
+            type="advisor", persona_id="x", advisorName="X", content="c",
         )
         self.assertEqual(msg.type, "advisor")
 
-    def test_persona_name_stored(self):
+    def test_advisor_name_stored(self):
         msg = PersistMessage(
             type="advisor",
             persona_id="methodologist",
-            persona_name="Dr. Method",
+            advisorName="Dr. Method",
             content="content",
         )
-        self.assertEqual(msg.persona_name, "Dr. Method")
+        self.assertEqual(msg.advisorName, "Dr. Method")
         self.assertEqual(msg.persona_id, "methodologist")
 
     def test_defaults_for_document_fields(self):
         msg = PersistMessage(
-            type="advisor", persona_id="x", persona_name="X", content="c",
+            type="advisor", persona_id="x", advisorName="X", content="c",
         )
         self.assertFalse(msg.used_documents)
         self.assertEqual(msg.document_chunks_used, 0)
@@ -53,7 +53,7 @@ class TestAdvisorPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="advisor",
             persona_id="x",
-            persona_name="X",
+            advisorName="X",
             content="c",
             used_documents=True,
             document_chunks_used=5,
@@ -63,14 +63,14 @@ class TestAdvisorPersistMessage(unittest.TestCase):
 
     def test_id_is_valid_objectid_string(self):
         msg = PersistMessage(
-            type="advisor", persona_id="x", persona_name="X", content="c",
+            type="advisor", persona_id="x", advisorName="X", content="c",
         )
         ObjectId(msg.id)
 
     def test_each_call_generates_unique_id(self):
         ids = {
             PersistMessage(
-                type="advisor", persona_id="x", persona_name="X", content="c",
+                type="advisor", persona_id="x", advisorName="X", content="c",
             ).id
             for _ in range(10)
         }
@@ -80,7 +80,7 @@ class TestAdvisorPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="advisor",
             persona_id="x",
-            persona_name="X",
+            advisorName="X",
             content="c",
             isReply=True,
         )
@@ -90,11 +90,11 @@ class TestAdvisorPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="advisor",
             persona_id="orchestrator",
-            persona_name="Orchestrator",
+            advisorName="Orchestrator",
             content="Tool output here",
         )
         self.assertEqual(msg.persona_id, "orchestrator")
-        self.assertEqual(msg.persona_name, "Orchestrator")
+        self.assertEqual(msg.advisorName, "Orchestrator")
         self.assertEqual(msg.content, "Tool output here")
         self.assertEqual(msg.type, "advisor")
 
@@ -102,7 +102,7 @@ class TestAdvisorPersistMessage(unittest.TestCase):
         msg = PersistMessage(
             type="advisor",
             persona_id="theorist",
-            persona_name="Dr. Theory",
+            advisorName="Dr. Theory",
             content="Here is a deeper explanation...",
             isExpansion=True,
         )

--- a/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_chat_stream_persistence.py
@@ -1,0 +1,97 @@
+import unittest
+
+from bson import ObjectId
+
+# The conftest stubs ``app.api.routes.chat`` with a MagicMock so that other
+# test modules can import ``app.api.routes`` without booting the LLM stack.
+# Pop the stub so we can import the real helper, then leave the real module
+# in sys.modules so it doesn't interfere with other test files.
+import sys
+
+sys.modules.pop("app.api.routes.chat", None)
+
+from app.api.routes.chat import build_advisor_persist_message  # noqa: E402
+
+
+REQUIRED_FIELDS = {"id", "type", "persona_id", "advisorName", "content",
+                    "used_documents", "document_chunks_used"}
+
+
+class TestBuildAdvisorPersistMessage(unittest.TestCase):
+
+    def test_includes_all_required_fields(self):
+        msg = build_advisor_persist_message(
+            persona_id="advisor_a",
+            persona_name="Advisor A",
+            content="Some advice.",
+        )
+        self.assertTrue(REQUIRED_FIELDS.issubset(msg.keys()),
+                        f"Missing fields: {REQUIRED_FIELDS - msg.keys()}")
+
+    def test_type_is_advisor(self):
+        msg = build_advisor_persist_message(
+            persona_id="x", persona_name="X", content="c",
+        )
+        self.assertEqual(msg["type"], "advisor")
+
+    def test_maps_persona_name_to_advisorName(self):
+        msg = build_advisor_persist_message(
+            persona_id="methodologist",
+            persona_name="Dr. Method",
+            content="content",
+        )
+        self.assertEqual(msg["advisorName"], "Dr. Method")
+        self.assertEqual(msg["persona_id"], "methodologist")
+
+    def test_defaults_for_document_fields(self):
+        msg = build_advisor_persist_message(
+            persona_id="x", persona_name="X", content="c",
+        )
+        self.assertFalse(msg["used_documents"])
+        self.assertEqual(msg["document_chunks_used"], 0)
+
+    def test_explicit_document_fields(self):
+        msg = build_advisor_persist_message(
+            persona_id="x",
+            persona_name="X",
+            content="c",
+            used_documents=True,
+            document_chunks_used=5,
+        )
+        self.assertTrue(msg["used_documents"])
+        self.assertEqual(msg["document_chunks_used"], 5)
+
+    def test_id_is_valid_objectid_string(self):
+        msg = build_advisor_persist_message(
+            persona_id="x", persona_name="X", content="c",
+        )
+        ObjectId(msg["id"])  # raises if invalid
+
+    def test_each_call_generates_unique_id(self):
+        ids = {
+            build_advisor_persist_message(
+                persona_id="x", persona_name="X", content="c",
+            )["id"]
+            for _ in range(10)
+        }
+        self.assertEqual(len(ids), 10)
+
+    def test_extra_kwargs_included(self):
+        msg = build_advisor_persist_message(
+            persona_id="x",
+            persona_name="X",
+            content="c",
+            isReply=True,
+        )
+        self.assertTrue(msg["isReply"])
+
+    def test_orchestrator_message_shape(self):
+        msg = build_advisor_persist_message(
+            persona_id="orchestrator",
+            persona_name="Orchestrator",
+            content="Tool output here",
+        )
+        self.assertEqual(msg["persona_id"], "orchestrator")
+        self.assertEqual(msg["advisorName"], "Orchestrator")
+        self.assertEqual(msg["content"], "Tool output here")
+        self.assertEqual(msg["type"], "advisor")

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -400,6 +400,7 @@ const handleNewChat = async (sessionId = null) => {
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
+      let refreshedForUserMessage = false;
 
       while (true) {
         const { done, value } = await reader.read();
@@ -412,6 +413,11 @@ const handleNewChat = async (sessionId = null) => {
         for (const line of lines) {
           if (!line.trim()) continue;
           const payload = JSON.parse(line);
+
+          if (!refreshedForUserMessage) {
+            setSidebarRefreshTrigger(prev => prev + 1);
+            refreshedForUserMessage = true;
+          }
 
           const d = payload.data || {};
 
@@ -551,6 +557,7 @@ const handleNewChat = async (sessionId = null) => {
 
   setIsLoading(false);
   setThinkingAdvisors([]);
+  setSidebarRefreshTrigger(prev => prev + 1);
 };
 
   const handleCopyMessage = (messageId, content) => {
@@ -634,6 +641,7 @@ const handleNewChat = async (sessionId = null) => {
 
     setIsLoading(false);
     setThinkingAdvisors([]);
+    setSidebarRefreshTrigger(prev => prev + 1);
   };
 
   const handleReplyToMessage = (message) => {

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -188,7 +188,8 @@ const loadChatSession = async (sessionId) => {
         const formattedMessages = result.context.messages.map(msg => ({
           ...msg,
           timestamp: new Date(msg.timestamp),
-          persona_id: msg.persona_id || msg.advisor || msg.advisorId
+          persona_id: msg.persona_id || msg.advisor || msg.advisorId,
+          advisorName: msg.advisorName || msg.persona_name || 'Advisor'
         }));
         
         setMessages(formattedMessages);

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -215,30 +215,6 @@ const loadChatSession = async (sessionId) => {
   }
 };
 
-// Save a message to the current session
-const saveMessageToSession = async (message) => {
-  if (!currentSessionId || !authToken) return;
-
-  try {
-    await fetch(`${process.env.REACT_APP_API_URL}/api/chat-sessions/${currentSessionId}/messages`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${authToken}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        session_id: currentSessionId,
-        message: {
-          ...message,
-          timestamp: message.timestamp.toISOString()
-        }
-      })
-    });
-  } catch (error) {
-    console.error('Error saving message to session:', error);
-  }
-};
-
 // Update session title based on first message
 const updateSessionTitle = async (sessionId, newTitle) => {
   if (!sessionId || !authToken) return;
@@ -364,10 +340,6 @@ const handleNewChat = async (sessionId = null) => {
       current_session_id: currentSessionId
     });
     
-    // Save document upload message to database if we have a current session
-    if (currentSessionId) {
-      await saveMessageToSession(documentMessage);
-    }
   };
 
 
@@ -457,7 +429,6 @@ const handleNewChat = async (sessionId = null) => {
               };
               setMessages(prev => [...prev, msg]);
               setThinkingAdvisors(prev => prev.filter(a => a !== d.persona_id));
-              await saveMessageToSession(msg);
               break;
             }
             case 'clarification':
@@ -531,9 +502,6 @@ const handleNewChat = async (sessionId = null) => {
 
   setMessages(prev => [...prev, replyMessage]);
   
-  // Save reply message to database with explicit session ID
-  await saveMessageToSession(replyMessage, sessionId);
-  
   setIsLoading(true);
   setThinkingAdvisors([replyContext.persona_id]);
 
@@ -568,9 +536,6 @@ const handleNewChat = async (sessionId = null) => {
         timestamp: new Date()
       };
       setMessages(prev => [...prev, replyResponseMessage]);
-      
-      // Save advisor reply to database
-      await saveMessageToSession(replyResponseMessage, sessionId);
     }
 
   } catch (error) {
@@ -582,9 +547,6 @@ const handleNewChat = async (sessionId = null) => {
       timestamp: new Date()
     };
     setMessages(prev => [...prev, errorMessage]);
-    
-    // Save error message to database
-    await saveMessageToSession(errorMessage, sessionId);
   }
 
   setIsLoading(false);
@@ -615,9 +577,6 @@ const handleNewChat = async (sessionId = null) => {
     };
     setMessages(prev => [...prev, expandMessage]);
     
-    // Save expand request to database
-    await saveMessageToSession(expandMessage);
-    
     setIsLoading(true);
     setThinkingAdvisors([advisorId]);
 
@@ -629,7 +588,8 @@ const handleNewChat = async (sessionId = null) => {
         },
         body: JSON.stringify({
           user_input: expandPrompt,
-          response_length: 'long'
+          response_length: 'long',
+          chat_session_id: currentSessionId
         }),
       });
 
@@ -651,9 +611,6 @@ const handleNewChat = async (sessionId = null) => {
           timestamp: new Date()
         };
         setMessages(prev => [...prev, expandedMessage]);
-        
-        // Save expanded response to database
-        await saveMessageToSession(expandedMessage);
       } else {
         const errorMessage = {
           id: generateMessageId(),
@@ -662,9 +619,6 @@ const handleNewChat = async (sessionId = null) => {
           timestamp: new Date()
         };
         setMessages(prev => [...prev, errorMessage]);
-        
-        // Save error message to database
-        await saveMessageToSession(errorMessage);
       }
 
     } catch (error) {
@@ -676,9 +630,6 @@ const handleNewChat = async (sessionId = null) => {
         timestamp: new Date()
       };
       setMessages(prev => [...prev, errorMessage]);
-      
-      // Save error message to database
-      await saveMessageToSession(errorMessage);
     }
 
     setIsLoading(false);

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -507,7 +507,8 @@ const handleNewChat = async (sessionId = null) => {
   };
 
   setMessages(prev => [...prev, replyMessage]);
-  
+  setSidebarRefreshTrigger(prev => prev + 1);
+
   setIsLoading(true);
   setThinkingAdvisors([replyContext.persona_id]);
 
@@ -583,7 +584,8 @@ const handleNewChat = async (sessionId = null) => {
       expandsMessageId: messageId
     };
     setMessages(prev => [...prev, expandMessage]);
-    
+    setSidebarRefreshTrigger(prev => prev + 1);
+
     setIsLoading(true);
     setThinkingAdvisors([advisorId]);
 

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -188,8 +188,7 @@ const loadChatSession = async (sessionId) => {
         const formattedMessages = result.context.messages.map(msg => ({
           ...msg,
           timestamp: new Date(msg.timestamp),
-          persona_id: msg.persona_id || msg.advisor || msg.advisorId,
-          advisorName: msg.advisorName || msg.persona_name || 'Advisor'
+          persona_id: msg.persona_id || msg.advisor || msg.advisorId
         }));
         
         setMessages(formattedMessages);


### PR DESCRIPTION
# Description

Move all message persistence from the frontend to the backend. The frontend's `saveMessageToSession` function and its 9 call sites have been removed from `ChatPage.js`. The backend now persists every message type (advisor responses, replies, expand messages, document uploads) via `persist_message` in the relevant endpoints (`/chat-stream`, `/reply-to-advisor`, `/chat/{persona_id}`, `/upload-document`).

# Issues

- Closes #46 
- Related to #42

# Other Notes

- The `POST /api/chat-sessions/{id}/messages` endpoint still exists but is no longer called. TODO note added that it can be deprecated once we confirm all changes are working.