### PR TITLE
Feat/support hybrid model selection rebase

### DIFF
--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -13,7 +13,7 @@ from app.api.routes.chat_sessions import persist_message
 from app.api.utils import get_or_create_session_for_request_async
 from app.core.auth import get_current_active_user
 from app.config import get_settings
-from app.core.bootstrap import chat_orchestrator
+from app.core.bootstrap import chat_orchestrator, get_llm_client
 from app.core.database import get_database
 from app.core.persona_filter import get_available_persona_ids
 from app.core.session_manager import get_session_manager
@@ -23,6 +23,41 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 session_manager = get_session_manager()
+
+
+def resolve_llm_clients(user: User) -> Dict[str, Any]:
+    """Resolve LLM clients from a user's stored configuration.
+
+    Returns ``{"orchestrator": LLMClient | None, "personas": {id: LLMClient} | None}``.
+
+    - No saved config: both values are ``None``; callers fall back to
+      orchestrator/persona defaults.
+    - Uniform mode: the same cached client is returned for the orchestrator
+      and every persona.
+    - Hybrid mode: the orchestrator and each persona may receive different
+      clients based on the user's per-persona mapping.
+    """
+    config = user.llm_config
+    if config is None:
+        return {"orchestrator": None, "personas": None}
+
+    if config.mode == "uniform":
+        client = get_llm_client(config.default_backend)
+        persona_clients = {
+            pid: client for pid in chat_orchestrator.personas
+        }
+        return {"orchestrator": client, "personas": persona_clients}
+
+    # Hybrid mode
+    orchestrator_backend = config.orchestrator_backend or config.default_backend
+    orchestrator_client = get_llm_client(orchestrator_backend)
+
+    persona_clients = {}
+    for pid in chat_orchestrator.personas:
+        backend = (config.persona_backends or {}).get(pid, config.default_backend)
+        persona_clients[pid] = get_llm_client(backend)
+
+    return {"orchestrator": orchestrator_client, "personas": persona_clients}
 
 # Enhanced data models
 class UserInput(BaseModel):
@@ -81,6 +116,11 @@ async def chat_stream(
 
     async def _event_generator():
         try:
+            # Resolve per-user LLM clients from their stored config
+            llm_clients = resolve_llm_clients(current_user)
+            orchestrator_llm = llm_clients["orchestrator"]
+            persona_llms = llm_clients["personas"]
+
             # Load or create the in-memory session
             if message.chat_session_id:
                 sid = f"chat_{message.chat_session_id}"
@@ -106,8 +146,10 @@ async def chat_stream(
                     type="progress", data={"phase": "received"},
                 ).to_ndjson()
 
-            if await chat_orchestrator.needs_clarification_improved(session, message.user_input):
-                clar = await chat_orchestrator.generate_contextual_clarification(message.user_input)
+            if chat_orchestrator.needs_clarification(session, message.user_input):
+                clar = await chat_orchestrator.generate_contextual_clarification(
+                    message.user_input, llm_client=orchestrator_llm,
+                )
                 yield ChatStreamLine(
                     type="clarification",
                     data={
@@ -123,7 +165,9 @@ async def chat_stream(
 
             # If an enabled tool can handle this query, return its response
             # directly and skip persona generation.
-            tool_result = await chat_orchestrator.get_tool_response(message.user_input)
+            tool_result = await chat_orchestrator.get_tool_response(
+                message.user_input, llm_client=orchestrator_llm,
+            )
             if tool_result.used_tool:
                 # Append user message to in-memory session and persist to MongoDB
                 session.append_message("orchestrator", tool_result.text)
@@ -164,6 +208,7 @@ async def chat_stream(
             top_personas = await chat_orchestrator.get_top_personas(
                 session_id=sid,
                 allowed_ids=available,
+                llm_client=orchestrator_llm,
             )
 
             # Guard against race condition where all selected advisors
@@ -210,9 +255,11 @@ async def chat_stream(
                             "document_chunks_used": 0,
                         })
                         return
+                    persona_llm = (persona_llms or {}).get(pid)
                     result = await chat_orchestrator.generate_single_persona_response(
                         session, persona,
                         message.response_length or "medium",
+                        llm_client=persona_llm,
                     )
                     session.append_message(pid, result["response"])
                     await done_queue.put(result)
@@ -390,7 +437,10 @@ async def create_new_chat(
         raise HTTPException(status_code=500, detail="Failed to create new chat")
 
 @router.post("/chat/{persona_id}")
-async def chat_with_specific_advisor(persona_id: str, input: UserInput, request: Request):
+async def chat_with_specific_advisor(
+    persona_id: str, input: UserInput, request: Request,
+    current_user: User = Depends(get_current_active_user),
+):
     """Chat with a specific advisor - UPDATED"""
     try:
         if persona_id not in chat_orchestrator.personas:
@@ -408,11 +458,15 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
                     isExpandRequest=True,
                 ),
             )
+        
+        llm_clients = resolve_llm_clients(current_user)
+        persona_llm = (llm_clients["personas"] or {}).get(persona_id)
 
         result = await chat_orchestrator.chat_with_persona(
             user_input=input.user_input,
             persona_id=persona_id,
-            session_id=session_id
+            session_id=session_id,
+            llm_client=persona_llm,
         )
         
         # Handle response structure
@@ -479,7 +533,10 @@ async def chat_with_specific_advisor(persona_id: str, input: UserInput, request:
         }
 
 @router.post("/reply-to-advisor")
-async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
+async def reply_to_advisor(
+    reply: ReplyToAdvisor, request: Request,
+    current_user: User = Depends(get_current_active_user),
+):
     """Reply to a specific advisor with proper context - UPDATED"""
     try:
         if reply.advisor_id not in chat_orchestrator.personas:
@@ -520,10 +577,14 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
         if original_message:
             contextual_input = f"[Replying to your previous message: '{original_message[:100]}...'] {reply.user_input}"
         
+        llm_clients = resolve_llm_clients(current_user)
+        advisor_llm = (llm_clients["personas"] or {}).get(reply.advisor_id)
+
         result = await chat_orchestrator.chat_with_persona(
             user_input=contextual_input,
             persona_id=reply.advisor_id,
-            session_id=session_id
+            session_id=session_id,
+            llm_client=advisor_llm,
         )
         
         # Handle response structure
@@ -600,15 +661,22 @@ async def reply_to_advisor(reply: ReplyToAdvisor, request: Request):
         }
 
 @router.post("/ask/")
-async def ask_question(query: PersonaQuery, request: Request):
+async def ask_question(
+    query: PersonaQuery, request: Request,
+    current_user: User = Depends(get_current_active_user),
+):
     """Ask question - UPDATED"""
     try:
         session_id = await get_or_create_session_for_request_async(request)
         
+        llm_clients = resolve_llm_clients(current_user)
+        persona_llm = (llm_clients["personas"] or {}).get(query.persona)
+
         result = await chat_orchestrator.chat_with_persona(
             user_input=query.question,
             persona_id=query.persona,
-            session_id=session_id
+            session_id=session_id,
+            llm_client=persona_llm,
         )
         
         if result["type"] == "single_persona_response":

--- a/multi_llm_chatbot_backend/app/api/routes/chat.py
+++ b/multi_llm_chatbot_backend/app/api/routes/chat.py
@@ -146,7 +146,7 @@ async def chat_stream(
                     type="progress", data={"phase": "received"},
                 ).to_ndjson()
 
-            if chat_orchestrator.needs_clarification(session, message.user_input):
+            if await chat_orchestrator.needs_clarification_improved(session, message.user_input):
                 clar = await chat_orchestrator.generate_contextual_clarification(
                     message.user_input, llm_client=orchestrator_llm,
                 )

--- a/multi_llm_chatbot_backend/app/api/routes/provider.py
+++ b/multi_llm_chatbot_backend/app/api/routes/provider.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from app.core.auth import get_current_active_user
-from app.core.bootstrap import chat_orchestrator, get_llm_client
+from app.core.bootstrap import chat_orchestrator, get_llm_client, AVAILABLE_BACKENDS
 from app.core.database import get_database
-from app.models.user import User, UserLLMConfig, LLM_BACKENDS
+from app.models.user import User, UserLLMConfig
 import logging
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ async def get_current_provider(
     config = current_user.llm_config or UserLLMConfig()
     return {
         "llm_config": config.model_dump(),
-        "available_backends": list(LLM_BACKENDS),
+        "available_backends": AVAILABLE_BACKENDS,
     }
 
 

--- a/multi_llm_chatbot_backend/app/api/routes/provider.py
+++ b/multi_llm_chatbot_backend/app/api/routes/provider.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from app.core.auth import get_current_active_user
-from app.core.bootstrap import chat_orchestrator, get_llm_client, AVAILABLE_BACKENDS
+from app.core.bootstrap import (
+    chat_orchestrator, get_llm_client, AVAILABLE_BACKENDS, _is_backend_enabled,
+)
 from app.core.database import get_database
 from app.models.user import User, UserLLMConfig
 import logging
@@ -45,6 +47,11 @@ async def switch_provider(
         backends_to_check.update(llm_config.persona_backends.values())
 
     for backend in backends_to_check:
+        if not _is_backend_enabled(backend):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Backend {backend!r} is disabled by the administrator.",
+            )
         try:
             get_llm_client(backend)
         except Exception as exc:

--- a/multi_llm_chatbot_backend/app/api/routes/provider.py
+++ b/multi_llm_chatbot_backend/app/api/routes/provider.py
@@ -1,108 +1,65 @@
-from fastapi import APIRouter, Body, HTTPException
-from app.config import get_settings
-from app.llm.improved_gemini_client import ImprovedGeminiClient
-from app.llm.improved_ollama_client import ImprovedOllamaClient
-from app.llm.improved_vllm_client import ImprovedVllmClient
-from app.models.default_personas import get_default_personas
-from app.core.bootstrap import chat_orchestrator, llm, current_provider, available_providers
-from app.core.brainforge_sync import BRAINFORGE_PERSONA_PREFIX
-from pydantic import BaseModel
-import os
+from fastapi import APIRouter, Depends, HTTPException, status
+from app.core.auth import get_current_active_user
+from app.core.bootstrap import chat_orchestrator, get_llm_client
+from app.core.database import get_database
+from app.models.user import User, UserLLMConfig, LLM_BACKENDS
 import logging
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-def create_llm_client(provider: str = None):
-    global current_provider
-    if provider is None:
-        provider = current_provider
-
-    if provider == "gemini":
-        try:
-            return ImprovedGeminiClient(model_name=os.getenv("GEMINI_MODEL"))
-        except ValueError as e:
-            logger.warning(f"Gemini API key not found, falling back to Ollama: {e}")
-            return ImprovedOllamaClient(model_name="llama3.2:1b")
-    elif provider == "ollama":
-        return ImprovedOllamaClient(model_name="llama3.2:1b")
-    elif provider == "vllm":
-        settings = get_settings()
-        if not settings.llm.vllm.api_url:
-            raise ValueError("No vLLM endpoint configured. Set llm.vllm.api_url in your config.")
-        return ImprovedVllmClient(
-            api_url=settings.llm.vllm.api_url,
-            api_key=settings.llm.vllm.api_key,
-        )
-    else:
-        raise ValueError(f"Unknown provider: {provider}")
-
-# Initialize LLM and personas
-llm = create_llm_client(current_provider)
-DEFAULT_PERSONAS = get_default_personas(llm)
-for persona in DEFAULT_PERSONAS:
-    chat_orchestrator.register_persona(persona)
-
-class ProviderSwitch(BaseModel):
-    provider: str
 
 @router.get("/current-provider")
-async def get_current_provider():
+async def get_current_provider(
+    current_user: User = Depends(get_current_active_user),
+):
+    """Return the authenticated user's LLM configuration."""
+    config = current_user.llm_config or UserLLMConfig()
     return {
-        "current_provider": current_provider,
-        "available_providers": available_providers,
-        "model_info": {
-            "name": llm.model_name if hasattr(llm, 'model_name') else "gemini-2.0-flash",
-            "provider": current_provider
-        }
+        "llm_config": config.model_dump(),
+        "available_backends": list(LLM_BACKENDS),
     }
 
+
 @router.post("/switch-provider")
-async def switch_provider(provider_data: ProviderSwitch):
-    global current_provider, llm
+async def switch_provider(
+    llm_config: UserLLMConfig,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Persist the user's LLM configuration to their profile."""
+    if llm_config.mode == "hybrid" and llm_config.persona_backends:
+        registered = set(chat_orchestrator.personas.keys())
+        unknown = set(llm_config.persona_backends.keys()) - registered
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown persona IDs: {sorted(unknown)}. "
+                       f"Valid IDs: {sorted(registered)}",
+            )
 
-    if provider_data.provider not in available_providers:
-        raise HTTPException(status_code=400, detail=f"Unknown provider: {provider_data.provider}. Available: {available_providers}")
+    backends_to_check = {llm_config.default_backend}
+    if llm_config.orchestrator_backend:
+        backends_to_check.add(llm_config.orchestrator_backend)
+    if llm_config.persona_backends:
+        backends_to_check.update(llm_config.persona_backends.values())
 
-    try:
-        current_provider = provider_data.provider
-        new_llm = create_llm_client(current_provider)
-        llm = new_llm
+    for backend in backends_to_check:
+        try:
+            get_llm_client(backend)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Backend {backend!r} is not configured: {exc}",
+            )
 
-        chat_orchestrator.llm_client = new_llm
+    db = get_database()
+    await db.users.update_one(
+        {"_id": current_user.id},
+        {"$set": {"llm_config": llm_config.model_dump()}},
+    )
 
-        new_personas = get_default_personas(new_llm)
-        # Clear only non-BrainForge personas; BF advisors have their own LLM clients
-        non_bf_ids = [pid for pid in chat_orchestrator.personas if not pid.startswith(f"{BRAINFORGE_PERSONA_PREFIX}_")]
-        for pid in non_bf_ids:
-            chat_orchestrator.unregister_persona(pid)
-        for persona in new_personas:
-            chat_orchestrator.register_persona(persona)
-
-        return {
-            "message": f"Successfully switched to {current_provider}",
-            "current_provider": current_provider,
-            "model_info": {
-                "name": new_llm.model_name if hasattr(new_llm, 'model_name') else "gemini-2.0-flash",
-                "provider": current_provider
-            }
-        }
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to switch to {provider_data.provider}: {str(e)}")
-
-@router.post("/switch-model")
-async def switch_model(model_name: str = Body(...)):
-    if "gemini" in model_name.lower():
-        return await switch_provider(ProviderSwitch(provider="gemini"))
-    else:
-        return await switch_provider(ProviderSwitch(provider="ollama"))
-
-@router.get("/current-model")
-async def get_current_model():
-    model_name = llm.model_name if hasattr(llm, 'model_name') else "gemini-2.0-flash"
     return {
-        "model": model_name,
-        "provider": current_provider
+        "message": "LLM configuration updated",
+        "llm_config": llm_config.model_dump(),
     }

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -294,6 +294,7 @@ class LLMConfig(BaseModel):
     ollama: OllamaConfig = OllamaConfig()
     vllm: VllmConfig = VllmConfig()
     brainforge: BrainForgeConfig = BrainForgeConfig()
+    health_check_interval: int = 300
 
 
 class RAGConfig(BaseModel):

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -253,6 +253,7 @@ class MongoDBConfig(BaseModel):
 
 
 class GeminiConfig(BaseModel):
+    enabled: bool = True
     api_key: str = Field(default=os.getenv("GEMINI_API_KEY"))
     model: str = "gemini-2.5-flash"
 
@@ -272,12 +273,14 @@ class GeminiConfig(BaseModel):
 
 
 class OllamaConfig(BaseModel):
+    enabled: bool = True
     model: str = "llama3.2:1b"
     # TODO: Drop support for `OLLAMA_BASE_URL` envvar handling
     base_url: str = Field(default=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"))
 
 
 class VllmConfig(BaseModel):
+    enabled: bool = True
     api_url: str = ""
     api_key: str = Field(default=os.getenv("VLLM_API_KEY", ""))
 

--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -293,11 +293,12 @@ class BrainForgeConfig(BaseModel):
 
 
 class LLMConfig(BaseModel):
+    default_backend: str = ""
     gemini: GeminiConfig = GeminiConfig()
     ollama: OllamaConfig = OllamaConfig()
     vllm: VllmConfig = VllmConfig()
     brainforge: BrainForgeConfig = BrainForgeConfig()
-    health_check_interval: int = 300
+    health_check_interval_seconds: int = 300
 
 
 class RAGConfig(BaseModel):

--- a/multi_llm_chatbot_backend/app/core/bootstrap.py
+++ b/multi_llm_chatbot_backend/app/core/bootstrap.py
@@ -5,18 +5,26 @@ from app.llm.improved_ollama_client import ImprovedOllamaClient
 from app.llm.improved_vllm_client import ImprovedVllmClient
 from app.core.improved_orchestrator import ImprovedChatOrchestrator
 from app.models.default_personas import get_default_personas
+from app.models.user import LLM_BACKENDS
+from app.llm.llm_client import LLMClient
 
 settings = get_settings()
 
-current_provider = "gemini"
-available_providers = ["ollama", "gemini", "vllm"]
+DEFAULT_BACKEND = "gemini"
 
-def create_llm_client(provider=None):
-    if provider is None:
-        provider = current_provider
-    if provider == "gemini":
+
+_client_cache = {}
+
+
+def create_llm_client(backend: str = DEFAULT_BACKEND):
+    """Create an LLM client for the given backend name."""
+    if backend not in LLM_BACKENDS:
+        raise ValueError(
+            f"Unknown backend {backend!r}. Must be one of {LLM_BACKENDS}"
+        )
+    if backend == "gemini":
         return ImprovedGeminiClient(model_name=settings.llm.gemini.model)
-    elif provider == "vllm":
+    elif backend == "vllm":
         if not settings.llm.vllm.api_url:
             raise ValueError("No vLLM endpoint configured. Set llm.vllm.api_url in your config.")
         return ImprovedVllmClient(
@@ -29,7 +37,16 @@ def create_llm_client(provider=None):
             base_url=settings.llm.ollama.base_url,
         )
 
+
+def get_llm_client(backend: str) -> LLMClient:
+    """Return a cached LLM client for *backend*, creating it on first access."""
+    if backend not in _client_cache:
+        _client_cache[backend] = create_llm_client(backend)
+    return _client_cache[backend]
+
+
 llm = create_llm_client()
+_client_cache[DEFAULT_BACKEND] = llm
 chat_orchestrator = ImprovedChatOrchestrator(llm_client=llm)
 
 DEFAULT_PERSONAS = get_default_personas(llm)

--- a/multi_llm_chatbot_backend/app/core/bootstrap.py
+++ b/multi_llm_chatbot_backend/app/core/bootstrap.py
@@ -1,4 +1,6 @@
 # app/core/bootstrap.py
+import asyncio
+
 from app.config import get_settings
 from app.llm.improved_gemini_client import ImprovedGeminiClient
 from app.llm.improved_ollama_client import ImprovedOllamaClient
@@ -45,8 +47,42 @@ def get_llm_client(backend: str) -> LLMClient:
     return _client_cache[backend]
 
 
+def get_available_backends() -> list:
+    """Return backends that are properly configured (sync, used at startup)."""
+    available = []
+    for backend in LLM_BACKENDS:
+        try:
+            get_llm_client(backend)
+            available.append(backend)
+        except Exception:
+            pass
+    return available
+
+
+async def refresh_available_backends():
+    """Re-check which backends are configured and reachable."""
+    available = []
+    for backend in LLM_BACKENDS:
+        try:
+            client = get_llm_client(backend)
+            if await client.health_check():
+                available.append(backend)
+        except Exception:
+            pass
+    AVAILABLE_BACKENDS[:] = available
+
+
+async def _backend_health_loop():
+    """Background task that periodically refreshes AVAILABLE_BACKENDS."""
+    interval = settings.llm.health_check_interval
+    while True:
+        await refresh_available_backends()
+        await asyncio.sleep(interval)
+
+
 llm = create_llm_client()
 _client_cache[DEFAULT_BACKEND] = llm
+AVAILABLE_BACKENDS = get_available_backends()
 chat_orchestrator = ImprovedChatOrchestrator(llm_client=llm)
 
 DEFAULT_PERSONAS = get_default_personas(llm)

--- a/multi_llm_chatbot_backend/app/core/bootstrap.py
+++ b/multi_llm_chatbot_backend/app/core/bootstrap.py
@@ -1,5 +1,6 @@
 # app/core/bootstrap.py
 import asyncio
+import logging
 
 from app.config import get_settings
 from app.llm.improved_gemini_client import ImprovedGeminiClient
@@ -10,15 +11,17 @@ from app.models.default_personas import get_default_personas
 from app.models.user import LLM_BACKENDS
 from app.llm.llm_client import LLMClient
 
-settings = get_settings()
+logger = logging.getLogger(__name__)
 
-_PREFERRED_BACKEND = "gemini"
+settings = get_settings()
 
 _client_cache = {}
 
 
-def create_llm_client(backend: str = _PREFERRED_BACKEND):
+def create_llm_client(backend: str = None):
     """Create an LLM client for the given backend name."""
+    if backend is None:
+        backend = settings.llm.default_backend
     if backend not in LLM_BACKENDS:
         raise ValueError(
             f"Unknown backend {backend!r}. Must be one of {LLM_BACKENDS}"
@@ -83,18 +86,22 @@ async def refresh_available_backends():
 
 async def _backend_health_loop():
     """Background task that periodically refreshes AVAILABLE_BACKENDS."""
-    interval = settings.llm.health_check_interval
+    interval = settings.llm.health_check_interval_seconds
     while True:
         await refresh_available_backends()
         await asyncio.sleep(interval)
 
 
-# Resolve the default backend: prefer _PREFERRED_BACKEND, but fall back to the first available.
+# Resolve the default backend: prefer the configured default, fall back to the first available.
 AVAILABLE_BACKENDS = get_available_backends()
-if _PREFERRED_BACKEND in AVAILABLE_BACKENDS:
-    DEFAULT_BACKEND = _PREFERRED_BACKEND
+if settings.llm.default_backend in AVAILABLE_BACKENDS:
+    DEFAULT_BACKEND = settings.llm.default_backend
 elif AVAILABLE_BACKENDS:
     DEFAULT_BACKEND = AVAILABLE_BACKENDS[0]
+    logger.warning(
+        "Configured default_backend %r is not available; falling back to %r",
+        settings.llm.default_backend, DEFAULT_BACKEND,
+    )
 else:
     raise RuntimeError(
         "No LLM backends are available. Check your config.yaml — "

--- a/multi_llm_chatbot_backend/app/core/bootstrap.py
+++ b/multi_llm_chatbot_backend/app/core/bootstrap.py
@@ -12,13 +12,12 @@ from app.llm.llm_client import LLMClient
 
 settings = get_settings()
 
-DEFAULT_BACKEND = "gemini"
-
+_PREFERRED_BACKEND = "gemini"
 
 _client_cache = {}
 
 
-def create_llm_client(backend: str = DEFAULT_BACKEND):
+def create_llm_client(backend: str = _PREFERRED_BACKEND):
     """Create an LLM client for the given backend name."""
     if backend not in LLM_BACKENDS:
         raise ValueError(
@@ -47,10 +46,18 @@ def get_llm_client(backend: str) -> LLMClient:
     return _client_cache[backend]
 
 
+def _is_backend_enabled(backend: str) -> bool:
+    """Check whether *backend* is enabled in the admin config."""
+    backend_config = getattr(settings.llm, backend, None)
+    return getattr(backend_config, "enabled", True)
+
+
 def get_available_backends() -> list:
-    """Return backends that are properly configured (sync, used at startup)."""
+    """Return backends that are enabled and properly configured (sync, used at startup)."""
     available = []
     for backend in LLM_BACKENDS:
+        if not _is_backend_enabled(backend):
+            continue
         try:
             get_llm_client(backend)
             available.append(backend)
@@ -60,9 +67,11 @@ def get_available_backends() -> list:
 
 
 async def refresh_available_backends():
-    """Re-check which backends are configured and reachable."""
+    """Re-check which backends are enabled, configured, and reachable."""
     available = []
     for backend in LLM_BACKENDS:
+        if not _is_backend_enabled(backend):
+            continue
         try:
             client = get_llm_client(backend)
             if await client.health_check():
@@ -80,9 +89,19 @@ async def _backend_health_loop():
         await asyncio.sleep(interval)
 
 
-llm = create_llm_client()
-_client_cache[DEFAULT_BACKEND] = llm
+# Resolve the default backend: prefer _PREFERRED_BACKEND, but fall back to the first available.
 AVAILABLE_BACKENDS = get_available_backends()
+if _PREFERRED_BACKEND in AVAILABLE_BACKENDS:
+    DEFAULT_BACKEND = _PREFERRED_BACKEND
+elif AVAILABLE_BACKENDS:
+    DEFAULT_BACKEND = AVAILABLE_BACKENDS[0]
+else:
+    raise RuntimeError(
+        "No LLM backends are available. Check your config.yaml — "
+        "at least one backend must be enabled and properly configured."
+    )
+llm = create_llm_client(DEFAULT_BACKEND)
+_client_cache[DEFAULT_BACKEND] = llm
 chat_orchestrator = ImprovedChatOrchestrator(llm_client=llm)
 
 DEFAULT_PERSONAS = get_default_personas(llm)

--- a/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
+++ b/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
@@ -45,7 +45,8 @@ class ImprovedChatOrchestrator:
         """List all available persona IDs"""
         return list(self.personas.keys())
 
-    async def get_tool_response(self, user_message: str) -> ToolCallResult:
+    async def get_tool_response(self, user_message: str,
+                               llm_client: LLMClient = None) -> ToolCallResult:
         """Check whether a tool can handle *user_message*.
 
         If tools are disabled in config, no LLM client is available, or the
@@ -53,7 +54,8 @@ class ImprovedChatOrchestrator:
         ``ToolCallResult(used_tool=False)``.  Otherwise executes the tool and
         returns the grounded response with ``used_tool=True``.
         """
-        if self.llm_client is None:
+        effective_llm = llm_client or self.llm_client
+        if effective_llm is None:
             return ToolCallResult(text="", used_tool=False)
 
         settings = get_settings()
@@ -80,7 +82,7 @@ class ImprovedChatOrchestrator:
             "to present structured data like course listings or professor ratings."
         )
 
-        return await self.llm_client.generate_with_tools(
+        return await effective_llm.generate_with_tools(
             system_prompt=system_prompt,
             user_message=user_message,
             tool_definitions=tool_definitions,
@@ -325,7 +327,9 @@ class ImprovedChatOrchestrator:
         logger.warning("Falling back to rule-based clarification check")
         return self.needs_clarification(session, user_input)
 
-    async def generate_contextual_clarification(self, user_input: str) -> Dict[str, Any]:
+    
+    async def generate_contextual_clarification(self, user_input: str,
+                                               llm_client: LLMClient = None) -> Dict[str, Any]:
         """
         Use the LLM to produce a clarification question and clickable
         suggestions that are tailored to what the user actually typed.
@@ -355,10 +359,8 @@ class ImprovedChatOrchestrator:
         )
 
         try:
-            # Use the orchestrator's own LLM rather than a persona's — BrainForge
-            # persona LLMs may not support the prompt format used here.
-            llm = self.llm_client
-            raw = await llm.generate(
+            effective_llm = llm_client or self.llm_client
+            raw = await effective_llm.generate(
                 system_prompt=system_prompt,
                 context=[{"role": "user", "content": user_prompt}],
                 temperature=0.4,
@@ -391,9 +393,14 @@ class ImprovedChatOrchestrator:
             "suggestions": fallback_suggestions,
         }
     
-    async def generate_persona_responses(self, session: ConversationContext, response_length: str = "medium"):
+    async def generate_persona_responses(self, session: ConversationContext,
+                                        response_length: str = "medium",
+                                        llm_clients: Dict[str, LLMClient] = None):
         """
-        Generate responses from all personas with enhanced RAG integration
+        Generate responses from all personas with enhanced RAG integration.
+
+        *llm_clients* maps persona IDs to the LLM client each should use.
+        Personas not present in the dict fall back to their default client.
         """
         responses = []
         
@@ -401,7 +408,10 @@ class ImprovedChatOrchestrator:
             logger.info(f"Generating response for {persona_id} with enhanced RAG")
             
             # Generate persona response with enhanced RAG
-            response_data = await self.generate_single_persona_response(session, persona, response_length)
+            persona_llm = (llm_clients or {}).get(persona_id)
+            response_data = await self.generate_single_persona_response(
+                session, persona, response_length, llm_client=persona_llm,
+            )
             
             # Add persona response to session context
             session.append_message(persona_id, response_data["response"])
@@ -410,9 +420,14 @@ class ImprovedChatOrchestrator:
         
         return responses
     
-    async def generate_single_persona_response(self, session, persona, response_length: str = "medium"):
+    async def generate_single_persona_response(self, session, persona,
+                                               response_length: str = "medium",
+                                               llm_client: LLMClient = None):
         """
-        Enhanced version - Generate response from a single persona with enhanced RAG integration
+        Enhanced version - Generate response from a single persona with enhanced RAG integration.
+
+        *llm_client* is forwarded to ``persona.respond()``; when ``None`` the
+        persona uses its default (system-default) client.
         """
         try:
             # Get the user's latest message for document retrieval
@@ -441,7 +456,7 @@ class ImprovedChatOrchestrator:
             )
             
             # Generate response with enhanced context
-            response = await persona.respond(enhanced_context, response_length)
+            response = await persona.respond(enhanced_context, response_length, llm=llm_client)
             
             # Validate and improve response quality
             if not self._is_valid_response(response, persona.id):
@@ -813,9 +828,13 @@ When analyzing the document context:
         """
         return self._get_enhanced_persona_context_keywords(persona_id)
     
-    async def chat_with_persona(self, user_input: str, persona_id: str, session_id: str, response_length: str = "medium") -> Dict[str, Any]:
+    async def chat_with_persona(self, user_input: str, persona_id: str,
+                               session_id: str, response_length: str = "medium",
+                               llm_client: LLMClient = None) -> Dict[str, Any]:
         """
-        Chat with a specific persona directly - FIXED for consistent document access
+        Chat with a specific persona directly - FIXED for consistent document access.
+
+        *llm_client* is forwarded to the persona's response generation.
         """
         try:
             persona = self.get_persona(persona_id)
@@ -838,7 +857,9 @@ When analyzing the document context:
             logger.info(f"Generating response for {persona_id} with session {session_id}")
             
             # Generate response from single persona using consistent session ID
-            response_data = await self.generate_single_persona_response(session, persona, response_length)
+            response_data = await self.generate_single_persona_response(
+                session, persona, response_length, llm_client=llm_client,
+            )
             
             # Add response to session
             session.append_message(persona_id, response_data["response"])
@@ -884,7 +905,8 @@ When analyzing the document context:
         
 
     async def get_top_personas(self, session_id: str, k: int = 3,
-                              allowed_ids: Optional[List[str]] = None) -> List[str]:
+                              allowed_ids: Optional[List[str]] = None,
+                              llm_client: LLMClient = None) -> List[str]:
         """
         Use the LLM to rank personas based on current session context.
         Falls back to default persona order if LLM fails or returns invalid data.
@@ -902,9 +924,7 @@ When analyzing the document context:
                 logger.warning("No personas available after filtering.")
                 return []
 
-            # Use the orchestrator's own LLM rather than a persona's — BrainForge
-            # persona LLMs may not support the prompt format used here.
-            llm = self.llm_client
+            effective_llm = llm_client or self.llm_client
 
             # Use recent conversation context (last 5 messages)
             recent_context = "\n".join(
@@ -935,7 +955,7 @@ When analyzing the document context:
                         {persona_descriptions}
                       """.strip()
 
-            llm_response = await llm.generate(
+            llm_response = await effective_llm.generate(
                 system_prompt=f"You are an assistant that selects the best advisors for a user of {app_title}.",
                 context=[{"role": "user", "content": prompt}],
                 temperature=0.4,

--- a/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
+++ b/multi_llm_chatbot_backend/app/core/improved_orchestrator.py
@@ -327,7 +327,6 @@ class ImprovedChatOrchestrator:
         logger.warning("Falling back to rule-based clarification check")
         return self.needs_clarification(session, user_input)
 
-    
     async def generate_contextual_clarification(self, user_input: str,
                                                llm_client: LLMClient = None) -> Dict[str, Any]:
         """

--- a/multi_llm_chatbot_backend/app/llm/improved_ollama_client.py
+++ b/multi_llm_chatbot_backend/app/llm/improved_ollama_client.py
@@ -111,3 +111,11 @@ class ImprovedOllamaClient(LLMClient):
             response.count("?") > 3,  # Too many questions
         ]
         return any(poor_indicators)
+
+    async def health_check(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(f"{self.base_url}/api/tags")
+                return resp.is_success
+        except Exception:
+            return False

--- a/multi_llm_chatbot_backend/app/llm/improved_vllm_client.py
+++ b/multi_llm_chatbot_backend/app/llm/improved_vllm_client.py
@@ -187,4 +187,14 @@ class ImprovedVllmClient(LLMClient):
                 used_tool=False,
             )
 
+    async def health_check(self) -> bool:
+        import httpx
+        try:
+            headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(f"{self.api_url}/v1/models", headers=headers)
+                return resp.is_success
+        except Exception:
+            return False
+
 

--- a/multi_llm_chatbot_backend/app/llm/llm_client.py
+++ b/multi_llm_chatbot_backend/app/llm/llm_client.py
@@ -67,6 +67,15 @@ class LLMClient(ABC):
         )
         return ToolCallResult(text=text, used_tool=False)
 
+    async def health_check(self) -> bool:
+        """Check if the backend service is reachable.
+
+        Subclasses for self-hosted services should override this with a
+        lightweight network probe.  The default returns True (suitable for
+        cloud APIs where the config check is sufficient).
+        """
+        return True
+
     def _clean_response(self, response: str) -> str:
         """Clean up response text, preserving Markdown formatting."""
         response = response.replace("\r\n", "\n").replace("\r", "\n")

--- a/multi_llm_chatbot_backend/app/main.py
+++ b/multi_llm_chatbot_backend/app/main.py
@@ -11,6 +11,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 
+import asyncio
+
 # Load configuration FIRST so every module can use it
 from app.config import load_settings
 from app.version import __version__
@@ -18,6 +20,7 @@ settings = load_settings()
 
 # Import the new database functions
 from app.core.database import connect_to_mongo, close_mongo_connection
+from app.core.bootstrap import _backend_health_loop
 
 # Import all route modules
 from app.api.routes import router as main_router
@@ -41,9 +44,11 @@ async def lifespan(app: FastAPI):
     from app.core.brainforge_sync import async_sync_brainforge_personas, periodic_sync_loop
     await async_sync_brainforge_personas(chat_orchestrator)
     sync_task = asyncio.create_task(periodic_sync_loop(chat_orchestrator))
+    health_task = asyncio.create_task(_backend_health_loop())
     yield
     # Shutdown
     sync_task.cancel()
+    health_task.cancel()
     await close_mongo_connection()
 
 app = FastAPI(

--- a/multi_llm_chatbot_backend/app/main.py
+++ b/multi_llm_chatbot_backend/app/main.py
@@ -124,6 +124,8 @@ def get_public_config():
             "dark_color": colors["dark_color"],
             "dark_bg_color": colors["dark_bg_color"],
             "image": "icon://Brain",
+            "backend_locked": True,
+            "default_backend": "brainforge",
         })
 
     return config

--- a/multi_llm_chatbot_backend/app/models/persona.py
+++ b/multi_llm_chatbot_backend/app/models/persona.py
@@ -245,10 +245,14 @@ class Persona:
         self.llm = llm
         self.temperature = temperature
 
-    async def respond(self, context: List[Dict], response_length: str = "medium") -> str:
+    async def respond(self, context: List[Dict], response_length: str = "medium",
+                      llm: LLMClient = None) -> str:
         """Generate a compact, well-formed Markdown response suitable for the UI.
-        Returns the compact Markdown string (backward compatible with previous callers).
+
+        *llm* overrides the default client for this call (used for per-user
+        backend selection).  Falls back to ``self.llm`` when not provided.
         """
+        effective_llm = llm or self.llm
         max_tokens = MAX_TOKENS_MAP.get(response_length, 500)
         structure_hint = STRUCTURE_HINTS.get(response_length, STRUCTURE_HINTS["medium"])
         temp_scaled = round(self.temperature / 10, 2)
@@ -259,7 +263,7 @@ class Persona:
             f"{structure_hint}"
         )
 
-        raw_text = await self.llm.generate(
+        raw_text = await effective_llm.generate(
             system_prompt=full_prompt,
             context=context,
             temperature=temp_scaled,

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -25,10 +25,7 @@ class UserLLMConfig(BaseModel):
     def _validate_hybrid_fields(self):
         if self.mode == "hybrid":
             if not self.orchestrator_backend and not self.persona_backends:
-                raise ValueError(
-                    "hybrid mode requires at least one of "
-                    "orchestrator_backend or persona_backends"
-                )
+                self.orchestrator_backend = self.default_backend
         else:
             self.orchestrator_backend = None
             self.persona_backends = None

--- a/multi_llm_chatbot_backend/app/models/user.py
+++ b/multi_llm_chatbot_backend/app/models/user.py
@@ -1,7 +1,38 @@
 from pydantic import BaseModel, EmailStr, Field, ConfigDict, model_validator
-from typing import Literal, Optional, List, Any
+from typing import Dict, Literal, Optional, List, Any, get_args
 from datetime import datetime
 from bson import ObjectId
+
+BackendName = Literal["gemini", "ollama", "vllm"]
+LLM_BACKENDS = get_args(BackendName)
+
+
+class UserLLMConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    """Per-user LLM provider configuration.
+
+    Uniform mode:  all advisors and the orchestrator use ``default_backend``.
+    Hybrid mode:   each advisor can use a different backend; ``default_backend``
+                   is the fallback for any persona not explicitly mapped.
+    """
+    mode: Literal["uniform", "hybrid"] = "uniform"
+    default_backend: BackendName = "gemini"
+    orchestrator_backend: Optional[BackendName] = None
+    persona_backends: Optional[Dict[str, BackendName]] = None
+
+    @model_validator(mode="after")
+    def _validate_hybrid_fields(self):
+        if self.mode == "hybrid":
+            if not self.orchestrator_backend and not self.persona_backends:
+                raise ValueError(
+                    "hybrid mode requires at least one of "
+                    "orchestrator_backend or persona_backends"
+                )
+        else:
+            self.orchestrator_backend = None
+            self.persona_backends = None
+        return self
 
 class PyObjectId(ObjectId):
     @classmethod
@@ -48,6 +79,7 @@ class User(BaseModel):
     academicStage: Optional[str] = None
     researchArea: Optional[str] = None
     disabled_advisors: Optional[List[str]] = None
+    llm_config: Optional[UserLLMConfig] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     last_login: Optional[datetime] = None
     is_active: bool = True

--- a/multi_llm_chatbot_backend/app/tests/unit/conftest.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/conftest.py
@@ -1,20 +1,18 @@
-"""Session-wide stubs for modules that do heavy work at import time.
+"""Session-wide stubs for heavy-import modules.
 
-``app.api.routes.__init__`` eagerly imports every sibling route, and
-``app.api.routes.provider`` instantiates real LLM clients at module
-load.  ``app.core.bootstrap`` and ``app.core.rag_manager`` likewise
-start NLTK, ChromaDB, and the LLM stack the moment they are imported.
+``app.core.rag_manager`` starts NLTK / ChromaDB the moment it is
+imported, so we replace it with a ``MagicMock`` before any test is
+collected.
 
-We install harmless ``MagicMock`` substitutes for those modules once,
-before any test file in this directory is collected, so every test
-gets a consistent, importable view of ``app.api.routes`` without
-having to reproduce the same stubbing recipe in every test module.
+``app.core.bootstrap`` (and the route modules that import it) can load
+normally because we pre-set ``GEMINI_API_KEY`` and ``CONFIG_PATH``
+before any import occurs.  This lets ``get_settings()``, the LLM-client
+constructors, and the orchestrator initialise without real credentials
+or config files.
 
-Tests that want to exercise the real version of a specific route
-module (for example, ``test_version.py`` wanting the real
-``app.api.routes.root``) can still pop their target out of
-``sys.modules`` in their own setup -- they no longer have to
-coordinate cleanup with peer test modules.
+Route modules that are *not* under direct test (documents, sessions,
+debug, phd_canvas) are still replaced with lightweight stubs so their
+dependency trees are never pulled in.
 """
 
 import os
@@ -26,15 +24,15 @@ from fastapi import APIRouter
 os.environ.setdefault("GEMINI_API_KEY", "fake-test-key")
 os.environ.setdefault("CONFIG_PATH", "")
 
-for _name in ("app.core.bootstrap", "app.core.rag_manager"):
-    sys.modules.setdefault(_name, MagicMock())
+# rag_manager triggers NLTK / ChromaDB on import — always stub it.
+sys.modules.setdefault("app.core.rag_manager", MagicMock())
 
+# Stub route modules that are NOT under direct test to avoid pulling
+# in their full dependency trees when app.api.routes.__init__ runs.
 _stub_router_module = MagicMock(router=APIRouter())
 for _name in (
-    "app.api.routes.chat",
     "app.api.routes.documents",
     "app.api.routes.sessions",
-    "app.api.routes.provider",
     "app.api.routes.debug",
     "app.api.routes.phd_canvas",
 ):

--- a/multi_llm_chatbot_backend/app/tests/unit/conftest.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/conftest.py
@@ -17,11 +17,14 @@ module (for example, ``test_version.py`` wanting the real
 coordinate cleanup with peer test modules.
 """
 
+import os
 import sys
 from unittest.mock import MagicMock
 
 from fastapi import APIRouter
 
+os.environ.setdefault("GEMINI_API_KEY", "fake-test-key")
+os.environ.setdefault("CONFIG_PATH", "")
 
 for _name in ("app.core.bootstrap", "app.core.rag_manager"):
     sys.modules.setdefault(_name, MagicMock())

--- a/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
@@ -13,6 +13,7 @@ os.environ.setdefault("CONFIG_PATH", "")
 # in a unit-test environment (no real LLM connections, no NLTK, etc.)
 for _name in ("app.core.rag_manager",):
     sys.modules.setdefault(_name, MagicMock())
+sys.modules.pop("app.core.bootstrap", None)
 
 # Patch the Gemini client constructor so creating a client doesn't fail
 with patch("app.llm.improved_gemini_client.ImprovedGeminiClient.__init__", lambda self, **kw: None):

--- a/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
@@ -1,0 +1,105 @@
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Set env vars before any app modules are imported so that config
+# validators don't raise during the bootstrap import chain.
+os.environ.setdefault("GEMINI_API_KEY", "fake-test-key")
+os.environ.setdefault("CONFIG_PATH", "")
+
+# Stub heavy modules that bootstrap imports which would fail or be slow
+# in a unit-test environment (no real LLM connections, no NLTK, etc.)
+for _name in ("app.core.rag_manager",):
+    sys.modules.setdefault(_name, MagicMock())
+
+# Patch the Gemini client constructor so creating a client doesn't fail
+with patch("app.llm.improved_gemini_client.ImprovedGeminiClient.__init__", lambda self, **kw: None):
+    from app.core.bootstrap import (  # noqa: E402
+        get_available_backends,
+        refresh_available_backends,
+        AVAILABLE_BACKENDS,
+        LLM_BACKENDS,
+    )
+
+
+class TestGetAvailableBackends(unittest.TestCase):
+    """Sync config-only check used at startup."""
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_all_configured(self, mock_get_client):
+        mock_get_client.return_value = MagicMock()
+        result = get_available_backends()
+        self.assertEqual(result, ["gemini", "ollama", "vllm"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_vllm_not_configured(self, mock_get_client):
+        def side_effect(backend):
+            if backend == "vllm":
+                raise ValueError("No vLLM endpoint configured.")
+            return MagicMock()
+        mock_get_client.side_effect = side_effect
+        result = get_available_backends()
+        self.assertEqual(result, ["gemini", "ollama"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_none_configured(self, mock_get_client):
+        mock_get_client.side_effect = ValueError("not configured")
+        result = get_available_backends()
+        self.assertEqual(result, [])
+
+
+class TestRefreshAvailableBackends(unittest.TestCase):
+    """Async health-check refresh."""
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_all_healthy(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.health_check = AsyncMock(return_value=True)
+        mock_get_client.return_value = mock_client
+
+        asyncio.run(refresh_available_backends())
+        self.assertEqual(list(AVAILABLE_BACKENDS), ["gemini", "ollama", "vllm"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_vllm_unhealthy(self, mock_get_client):
+        def side_effect(backend):
+            client = MagicMock()
+            client.health_check = AsyncMock(return_value=(backend != "vllm"))
+            return client
+        mock_get_client.side_effect = side_effect
+
+        asyncio.run(refresh_available_backends())
+        self.assertEqual(list(AVAILABLE_BACKENDS), ["gemini", "ollama"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_health_check_exception(self, mock_get_client):
+        def side_effect(backend):
+            client = MagicMock()
+            if backend == "ollama":
+                client.health_check = AsyncMock(side_effect=Exception("timeout"))
+            else:
+                client.health_check = AsyncMock(return_value=True)
+            return client
+        mock_get_client.side_effect = side_effect
+
+        asyncio.run(refresh_available_backends())
+        self.assertEqual(list(AVAILABLE_BACKENDS), ["gemini", "vllm"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_unconfigured_backend_excluded(self, mock_get_client):
+        def side_effect(backend):
+            if backend == "vllm":
+                raise ValueError("No vLLM endpoint configured.")
+            client = MagicMock()
+            client.health_check = AsyncMock(return_value=True)
+            return client
+        mock_get_client.side_effect = side_effect
+
+        asyncio.run(refresh_available_backends())
+        self.assertEqual(list(AVAILABLE_BACKENDS), ["gemini", "ollama"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
@@ -1,28 +1,13 @@
 import asyncio
-import os
-import sys
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# Set env vars before any app modules are imported so that config
-# validators don't raise during the bootstrap import chain.
-os.environ.setdefault("GEMINI_API_KEY", "fake-test-key")
-os.environ.setdefault("CONFIG_PATH", "")
-
-# Stub heavy modules that bootstrap imports which would fail or be slow
-# in a unit-test environment (no real LLM connections, no NLTK, etc.)
-for _name in ("app.core.rag_manager",):
-    sys.modules.setdefault(_name, MagicMock())
-sys.modules.pop("app.core.bootstrap", None)
-
-# Patch the Gemini client constructor so creating a client doesn't fail
-with patch("app.llm.improved_gemini_client.ImprovedGeminiClient.__init__", lambda self, **kw: None):
-    from app.core.bootstrap import (  # noqa: E402
-        get_available_backends,
-        refresh_available_backends,
-        AVAILABLE_BACKENDS,
-        LLM_BACKENDS,
-    )
+from app.core.bootstrap import (
+    get_available_backends,
+    refresh_available_backends,
+    AVAILABLE_BACKENDS,
+    LLM_BACKENDS,
+)
 
 
 class TestGetAvailableBackends(unittest.TestCase):

--- a/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_available_backends.py
@@ -30,6 +30,16 @@ class TestGetAvailableBackends(unittest.TestCase):
         self.assertEqual(result, ["gemini", "ollama"])
 
     @patch("app.core.bootstrap.get_llm_client")
+    def test_gemini_not_configured(self, mock_get_client):
+        def side_effect(backend):
+            if backend == "gemini":
+                raise ValueError("No Gemini endpoint configured.")
+            return MagicMock()
+        mock_get_client.side_effect = side_effect
+        result = get_available_backends()
+        self.assertEqual(result, ["ollama", "vllm"])
+
+    @patch("app.core.bootstrap.get_llm_client")
     def test_none_configured(self, mock_get_client):
         mock_get_client.side_effect = ValueError("not configured")
         result = get_available_backends()
@@ -85,6 +95,19 @@ class TestRefreshAvailableBackends(unittest.TestCase):
 
         asyncio.run(refresh_available_backends())
         self.assertEqual(list(AVAILABLE_BACKENDS), ["gemini", "ollama"])
+
+    @patch("app.core.bootstrap.get_llm_client")
+    def test_gemini_unconfigured_excluded(self, mock_get_client):
+        def side_effect(backend):
+            if backend == "gemini":
+                raise ValueError("No Gemini endpoint configured.")
+            client = MagicMock()
+            client.health_check = AsyncMock(return_value=True)
+            return client
+        mock_get_client.side_effect = side_effect
+
+        asyncio.run(refresh_available_backends())
+        self.assertEqual(list(AVAILABLE_BACKENDS), ["ollama", "vllm"])
 
 
 if __name__ == "__main__":

--- a/multi_llm_chatbot_backend/app/tests/unit/test_llm_provider_config.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_llm_provider_config.py
@@ -1,0 +1,364 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.api.routes.chat import resolve_llm_clients
+from app.api.routes.provider import switch_provider
+from app.models.user import User, UserLLMConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(llm_config=None):
+    return User(
+        _id=ObjectId(),
+        firstName="Test",
+        lastName="User",
+        email="test@example.com",
+        hashed_password="fakehash",
+        llm_config=llm_config,
+    )
+
+
+# ===================================================================
+# 1. UserLLMConfig — Pydantic model validation
+# ===================================================================
+
+class TestUserLLMConfig(unittest.TestCase):
+    """Validate the UserLLMConfig Pydantic model and its _validate_hybrid_fields
+    model validator."""
+
+    def test_defaults(self):
+        cfg = UserLLMConfig()
+        self.assertEqual(cfg.mode, "uniform")
+        self.assertEqual(cfg.default_backend, "gemini")
+        self.assertIsNone(cfg.orchestrator_backend)
+        self.assertIsNone(cfg.persona_backends)
+
+    def test_uniform_strips_hybrid_fields(self):
+        cfg = UserLLMConfig(
+            mode="uniform",
+            default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"x": "vllm"},
+        )
+        self.assertIsNone(cfg.orchestrator_backend)
+        self.assertIsNone(cfg.persona_backends)
+
+    def test_hybrid_requires_at_least_one_override(self):
+        with self.assertRaises(ValidationError) as ctx:
+            UserLLMConfig(mode="hybrid", default_backend="gemini")
+        self.assertIn("hybrid mode requires", str(ctx.exception))
+
+    def test_hybrid_with_orchestrator_only(self):
+        cfg = UserLLMConfig(
+            mode="hybrid",
+            default_backend="gemini",
+            orchestrator_backend="ollama",
+        )
+        self.assertEqual(cfg.orchestrator_backend, "ollama")
+        self.assertIsNone(cfg.persona_backends)
+
+    def test_hybrid_with_persona_backends_only(self):
+        cfg = UserLLMConfig(
+            mode="hybrid",
+            default_backend="gemini",
+            persona_backends={"advisor_1": "vllm"},
+        )
+        self.assertIsNone(cfg.orchestrator_backend)
+        self.assertEqual(cfg.persona_backends, {"advisor_1": "vllm"})
+
+    def test_hybrid_with_both(self):
+        cfg = UserLLMConfig(
+            mode="hybrid",
+            default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"advisor_1": "vllm"},
+        )
+        self.assertEqual(cfg.orchestrator_backend, "ollama")
+        self.assertEqual(cfg.persona_backends, {"advisor_1": "vllm"})
+
+    def test_rejects_unknown_backend_name(self):
+        with self.assertRaises(ValidationError):
+            UserLLMConfig(default_backend="claude")
+
+    def test_extra_fields_forbidden(self):
+        with self.assertRaises(ValidationError):
+            UserLLMConfig(default_backend="gemini", surprise="boom")
+
+    def test_model_dump_roundtrip(self):
+        original = UserLLMConfig(
+            mode="hybrid",
+            default_backend="ollama",
+            orchestrator_backend="gemini",
+            persona_backends={"a": "vllm", "b": "gemini"},
+        )
+        restored = UserLLMConfig(**original.model_dump())
+        self.assertEqual(original.model_dump(), restored.model_dump())
+
+
+# ===================================================================
+# 2. resolve_llm_clients — chat routing logic
+# ===================================================================
+
+class TestResolveLlmClients(unittest.TestCase):
+    """Verify that resolve_llm_clients maps a user's stored config to the
+    correct LLM client instances."""
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_no_config_returns_nones(self, mock_get, mock_orch):
+        result = resolve_llm_clients(_make_user(llm_config=None))
+        self.assertIsNone(result["orchestrator"])
+        self.assertIsNone(result["personas"])
+        mock_get.assert_not_called()
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_uniform_same_client_for_all(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock(), "b": MagicMock(), "c": MagicMock()}
+        sentinel = MagicMock(name="shared_client")
+        mock_get.return_value = sentinel
+
+        user = _make_user(UserLLMConfig(mode="uniform", default_backend="ollama"))
+        result = resolve_llm_clients(user)
+
+        mock_get.assert_called_once_with("ollama")
+        self.assertIs(result["orchestrator"], sentinel)
+        for pid in ("a", "b", "c"):
+            self.assertIs(result["personas"][pid], sentinel)
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_hybrid_orchestrator_override(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock()}
+        clients = {"gemini": MagicMock(), "ollama": MagicMock()}
+        mock_get.side_effect = lambda b: clients[b]
+
+        user = _make_user(UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"a": "gemini"},
+        ))
+        result = resolve_llm_clients(user)
+        self.assertIs(result["orchestrator"], clients["ollama"])
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_hybrid_orchestrator_falls_back_to_default(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock()}
+        sentinel = MagicMock()
+        mock_get.return_value = sentinel
+
+        user = _make_user(UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"a": "gemini"},
+        ))
+        result = resolve_llm_clients(user)
+        self.assertIs(result["orchestrator"], sentinel)
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_hybrid_persona_override(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock(), "b": MagicMock()}
+        clients = {"gemini": MagicMock(), "vllm": MagicMock()}
+        mock_get.side_effect = lambda b: clients[b]
+
+        user = _make_user(UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"a": "vllm", "b": "gemini"},
+        ))
+        result = resolve_llm_clients(user)
+        self.assertIs(result["personas"]["a"], clients["vllm"])
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_hybrid_unmapped_persona_uses_default(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock(), "unmapped": MagicMock()}
+        clients = {"gemini": MagicMock(), "vllm": MagicMock()}
+        mock_get.side_effect = lambda b: clients[b]
+
+        user = _make_user(UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"a": "vllm"},
+        ))
+        result = resolve_llm_clients(user)
+        self.assertIs(result["personas"]["unmapped"], clients["gemini"])
+
+    @patch("app.api.routes.chat.chat_orchestrator")
+    @patch("app.api.routes.chat.get_llm_client")
+    def test_hybrid_mixed(self, mock_get, mock_orch):
+        mock_orch.personas = {"a": MagicMock(), "b": MagicMock()}
+        clients = {"gemini": MagicMock(), "ollama": MagicMock(), "vllm": MagicMock()}
+        mock_get.side_effect = lambda b: clients[b]
+
+        user = _make_user(UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"a": "vllm"},
+        ))
+        result = resolve_llm_clients(user)
+        self.assertIs(result["orchestrator"], clients["ollama"])
+        self.assertIs(result["personas"]["a"], clients["vllm"])
+        self.assertIs(result["personas"]["b"], clients["gemini"])
+
+
+# ===================================================================
+# 3. switch_provider — endpoint validation
+# ===================================================================
+
+class TestSwitchProvider(unittest.IsolatedAsyncioTestCase):
+    """Validate the switch_provider endpoint's guard logic."""
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_rejects_unknown_persona_id(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {"known": MagicMock()}
+        mock_get.return_value = MagicMock()
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"unknown_id": "gemini"},
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            await switch_provider(cfg, _make_user())
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("Unknown persona IDs", ctx.exception.detail)
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_accepts_known_persona_ids(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {"a": MagicMock(), "b": MagicMock()}
+        mock_get.return_value = MagicMock()
+        mock_db.return_value.users.update_one = AsyncMock()
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"a": "gemini", "b": "gemini"},
+        )
+        result = await switch_provider(cfg, _make_user())
+        self.assertEqual(result["message"], "LLM configuration updated")
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_rejects_unconfigured_default_backend(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {}
+        mock_get.side_effect = ValueError("not configured")
+
+        cfg = UserLLMConfig(mode="uniform", default_backend="ollama")
+        with self.assertRaises(HTTPException) as ctx:
+            await switch_provider(cfg, _make_user())
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("not configured", ctx.exception.detail)
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_rejects_unconfigured_orchestrator_backend(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {}
+
+        def side_effect(backend):
+            if backend == "vllm":
+                raise ValueError("no vLLM endpoint")
+            return MagicMock()
+        mock_get.side_effect = side_effect
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            orchestrator_backend="vllm",
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            await switch_provider(cfg, _make_user())
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("not configured", ctx.exception.detail)
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_rejects_unconfigured_persona_backend(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {"a": MagicMock()}
+
+        def side_effect(backend):
+            if backend == "vllm":
+                raise ValueError("no vLLM endpoint")
+            return MagicMock()
+        mock_get.side_effect = side_effect
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            persona_backends={"a": "vllm"},
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            await switch_provider(cfg, _make_user())
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("not configured", ctx.exception.detail)
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_checks_all_distinct_backends(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {"a": MagicMock(), "b": MagicMock()}
+        mock_get.return_value = MagicMock()
+        mock_db.return_value.users.update_one = AsyncMock()
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"a": "vllm", "b": "gemini"},
+        )
+        await switch_provider(cfg, _make_user())
+
+        checked = {call.args[0] for call in mock_get.call_args_list}
+        self.assertEqual(checked, {"gemini", "ollama", "vllm"})
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_persists_to_database(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {}
+        mock_get.return_value = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.update_one = AsyncMock()
+        mock_db.return_value.users = mock_collection
+
+        user = _make_user()
+        cfg = UserLLMConfig(mode="uniform", default_backend="ollama")
+        await switch_provider(cfg, user)
+
+        mock_collection.update_one.assert_awaited_once()
+        call_args = mock_collection.update_one.call_args
+        self.assertEqual(call_args[0][0], {"_id": user.id})
+        self.assertEqual(
+            call_args[0][1],
+            {"$set": {"llm_config": cfg.model_dump()}},
+        )
+
+    @patch("app.api.routes.provider.get_database")
+    @patch("app.api.routes.provider.get_llm_client")
+    @patch("app.api.routes.provider.chat_orchestrator")
+    async def test_returns_updated_config(self, mock_orch, mock_get, mock_db):
+        mock_orch.personas = {"a": MagicMock()}
+        mock_get.return_value = MagicMock()
+        mock_db.return_value.users.update_one = AsyncMock()
+
+        cfg = UserLLMConfig(
+            mode="hybrid", default_backend="gemini",
+            orchestrator_backend="ollama",
+            persona_backends={"a": "vllm"},
+        )
+        result = await switch_provider(cfg, _make_user())
+
+        self.assertEqual(result["message"], "LLM configuration updated")
+        self.assertEqual(result["llm_config"], cfg.model_dump())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/multi_llm_chatbot_backend/app/tests/unit/test_llm_provider_config.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_llm_provider_config.py
@@ -50,10 +50,10 @@ class TestUserLLMConfig(unittest.TestCase):
         self.assertIsNone(cfg.orchestrator_backend)
         self.assertIsNone(cfg.persona_backends)
 
-    def test_hybrid_requires_at_least_one_override(self):
-        with self.assertRaises(ValidationError) as ctx:
-            UserLLMConfig(mode="hybrid", default_backend="gemini")
-        self.assertIn("hybrid mode requires", str(ctx.exception))
+    def test_hybrid_without_overrides_falls_back_to_default(self):
+        cfg = UserLLMConfig(mode="hybrid", default_backend="gemini")
+        self.assertEqual(cfg.orchestrator_backend, "gemini")
+        self.assertIsNone(cfg.persona_backends)
 
     def test_hybrid_with_orchestrator_only(self):
         cfg = UserLLMConfig(

--- a/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
+++ b/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
@@ -1,0 +1,160 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+// Reusable per-advisor backend configuration panel.
+//
+// Used in two places:
+//   - Welcome-state "Advanced" expander on ChatPage
+//   - "Advisor Config" tab inside SettingsModal (lives on feat/UI-for-User-Account-updates;
+//     drop this component in once branches merge)
+//
+// Controlled component. Parent owns the config object and decides when to persist.
+//
+// Shape of `value`:
+//   { default_backend, orchestrator_backend, persona_backends: { [personaId]: backend } }
+
+const rowStyle = {
+  display: 'grid', gridTemplateColumns: '1fr 180px', alignItems: 'center',
+  gap: 12, padding: '10px 0', borderBottom: '1px solid var(--border-primary)',
+};
+
+const selectStyle = {
+  padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border-primary)',
+  background: 'var(--bg-secondary)', color: 'var(--text-primary)', fontSize: 13.5,
+  width: '100%',
+};
+
+const buildInitial = (initialConfig, personaIds, availableBackends) => {
+  const fallback = initialConfig?.default_backend || availableBackends[0] || 'gemini';
+  const seed = initialConfig?.persona_backends || {};
+  const personas = {};
+  for (const id of personaIds) {
+    personas[id] = seed[id] || fallback;
+  }
+  return {
+    default_backend: fallback,
+    orchestrator_backend: initialConfig?.orchestrator_backend || fallback,
+    persona_backends: personas,
+  };
+};
+
+const AdvisorConfigPanel = ({
+  advisors,
+  availableBackends,
+  value,
+  initialConfig,
+  onChange,
+  hideDefault = false,
+  hideOrchestrator = false,
+  description,
+}) => {
+  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
+  const isControlled = value !== undefined;
+
+  const [internal, setInternal] = useState(() =>
+    buildInitial(initialConfig, personaIds, availableBackends)
+  );
+
+  useEffect(() => {
+    if (isControlled) return;
+    setInternal(prev => {
+      const next = { ...prev.persona_backends };
+      let changed = false;
+      const fallback = prev.default_backend || availableBackends[0] || 'gemini';
+      for (const id of personaIds) {
+        if (next[id] === undefined) {
+          next[id] = fallback;
+          changed = true;
+        }
+      }
+      return changed ? { ...prev, persona_backends: next } : prev;
+    });
+  }, [personaIds, availableBackends, isControlled]);
+
+  const config = isControlled ? value : internal;
+
+  const update = (next) => {
+    if (!isControlled) setInternal(next);
+    if (onChange) onChange(next);
+  };
+
+  const setDefault = (val) => update({ ...config, default_backend: val });
+  const setOrchestrator = (val) => update({ ...config, orchestrator_backend: val });
+  const setPersona = (id, val) => update({
+    ...config,
+    persona_backends: { ...config.persona_backends, [id]: val },
+  });
+
+  return (
+    <div>
+      {description && (
+        <p style={{ margin: '0 0 16px', color: 'var(--text-secondary)', fontSize: 13.5 }}>
+          {description}
+        </p>
+      )}
+
+      {!hideDefault && (
+        <div style={rowStyle}>
+          <div>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>Default backend</div>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+              Used when no specific override is set.
+            </div>
+          </div>
+          <select
+            style={selectStyle}
+            value={config.default_backend}
+            onChange={(e) => setDefault(e.target.value)}
+          >
+            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </div>
+      )}
+
+      {!hideOrchestrator && (
+        <div style={rowStyle}>
+          <div>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>Orchestrator</div>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+              Routes user input across advisors.
+            </div>
+          </div>
+          <select
+            style={selectStyle}
+            value={config.orchestrator_backend}
+            onChange={(e) => setOrchestrator(e.target.value)}
+          >
+            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </div>
+      )}
+
+      {personaIds.map((id) => {
+        const advisor = advisors[id];
+        const locked = advisor?.backendLocked;
+        const personaValue = locked && advisor?.defaultBackend
+          ? advisor.defaultBackend
+          : (config.persona_backends?.[id] || config.default_backend);
+        return (
+          <div style={rowStyle} key={id}>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: 14 }}>{advisor?.name || id}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                {advisor?.role || id}{locked ? ' · backend locked' : ''}
+              </div>
+            </div>
+            <select
+              style={{ ...selectStyle, opacity: locked ? 0.6 : 1 }}
+              value={personaValue}
+              disabled={locked}
+              onChange={(e) => setPersona(id, e.target.value)}
+            >
+              {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+            </select>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AdvisorConfigPanel;

--- a/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
+++ b/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
@@ -24,7 +24,7 @@ const selectStyle = {
 };
 
 const buildInitial = (initialConfig, personaIds, availableBackends) => {
-  const fallback = initialConfig?.default_backend || availableBackends[0] || 'gemini';
+  const fallback = initialConfig?.default_backend || availableBackends[0];
   const seed = initialConfig?.persona_backends || {};
   const personas = {};
   for (const id of personaIds) {
@@ -59,7 +59,7 @@ const AdvisorConfigPanel = ({
     setInternal(prev => {
       const next = { ...prev.persona_backends };
       let changed = false;
-      const fallback = prev.default_backend || availableBackends[0] || 'gemini';
+      const fallback = prev.default_backend || availableBackends[0];
       for (const id of personaIds) {
         if (next[id] === undefined) {
           next[id] = fallback;

--- a/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
+++ b/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
@@ -11,6 +11,27 @@ import React, { useEffect, useMemo, useState } from 'react';
 //
 // Shape of `value`:
 //   { default_backend, orchestrator_backend, persona_backends: { [personaId]: backend } }
+//
+// The orchestrator and each advisor can be set to DEFAULT_BACKEND ("Default"),
+// meaning "follow default_backend". Call stripDefaultBackends() before persisting:
+// it drops those sentinels so the backend falls through to default_backend (and
+// moves them automatically when the default changes).
+
+export const DEFAULT_BACKEND = '__default__';
+
+export const stripDefaultBackends = (config) => {
+  if (!config) return config;
+  const source = config.persona_backends || {};
+  const cleaned = {};
+  for (const [id, backend] of Object.entries(source)) {
+    if (backend && backend !== DEFAULT_BACKEND) cleaned[id] = backend;
+  }
+  const orchestrator =
+    config.orchestrator_backend && config.orchestrator_backend !== DEFAULT_BACKEND
+      ? config.orchestrator_backend
+      : null;
+  return { ...config, orchestrator_backend: orchestrator, persona_backends: cleaned };
+};
 
 const rowStyle = {
   display: 'grid', gridTemplateColumns: '1fr 180px', alignItems: 'center',
@@ -20,19 +41,25 @@ const rowStyle = {
 const selectStyle = {
   padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border-primary)',
   background: 'var(--bg-secondary)', color: 'var(--text-primary)', fontSize: 13.5,
-  width: '100%',
+  width: '100%', colorScheme: 'light dark',
 };
+
+// Native dropdown option list ignores the <select> colors in several browsers,
+// so set the themed background/text explicitly on each <option>.
+const optionStyle = { background: 'var(--bg-secondary)', color: 'var(--text-primary)' };
+
+const titleStyle = { fontWeight: 600, fontSize: 14, color: 'var(--text-primary)' };
 
 const buildInitial = (initialConfig, personaIds, availableBackends) => {
   const fallback = initialConfig?.default_backend || availableBackends[0];
   const seed = initialConfig?.persona_backends || {};
   const personas = {};
   for (const id of personaIds) {
-    personas[id] = seed[id] || fallback;
+    personas[id] = seed[id] || DEFAULT_BACKEND;
   }
   return {
     default_backend: fallback,
-    orchestrator_backend: initialConfig?.orchestrator_backend || fallback,
+    orchestrator_backend: initialConfig?.orchestrator_backend || DEFAULT_BACKEND,
     persona_backends: personas,
   };
 };
@@ -59,10 +86,9 @@ const AdvisorConfigPanel = ({
     setInternal(prev => {
       const next = { ...prev.persona_backends };
       let changed = false;
-      const fallback = prev.default_backend || availableBackends[0];
       for (const id of personaIds) {
         if (next[id] === undefined) {
-          next[id] = fallback;
+          next[id] = DEFAULT_BACKEND;
           changed = true;
         }
       }
@@ -95,7 +121,7 @@ const AdvisorConfigPanel = ({
       {!hideDefault && (
         <div style={rowStyle}>
           <div>
-            <div style={{ fontWeight: 600, fontSize: 14 }}>Default backend</div>
+            <div style={titleStyle}>Default backend</div>
             <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
               Used when no specific override is set.
             </div>
@@ -105,7 +131,7 @@ const AdvisorConfigPanel = ({
             value={config.default_backend}
             onChange={(e) => setDefault(e.target.value)}
           >
-            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+            {availableBackends.map(b => <option key={b} value={b} style={optionStyle}>{b}</option>)}
           </select>
         </div>
       )}
@@ -113,7 +139,7 @@ const AdvisorConfigPanel = ({
       {!hideOrchestrator && (
         <div style={rowStyle}>
           <div>
-            <div style={{ fontWeight: 600, fontSize: 14 }}>Orchestrator</div>
+            <div style={titleStyle}>Orchestrator</div>
             <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
               Routes user input across advisors.
             </div>
@@ -123,7 +149,8 @@ const AdvisorConfigPanel = ({
             value={config.orchestrator_backend}
             onChange={(e) => setOrchestrator(e.target.value)}
           >
-            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+            <option value={DEFAULT_BACKEND} style={optionStyle}>Default</option>
+            {availableBackends.map(b => <option key={b} value={b} style={optionStyle}>{b}</option>)}
           </select>
         </div>
       )}
@@ -133,11 +160,11 @@ const AdvisorConfigPanel = ({
         const locked = advisor?.backendLocked;
         const personaValue = locked && advisor?.defaultBackend
           ? advisor.defaultBackend
-          : (config.persona_backends?.[id] || config.default_backend);
+          : (config.persona_backends?.[id] || DEFAULT_BACKEND);
         return (
           <div style={rowStyle} key={id}>
             <div>
-              <div style={{ fontWeight: 600, fontSize: 14 }}>{advisor?.name || id}</div>
+              <div style={titleStyle}>{advisor?.name || id}</div>
               <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
                 {advisor?.role || id}{locked ? ' · backend locked' : ''}
               </div>
@@ -152,7 +179,8 @@ const AdvisorConfigPanel = ({
                 value={personaValue}
                 onChange={(e) => setPersona(id, e.target.value)}
               >
-                {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+                <option value={DEFAULT_BACKEND} style={optionStyle}>Default</option>
+                {availableBackends.map(b => <option key={b} value={b} style={optionStyle}>{b}</option>)}
               </select>
             )}
           </div>

--- a/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
+++ b/phd-advisor-frontend/src/components/AdvisorConfigPanel.js
@@ -142,14 +142,19 @@ const AdvisorConfigPanel = ({
                 {advisor?.role || id}{locked ? ' · backend locked' : ''}
               </div>
             </div>
-            <select
-              style={{ ...selectStyle, opacity: locked ? 0.6 : 1 }}
-              value={personaValue}
-              disabled={locked}
-              onChange={(e) => setPersona(id, e.target.value)}
-            >
-              {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
-            </select>
+            {locked ? (
+              <div style={{ ...selectStyle, opacity: 0.6, cursor: 'not-allowed' }}>
+                {personaValue}
+              </div>
+            ) : (
+              <select
+                style={selectStyle}
+                value={personaValue}
+                onChange={(e) => setPersona(id, e.target.value)}
+              >
+                {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+              </select>
+            )}
           </div>
         );
       })}

--- a/phd-advisor-frontend/src/components/AvatarPickerModal 2.js
+++ b/phd-advisor-frontend/src/components/AvatarPickerModal 2.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { X } from 'lucide-react';
+import { useAppConfig } from '../contexts/AppConfigContext';
+
+const API = process.env.REACT_APP_API_URL || '';
+
+const BUNDLED = [
+  'advisor1.png','advisor2.png','advisor3.png','advisor4.png',
+  'advisor5.png','advisor6.png','advisor7.png',
+];
+
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+};
+
+const modal = {
+  background: 'var(--bg-primary)', borderRadius: 16, padding: 24, width: 480,
+  maxWidth: '95vw', maxHeight: '85vh', overflowY: 'auto',
+  boxShadow: 'var(--shadow-xl)',
+};
+
+const AvatarPickerModal = ({ advisorId, advisorName, onClose }) => {
+  const { setAdvisorAvatar } = useAppConfig();
+
+  const select = (url) => {
+    setAdvisorAvatar(advisorId, url || '');
+    onClose();
+  };
+
+  return ReactDOM.createPortal(
+    <div style={overlay} onClick={(e) => e.target === e.currentTarget && onClose()} onMouseDown={(e) => e.stopPropagation()}>
+      <div style={modal}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
+          <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 18 }}>
+            Choose Avatar — {advisorName}
+          </h3>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)' }}>
+            <X size={20} />
+          </button>
+        </div>
+
+        <p style={{ margin: '0 0 10px', color: 'var(--text-secondary)', fontSize: 13, fontWeight: 600 }}>Pre-made Avatars</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 8, marginBottom: 20 }}>
+          {BUNDLED.map((file) => (
+            <img
+              key={file}
+              src={`${API}/api/avatars/bundled/${file}`}
+              alt={file}
+              onClick={() => select(`${API}/api/avatars/bundled/${file}`)}
+              style={{ width: '100%', aspectRatio: '1', borderRadius: '50%', objectFit: 'cover', cursor: 'pointer', border: '2px solid transparent', transition: 'border-color 0.15s' }}
+              onMouseEnter={e => e.target.style.borderColor = 'var(--accent-primary)'}
+              onMouseLeave={e => e.target.style.borderColor = 'transparent'}
+            />
+          ))}
+        </div>
+
+        <button
+          onClick={() => select(null)}
+          style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'transparent', border: '1px solid var(--border-primary)', borderRadius: 10, color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 13.5 }}
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="8" r="4" />
+            <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+          </svg>
+          Use default icon
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default AvatarPickerModal;

--- a/phd-advisor-frontend/src/components/HybridConfigModal.js
+++ b/phd-advisor-frontend/src/components/HybridConfigModal.js
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { X, Layers } from 'lucide-react';
+import AdvisorConfigPanel from './AdvisorConfigPanel';
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -13,15 +14,18 @@ const modal = {
   boxShadow: 'var(--shadow-xl)', color: 'var(--text-primary)',
 };
 
-const row = {
-  display: 'grid', gridTemplateColumns: '1fr 180px', alignItems: 'center',
-  gap: 12, padding: '10px 0', borderBottom: '1px solid var(--border-primary)',
-};
-
-const select = {
-  padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border-primary)',
-  background: 'var(--bg-secondary)', color: 'var(--text-primary)', fontSize: 13.5,
-  width: '100%',
+const seedConfig = (initialConfig, personaIds, availableBackends) => {
+  const fallback = initialConfig?.default_backend || availableBackends[0] || 'gemini';
+  const seedPersonas = initialConfig?.persona_backends || {};
+  const personas = {};
+  for (const id of personaIds) {
+    personas[id] = seedPersonas[id] || fallback;
+  }
+  return {
+    default_backend: fallback,
+    orchestrator_backend: initialConfig?.orchestrator_backend || fallback,
+    persona_backends: personas,
+  };
 };
 
 const HybridConfigModal = ({
@@ -33,33 +37,7 @@ const HybridConfigModal = ({
   onClose,
 }) => {
   const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
-
-  const [defaultBackend, setDefaultBackend] = useState(
-    initialConfig?.default_backend || availableBackends[0] || 'gemini'
-  );
-  const [orchestratorBackend, setOrchestratorBackend] = useState(
-    initialConfig?.orchestrator_backend || initialConfig?.default_backend || availableBackends[0] || 'gemini'
-  );
-  const [personaBackends, setPersonaBackends] = useState(() => {
-    const seed = initialConfig?.persona_backends || {};
-    const out = {};
-    for (const id of personaIds) {
-      out[id] = seed[id] || initialConfig?.default_backend || availableBackends[0] || 'gemini';
-    }
-    return out;
-  });
-
-  const setPersona = (id, value) => {
-    setPersonaBackends(prev => ({ ...prev, [id]: value }));
-  };
-
-  const handleSave = () => {
-    onSubmit({
-      default_backend: defaultBackend,
-      orchestrator_backend: orchestratorBackend,
-      persona_backends: personaBackends,
-    });
-  };
+  const [config, setConfig] = useState(() => seedConfig(initialConfig, personaIds, availableBackends));
 
   return ReactDOM.createPortal(
     <div style={overlay} onClick={(e) => e.target === e.currentTarget && onClose()}>
@@ -77,53 +55,13 @@ const HybridConfigModal = ({
           </button>
         </div>
 
-        <p style={{ margin: '0 0 16px', color: 'var(--text-secondary)', fontSize: 13.5 }}>
-          Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback.
-        </p>
-
-        <div style={row}>
-          <div>
-            <div style={{ fontWeight: 600, fontSize: 14 }}>Default backend</div>
-            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>Used when no specific override is set.</div>
-          </div>
-          <select style={select} value={defaultBackend} onChange={(e) => setDefaultBackend(e.target.value)}>
-            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
-          </select>
-        </div>
-
-        <div style={row}>
-          <div>
-            <div style={{ fontWeight: 600, fontSize: 14 }}>Orchestrator</div>
-            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>Routes user input across advisors.</div>
-          </div>
-          <select style={select} value={orchestratorBackend} onChange={(e) => setOrchestratorBackend(e.target.value)}>
-            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
-          </select>
-        </div>
-
-        {personaIds.map((id) => {
-          const advisor = advisors[id];
-          const locked = advisor?.backendLocked;
-          const value = locked && advisor?.defaultBackend ? advisor.defaultBackend : personaBackends[id];
-          return (
-            <div style={row} key={id}>
-              <div>
-                <div style={{ fontWeight: 600, fontSize: 14 }}>{advisor?.name || id}</div>
-                <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
-                  {advisor?.role || id}{locked ? ' · backend locked' : ''}
-                </div>
-              </div>
-              <select
-                style={{ ...select, opacity: locked ? 0.6 : 1 }}
-                value={value}
-                disabled={locked}
-                onChange={(e) => setPersona(id, e.target.value)}
-              >
-                {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
-              </select>
-            </div>
-          );
-        })}
+        <AdvisorConfigPanel
+          advisors={advisors}
+          availableBackends={availableBackends}
+          value={config}
+          onChange={setConfig}
+          description="Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback."
+        />
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 20 }}>
           <button
@@ -137,7 +75,7 @@ const HybridConfigModal = ({
             Cancel
           </button>
           <button
-            onClick={handleSave}
+            onClick={() => onSubmit(config)}
             disabled={isSaving}
             style={{
               padding: '8px 14px', borderRadius: 8, border: 'none',

--- a/phd-advisor-frontend/src/components/HybridConfigModal.js
+++ b/phd-advisor-frontend/src/components/HybridConfigModal.js
@@ -1,0 +1,157 @@
+import React, { useState, useMemo } from 'react';
+import ReactDOM from 'react-dom';
+import { X, Layers } from 'lucide-react';
+
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+};
+
+const modal = {
+  background: 'var(--bg-primary)', borderRadius: 16, padding: 24, width: 560,
+  maxWidth: '95vw', maxHeight: '85vh', overflowY: 'auto',
+  boxShadow: 'var(--shadow-xl)', color: 'var(--text-primary)',
+};
+
+const row = {
+  display: 'grid', gridTemplateColumns: '1fr 180px', alignItems: 'center',
+  gap: 12, padding: '10px 0', borderBottom: '1px solid var(--border-primary)',
+};
+
+const select = {
+  padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border-primary)',
+  background: 'var(--bg-secondary)', color: 'var(--text-primary)', fontSize: 13.5,
+  width: '100%',
+};
+
+const HybridConfigModal = ({
+  advisors,
+  availableBackends,
+  initialConfig,
+  isSaving,
+  onSubmit,
+  onClose,
+}) => {
+  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
+
+  const [defaultBackend, setDefaultBackend] = useState(
+    initialConfig?.default_backend || availableBackends[0] || 'gemini'
+  );
+  const [orchestratorBackend, setOrchestratorBackend] = useState(
+    initialConfig?.orchestrator_backend || initialConfig?.default_backend || availableBackends[0] || 'gemini'
+  );
+  const [personaBackends, setPersonaBackends] = useState(() => {
+    const seed = initialConfig?.persona_backends || {};
+    const out = {};
+    for (const id of personaIds) {
+      out[id] = seed[id] || initialConfig?.default_backend || availableBackends[0] || 'gemini';
+    }
+    return out;
+  });
+
+  const setPersona = (id, value) => {
+    setPersonaBackends(prev => ({ ...prev, [id]: value }));
+  };
+
+  const handleSave = () => {
+    onSubmit({
+      default_backend: defaultBackend,
+      orchestrator_backend: orchestratorBackend,
+      persona_backends: personaBackends,
+    });
+  };
+
+  return ReactDOM.createPortal(
+    <div style={overlay} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div style={modal}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <Layers size={20} />
+            <h3 style={{ margin: 0, fontSize: 18 }}>Hybrid LLM Configuration</h3>
+          </div>
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)' }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <p style={{ margin: '0 0 16px', color: 'var(--text-secondary)', fontSize: 13.5 }}>
+          Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback.
+        </p>
+
+        <div style={row}>
+          <div>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>Default backend</div>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>Used when no specific override is set.</div>
+          </div>
+          <select style={select} value={defaultBackend} onChange={(e) => setDefaultBackend(e.target.value)}>
+            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </div>
+
+        <div style={row}>
+          <div>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>Orchestrator</div>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>Routes user input across advisors.</div>
+          </div>
+          <select style={select} value={orchestratorBackend} onChange={(e) => setOrchestratorBackend(e.target.value)}>
+            {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </div>
+
+        {personaIds.map((id) => {
+          const advisor = advisors[id];
+          const locked = advisor?.backendLocked;
+          const value = locked && advisor?.defaultBackend ? advisor.defaultBackend : personaBackends[id];
+          return (
+            <div style={row} key={id}>
+              <div>
+                <div style={{ fontWeight: 600, fontSize: 14 }}>{advisor?.name || id}</div>
+                <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                  {advisor?.role || id}{locked ? ' · backend locked' : ''}
+                </div>
+              </div>
+              <select
+                style={{ ...select, opacity: locked ? 0.6 : 1 }}
+                value={value}
+                disabled={locked}
+                onChange={(e) => setPersona(id, e.target.value)}
+              >
+                {availableBackends.map(b => <option key={b} value={b}>{b}</option>)}
+              </select>
+            </div>
+          );
+        })}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 20 }}>
+          <button
+            onClick={onClose}
+            disabled={isSaving}
+            style={{
+              padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-primary)',
+              background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 13.5,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            style={{
+              padding: '8px 14px', borderRadius: 8, border: 'none',
+              background: 'var(--accent-primary)', color: '#fff',
+              cursor: isSaving ? 'wait' : 'pointer', fontSize: 13.5, fontWeight: 600,
+            }}
+          >
+            {isSaving ? 'Saving…' : 'Save configuration'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default HybridConfigModal;

--- a/phd-advisor-frontend/src/components/HybridConfigModal.js
+++ b/phd-advisor-frontend/src/components/HybridConfigModal.js
@@ -15,7 +15,7 @@ const modal = {
 };
 
 const seedConfig = (initialConfig, personaIds, availableBackends) => {
-  const fallback = initialConfig?.default_backend || availableBackends[0] || 'gemini';
+  const fallback = initialConfig?.default_backend || availableBackends[0];
   const seedPersonas = initialConfig?.persona_backends || {};
   const personas = {};
   for (const id of personaIds) {

--- a/phd-advisor-frontend/src/components/HybridConfigModal.js
+++ b/phd-advisor-frontend/src/components/HybridConfigModal.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { X, Layers } from 'lucide-react';
-import AdvisorConfigPanel from './AdvisorConfigPanel';
+import AdvisorConfigPanel, { DEFAULT_BACKEND, stripDefaultBackends } from './AdvisorConfigPanel';
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -19,11 +19,11 @@ const seedConfig = (initialConfig, personaIds, availableBackends) => {
   const seedPersonas = initialConfig?.persona_backends || {};
   const personas = {};
   for (const id of personaIds) {
-    personas[id] = seedPersonas[id] || fallback;
+    personas[id] = seedPersonas[id] || DEFAULT_BACKEND;
   }
   return {
     default_backend: fallback,
-    orchestrator_backend: initialConfig?.orchestrator_backend || fallback,
+    orchestrator_backend: initialConfig?.orchestrator_backend || DEFAULT_BACKEND,
     persona_backends: personas,
   };
 };
@@ -75,7 +75,7 @@ const HybridConfigModal = ({
             Cancel
           </button>
           <button
-            onClick={() => onSubmit(config)}
+            onClick={() => onSubmit(stripDefaultBackends(config))}
             disabled={isSaving}
             style={{
               padding: '8px 14px', borderRadius: 8, border: 'none',

--- a/phd-advisor-frontend/src/components/ProviderDropdown.js
+++ b/phd-advisor-frontend/src/components/ProviderDropdown.js
@@ -1,9 +1,9 @@
 // src/components/ProviderDropdown.js
 import React, { useState, useRef, useEffect } from 'react';
-import { ChevronDown, Cpu, Cloud, Server, Loader2 } from 'lucide-react';
+import { ChevronDown, Cpu, Cloud, Server, Loader2, Layers, Settings2 } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 
-const ProviderDropdown = ({ currentProvider, onProviderChange, isLoading = false }) => {
+const ProviderDropdown = ({ currentProvider, onProviderChange, isLoading = false, onConfigureHybrid }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
   const { isDark } = useTheme();
@@ -29,6 +29,13 @@ const ProviderDropdown = ({ currentProvider, onProviderChange, isLoading = false
       description: 'vLLM inference endpoint',
       icon: Server,
       badge: 'API'
+    },
+    {
+      id: 'hybrid',
+      name: 'Hybrid',
+      description: 'Per-advisor backend selection',
+      icon: Layers,
+      badge: 'Mixed'
     }
   ];
 
@@ -49,10 +56,23 @@ const ProviderDropdown = ({ currentProvider, onProviderChange, isLoading = false
   }, []);
 
   const handleProviderSelect = (providerId) => {
-    if (providerId !== currentProvider && !isLoading) {
+    if (isLoading) return;
+    if (providerId === 'hybrid') {
+      onProviderChange(providerId);
+      if (onConfigureHybrid) onConfigureHybrid();
+      setIsOpen(false);
+      return;
+    }
+    if (providerId !== currentProvider) {
       onProviderChange(providerId);
       setIsOpen(false);
     }
+  };
+
+  const handleConfigureClick = (event) => {
+    event.stopPropagation();
+    if (onConfigureHybrid) onConfigureHybrid();
+    setIsOpen(false);
   };
 
   const toggleDropdown = () => {
@@ -110,6 +130,16 @@ const ProviderDropdown = ({ currentProvider, onProviderChange, isLoading = false
                 </div>
                 {isSelected && (
                   <div className="provider-option-checkmark">✓</div>
+                )}
+                {provider.id === 'hybrid' && isSelected && onConfigureHybrid && (
+                  <button
+                    type="button"
+                    className="provider-option-configure"
+                    onClick={handleConfigureClick}
+                    title="Configure hybrid mapping"
+                  >
+                    <Settings2 size={14} />
+                  </button>
                 )}
               </button>
             );

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -1,8 +1,27 @@
+// TODO(@frontend-dev): This file has unresolved merge conflicts.
+// HEAD = disable-specific-personas + brainforge + message-persistence features
+// INCOMING = hybrid model selection feature (AdvisorConfigPanel, LLM config draft state)
+// Both sides need to be merged: keep HEAD's full multi-tab modal (Profile, Password,
+// Advisors toggles, Delete Account) and add incoming's AdvisorConfigPanel + LLM config
+// into the Advisors tab.
+
+<<<<<<< HEAD
 import React, { useState, useRef, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users } from 'lucide-react';
 import Toggle from './Toggle';
 import { useAppConfig } from '../contexts/AppConfigContext';
+=======
+import React, { useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { X, Layers } from 'lucide-react';
+import AdvisorConfigPanel from './AdvisorConfigPanel';
+
+// Settings modal. On feat/UI-for-User-Account-updates this file also has
+// Profile / Password / Delete Account tabs. When that branch merges, fold
+// those tabs into the tabRow + body sections below — the "advisors" tab
+// shipped on this branch is the only one not present there.
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -10,7 +29,7 @@ const overlay = {
 };
 
 const modal = {
-  background: 'var(--bg-primary)', borderRadius: 16, padding: 0, width: 560,
+  background: 'var(--bg-primary)', borderRadius: 16, padding: 0, width: 640,
   maxWidth: '95vw', maxHeight: '85vh', overflow: 'hidden',
   boxShadow: 'var(--shadow-xl)', display: 'flex', flexDirection: 'column',
 };
@@ -36,8 +55,18 @@ const tabBtn = (active) => ({
 
 const body = { padding: 24, overflowY: 'auto', flex: 1 };
 
-const label = { display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 6 };
+const SettingsModal = ({
+  user,
+  advisors,
+  availableBackends,
+  llmConfig,
+  isSaving,
+  onSubmitConfig,
+  onClose,
+}) => {
+  const [activeTab, setActiveTab] = useState('advisors');
 
+<<<<<<< HEAD
 const input = {
   width: '100%', padding: '10px 12px', borderRadius: 8,
   border: '1px solid var(--border-primary)', background: 'var(--bg-secondary)',
@@ -125,132 +154,24 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
     if (!firstName.trim() && !lastName.trim()) {
       setMessage({ type: 'error', text: 'Enter a first or last name.' });
       return;
+=======
+  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
+  const [draft, setDraft] = useState(() => {
+    const fallback = llmConfig?.default_backend || availableBackends?.[0] || 'gemini';
+    const seed = llmConfig?.persona_backends || {};
+    const personas = {};
+    for (const id of personaIds) {
+      personas[id] = seed[id] || fallback;
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
     }
-    setIsSubmitting(true);
-    try {
-      const response = await fetch(`${apiUrl}/auth/me`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${authToken}`,
-        },
-        body: JSON.stringify({
-          first_name: firstName.trim(),
-          last_name: lastName.trim(),
-        }),
-      });
-      const data = await response.json().catch(() => null);
-      if (!response.ok) {
-        setMessage({ type: 'error', text: extractError(data, 'Could not update profile.') });
-        return;
-      }
-      onUserUpdate?.(data);
-      setFirstName(data.firstName || '');
-      setLastName(data.lastName || '');
-      setMessage({ type: 'success', text: 'Profile updated.' });
-    } catch (err) {
-      setMessage({ type: 'error', text: 'Network error. Please try again.' });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handlePasswordSubmit = async (e) => {
-    e.preventDefault();
-    setMessage(null);
-    if (newPassword !== confirmPassword) {
-      setMessage({ type: 'error', text: 'New passwords do not match.' });
-      return;
-    }
-    if (newPassword.length < 8) {
-      setMessage({ type: 'error', text: 'New password must be at least 8 characters.' });
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      const response = await fetch(`${apiUrl}/auth/me/password`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${authToken}`,
-        },
-        body: JSON.stringify({
-          current_password: currentPassword,
-          new_password: newPassword,
-        }),
-      });
-      const data = await response.json().catch(() => null);
-      if (!response.ok) {
-        setMessage({ type: 'error', text: extractError(data, 'Could not change password.') });
-        return;
-      }
-      setCurrentPassword('');
-      setNewPassword('');
-      setConfirmPassword('');
-      setMessage({ type: 'success', text: 'Password changed.' });
-    } catch (err) {
-      setMessage({ type: 'error', text: 'Network error. Please try again.' });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleDeleteAccount = async (e) => {
-    e.preventDefault();
-    setMessage(null);
-    if (deleteConfirmText !== 'DELETE') {
-      setMessage({ type: 'error', text: 'Type DELETE to confirm.' });
-      return;
-    }
-    if (!deleteConfirmPassword) {
-      setMessage({ type: 'error', text: 'Password required to delete account.' });
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      const response = await fetch(`${apiUrl}/auth/me`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${authToken}`,
-        },
-        body: JSON.stringify({ password: deleteConfirmPassword }),
-      });
-      const data = await response.json().catch(() => null);
-      if (!response.ok) {
-        setMessage({ type: 'error', text: extractError(data, 'Could not delete account.') });
-        return;
-      }
-      onClose?.();
-      onSignOut?.();
-    } catch (err) {
-      setMessage({ type: 'error', text: 'Network error. Please try again.' });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const messageStyle = (type) => ({
-    padding: '10px 12px', borderRadius: 8, marginBottom: 16, fontSize: 13,
-    background: type === 'error'
-      ? 'rgba(220,38,38,0.1)'
-      : type === 'success'
-        ? 'rgba(22,163,74,0.1)'
-        : 'var(--bg-secondary)',
-    color: type === 'error'
-      ? '#dc2626'
-      : type === 'success'
-        ? '#16a34a'
-        : 'var(--text-secondary)',
-    border: `1px solid ${
-      type === 'error'
-        ? 'rgba(220,38,38,0.3)'
-        : type === 'success'
-          ? 'rgba(22,163,74,0.3)'
-          : 'var(--border-primary)'
-    }`,
+    return {
+      default_backend: fallback,
+      orchestrator_backend: llmConfig?.orchestrator_backend || fallback,
+      persona_backends: personas,
+    };
   });
 
+<<<<<<< HEAD
   const advisorEntries = Object.entries(advisors || {});
   const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
   const setAll = (enabled) => setAllAdvisorsEnabled(enabled);
@@ -280,19 +201,28 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
       setAdvisorEnabled(pendingDisable.id, false);
     }
     setPendingDisable(null);
+=======
+  const handleSave = () => {
+    onSubmitConfig(draft);
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
   };
 
   return ReactDOM.createPortal(
-    <div style={overlay} onMouseDown={handleOverlayMouseDown} onMouseUp={handleOverlayMouseUp}>
+    <div style={overlay} onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div style={modal}>
         <div style={header}>
           <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 18 }}>Settings</h3>
+<<<<<<< HEAD
           <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 4, display: 'flex' }} aria-label="Close settings">
+=======
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)' }}>
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
             <X size={20} />
           </button>
         </div>
 
         <div style={tabRow}>
+<<<<<<< HEAD
           <button style={tabBtn(activeTab === 'profile')} onClick={() => { setActiveTab('profile'); setMessage(null); }}>
             <UserIcon size={15} /> Profile
           </button>
@@ -304,18 +234,47 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
           </button>
           <button style={tabBtn(activeTab === 'danger')} onClick={() => { setActiveTab('danger'); setMessage(null); }}>
             <Trash2 size={15} /> Delete Account
+=======
+          <button style={tabBtn(activeTab === 'advisors')} onClick={() => setActiveTab('advisors')}>
+            <Layers size={15} /> Advisor Config
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
           </button>
         </div>
 
         <div style={body}>
-          {message && <div style={messageStyle(message.type)}>{message.text}</div>}
-
-          {activeTab === 'profile' && (
-            <form onSubmit={handleProfileSubmit}>
-              <div style={{ marginBottom: 16 }}>
-                <label style={label}>Email</label>
-                <input style={{ ...input, opacity: 0.6, cursor: 'not-allowed' }} value={user?.email || ''} disabled />
+          {activeTab === 'advisors' && (
+            <>
+              <AdvisorConfigPanel
+                advisors={advisors}
+                availableBackends={availableBackends || []}
+                value={draft}
+                onChange={setDraft}
+                description="Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback."
+              />
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 20 }}>
+                <button
+                  onClick={onClose}
+                  disabled={isSaving}
+                  style={{
+                    padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-primary)',
+                    background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 13.5,
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={isSaving}
+                  style={{
+                    padding: '8px 14px', borderRadius: 8, border: 'none',
+                    background: 'var(--accent-primary)', color: '#fff',
+                    cursor: isSaving ? 'wait' : 'pointer', fontSize: 13.5, fontWeight: 600,
+                  }}
+                >
+                  {isSaving ? 'Saving…' : 'Save configuration'}
+                </button>
               </div>
+<<<<<<< HEAD
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
                 <div>
                   <label style={label}>First Name</label>
@@ -447,6 +406,9 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
                 {isSubmitting ? 'Deleting…' : 'Permanently Delete Account'}
               </button>
             </form>
+=======
+            </>
+>>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
           )}
         </div>
 

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users, Layers } from 'lucide-react';
 import Toggle from './Toggle';
 import { useAppConfig } from '../contexts/AppConfigContext';
-import AdvisorConfigPanel from './AdvisorConfigPanel';
+import AdvisorConfigPanel, { DEFAULT_BACKEND, stripDefaultBackends } from './AdvisorConfigPanel';
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -120,10 +120,10 @@ const SettingsModal = ({
     const fallback = llmConfig?.default_backend || availableBackends?.[0];
     const seed = llmConfig?.persona_backends || {};
     const personas = {};
-    for (const id of personaIds) personas[id] = seed[id] || fallback;
+    for (const id of personaIds) personas[id] = seed[id] || DEFAULT_BACKEND;
     return {
       default_backend: fallback,
-      orchestrator_backend: llmConfig?.orchestrator_backend || fallback,
+      orchestrator_backend: llmConfig?.orchestrator_backend || DEFAULT_BACKEND,
       persona_backends: personas,
     };
   });
@@ -250,7 +250,7 @@ const SettingsModal = ({
 
   const handleModelSave = async () => {
     if (!onSubmitConfig) return;
-    await onSubmitConfig(modelDraft);
+    await onSubmitConfig(stripDefaultBackends(modelDraft));
   };
 
   const messageStyle = (type) => ({

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -117,7 +117,7 @@ const SettingsModal = ({
 
   const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
   const [modelDraft, setModelDraft] = useState(() => {
-    const fallback = llmConfig?.default_backend || availableBackends?.[0] || 'gemini';
+    const fallback = llmConfig?.default_backend || availableBackends?.[0];
     const seed = llmConfig?.persona_backends || {};
     const personas = {};
     for (const id of personaIds) personas[id] = seed[id] || fallback;

--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -1,27 +1,9 @@
-// TODO(@frontend-dev): This file has unresolved merge conflicts.
-// HEAD = disable-specific-personas + brainforge + message-persistence features
-// INCOMING = hybrid model selection feature (AdvisorConfigPanel, LLM config draft state)
-// Both sides need to be merged: keep HEAD's full multi-tab modal (Profile, Password,
-// Advisors toggles, Delete Account) and add incoming's AdvisorConfigPanel + LLM config
-// into the Advisors tab.
-
-<<<<<<< HEAD
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users } from 'lucide-react';
+import { X, User as UserIcon, Lock, Trash2, AlertTriangle, Users, Layers } from 'lucide-react';
 import Toggle from './Toggle';
 import { useAppConfig } from '../contexts/AppConfigContext';
-=======
-import React, { useMemo, useState } from 'react';
-import ReactDOM from 'react-dom';
-import { X, Layers } from 'lucide-react';
 import AdvisorConfigPanel from './AdvisorConfigPanel';
-
-// Settings modal. On feat/UI-for-User-Account-updates this file also has
-// Profile / Password / Delete Account tabs. When that branch merges, fold
-// those tabs into the tabRow + body sections below — the "advisors" tab
-// shipped on this branch is the only one not present there.
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
 
 const overlay = {
   position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
@@ -55,18 +37,8 @@ const tabBtn = (active) => ({
 
 const body = { padding: 24, overflowY: 'auto', flex: 1 };
 
-const SettingsModal = ({
-  user,
-  advisors,
-  availableBackends,
-  llmConfig,
-  isSaving,
-  onSubmitConfig,
-  onClose,
-}) => {
-  const [activeTab, setActiveTab] = useState('advisors');
+const label = { display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 6 };
 
-<<<<<<< HEAD
 const input = {
   width: '100%', padding: '10px 12px', borderRadius: 8,
   border: '1px solid var(--border-primary)', background: 'var(--bg-secondary)',
@@ -96,27 +68,31 @@ const miniBtn = {
   fontFamily: 'inherit',
 };
 
-const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) => {
+const SettingsModal = ({
+  user,
+  authToken,
+  onUserUpdate,
+  onSignOut,
+  onClose,
+  advisors,
+  availableBackends,
+  llmConfig,
+  isSaving,
+  onSubmitConfig,
+}) => {
   const [activeTab, setActiveTab] = useState('profile');
   const {
-    advisors,
     isAdvisorEnabled,
     setAdvisorEnabled,
     setAllAdvisorsEnabled,
     hydrateAdvisorPreferences,
   } = useAppConfig();
 
-  // Reconcile with the backend whenever the user opens Settings (covers fresh
-  // logins and changes made on another device).
   useEffect(() => {
     hydrateAdvisorPreferences();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Track where the mouse went DOWN so we don't close the modal when a user
-  // drags to select text inside an input and the mouseup happens outside the modal.
-  // (React's onClick fires on the common ancestor of down+up, which can be the
-  // overlay itself — causing accidental close on text selection.)
   const mouseDownOnOverlay = useRef(false);
   const handleOverlayMouseDown = (e) => {
     mouseDownOnOverlay.current = e.target === e.currentTarget;
@@ -139,6 +115,19 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
   const [message, setMessage] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
+  const [modelDraft, setModelDraft] = useState(() => {
+    const fallback = llmConfig?.default_backend || availableBackends?.[0] || 'gemini';
+    const seed = llmConfig?.persona_backends || {};
+    const personas = {};
+    for (const id of personaIds) personas[id] = seed[id] || fallback;
+    return {
+      default_backend: fallback,
+      orchestrator_backend: llmConfig?.orchestrator_backend || fallback,
+      persona_backends: personas,
+    };
+  });
+
   const apiUrl = process.env.REACT_APP_API_URL;
 
   const extractError = (data, fallback) => {
@@ -154,31 +143,141 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
     if (!firstName.trim() && !lastName.trim()) {
       setMessage({ type: 'error', text: 'Enter a first or last name.' });
       return;
-=======
-  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
-  const [draft, setDraft] = useState(() => {
-    const fallback = llmConfig?.default_backend || availableBackends?.[0] || 'gemini';
-    const seed = llmConfig?.persona_backends || {};
-    const personas = {};
-    for (const id of personaIds) {
-      personas[id] = seed[id] || fallback;
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
     }
-    return {
-      default_backend: fallback,
-      orchestrator_backend: llmConfig?.orchestrator_backend || fallback,
-      persona_backends: personas,
-    };
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`${apiUrl}/auth/me`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          first_name: firstName.trim(),
+          last_name: lastName.trim(),
+        }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        setMessage({ type: 'error', text: extractError(data, 'Could not update profile.') });
+        return;
+      }
+      onUserUpdate?.(data);
+      setFirstName(data.firstName || '');
+      setLastName(data.lastName || '');
+      setMessage({ type: 'success', text: 'Profile updated.' });
+    } catch (err) {
+      setMessage({ type: 'error', text: 'Network error. Please try again.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    setMessage(null);
+    if (newPassword !== confirmPassword) {
+      setMessage({ type: 'error', text: 'New passwords do not match.' });
+      return;
+    }
+    if (newPassword.length < 8) {
+      setMessage({ type: 'error', text: 'New password must be at least 8 characters.' });
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`${apiUrl}/auth/me/password`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        setMessage({ type: 'error', text: extractError(data, 'Could not change password.') });
+        return;
+      }
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setMessage({ type: 'success', text: 'Password changed.' });
+    } catch (err) {
+      setMessage({ type: 'error', text: 'Network error. Please try again.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteAccount = async (e) => {
+    e.preventDefault();
+    setMessage(null);
+    if (deleteConfirmText !== 'DELETE') {
+      setMessage({ type: 'error', text: 'Type DELETE to confirm.' });
+      return;
+    }
+    if (!deleteConfirmPassword) {
+      setMessage({ type: 'error', text: 'Password required to delete account.' });
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`${apiUrl}/auth/me`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({ password: deleteConfirmPassword }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        setMessage({ type: 'error', text: extractError(data, 'Could not delete account.') });
+        return;
+      }
+      onClose?.();
+      onSignOut?.();
+    } catch (err) {
+      setMessage({ type: 'error', text: 'Network error. Please try again.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleModelSave = async () => {
+    if (!onSubmitConfig) return;
+    await onSubmitConfig(modelDraft);
+  };
+
+  const messageStyle = (type) => ({
+    padding: '10px 12px', borderRadius: 8, marginBottom: 16, fontSize: 13,
+    background: type === 'error'
+      ? 'rgba(220,38,38,0.1)'
+      : type === 'success'
+        ? 'rgba(22,163,74,0.1)'
+        : 'var(--bg-secondary)',
+    color: type === 'error'
+      ? '#dc2626'
+      : type === 'success'
+        ? '#16a34a'
+        : 'var(--text-secondary)',
+    border: `1px solid ${
+      type === 'error'
+        ? 'rgba(220,38,38,0.3)'
+        : type === 'success'
+          ? 'rgba(22,163,74,0.3)'
+          : 'var(--border-primary)'
+    }`,
   });
 
-<<<<<<< HEAD
   const advisorEntries = Object.entries(advisors || {});
   const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
   const setAll = (enabled) => setAllAdvisorsEnabled(enabled);
 
-  // pendingDisable: { type: 'all' } | { type: 'single', id } — set when the
-  // user is about to leave zero advisors enabled. Confirming runs the action;
-  // "Go back" leaves state untouched.
   const [pendingDisable, setPendingDisable] = useState(null);
 
   const handleDisableAllClick = () => {
@@ -201,28 +300,19 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
       setAdvisorEnabled(pendingDisable.id, false);
     }
     setPendingDisable(null);
-=======
-  const handleSave = () => {
-    onSubmitConfig(draft);
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
   };
 
   return ReactDOM.createPortal(
-    <div style={overlay} onClick={(e) => e.target === e.currentTarget && onClose()}>
+    <div style={overlay} onMouseDown={handleOverlayMouseDown} onMouseUp={handleOverlayMouseUp}>
       <div style={modal}>
         <div style={header}>
           <h3 style={{ margin: 0, color: 'var(--text-primary)', fontSize: 18 }}>Settings</h3>
-<<<<<<< HEAD
           <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 4, display: 'flex' }} aria-label="Close settings">
-=======
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)' }}>
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
             <X size={20} />
           </button>
         </div>
 
         <div style={tabRow}>
-<<<<<<< HEAD
           <button style={tabBtn(activeTab === 'profile')} onClick={() => { setActiveTab('profile'); setMessage(null); }}>
             <UserIcon size={15} /> Profile
           </button>
@@ -232,49 +322,23 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
           <button style={tabBtn(activeTab === 'advisors')} onClick={() => { setActiveTab('advisors'); setMessage(null); }}>
             <Users size={15} /> Advisors
           </button>
+          <button style={tabBtn(activeTab === 'model')} onClick={() => { setActiveTab('model'); setMessage(null); }}>
+            <Layers size={15} /> Model
+          </button>
           <button style={tabBtn(activeTab === 'danger')} onClick={() => { setActiveTab('danger'); setMessage(null); }}>
             <Trash2 size={15} /> Delete Account
-=======
-          <button style={tabBtn(activeTab === 'advisors')} onClick={() => setActiveTab('advisors')}>
-            <Layers size={15} /> Advisor Config
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
           </button>
         </div>
 
         <div style={body}>
-          {activeTab === 'advisors' && (
-            <>
-              <AdvisorConfigPanel
-                advisors={advisors}
-                availableBackends={availableBackends || []}
-                value={draft}
-                onChange={setDraft}
-                description="Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback."
-              />
-              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 20 }}>
-                <button
-                  onClick={onClose}
-                  disabled={isSaving}
-                  style={{
-                    padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-primary)',
-                    background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 13.5,
-                  }}
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={isSaving}
-                  style={{
-                    padding: '8px 14px', borderRadius: 8, border: 'none',
-                    background: 'var(--accent-primary)', color: '#fff',
-                    cursor: isSaving ? 'wait' : 'pointer', fontSize: 13.5, fontWeight: 600,
-                  }}
-                >
-                  {isSaving ? 'Saving…' : 'Save configuration'}
-                </button>
+          {message && <div style={messageStyle(message.type)}>{message.text}</div>}
+
+          {activeTab === 'profile' && (
+            <form onSubmit={handleProfileSubmit}>
+              <div style={{ marginBottom: 16 }}>
+                <label style={label}>Email</label>
+                <input style={{ ...input, opacity: 0.6, cursor: 'not-allowed' }} value={user?.email || ''} disabled />
               </div>
-<<<<<<< HEAD
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
                 <div>
                   <label style={label}>First Name</label>
@@ -382,6 +446,43 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
             </>
           )}
 
+          {activeTab === 'model' && (
+            <>
+              <AdvisorConfigPanel
+                advisors={advisors}
+                availableBackends={availableBackends || []}
+                value={modelDraft}
+                onChange={setModelDraft}
+                description="Pick a backend for the orchestrator and each advisor. The default backend is used as a fallback."
+              />
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 20 }}>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={isSaving}
+                  style={{
+                    padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-primary)',
+                    background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer', fontSize: 13.5,
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleModelSave}
+                  disabled={isSaving}
+                  style={{
+                    ...primaryBtn,
+                    padding: '8px 14px', fontSize: 13.5, fontWeight: 600,
+                    cursor: isSaving ? 'wait' : 'pointer',
+                  }}
+                >
+                  {isSaving ? 'Saving…' : 'Save configuration'}
+                </button>
+              </div>
+            </>
+          )}
+
           {activeTab === 'danger' && (
             <form onSubmit={handleDeleteAccount}>
               <div style={{
@@ -406,9 +507,6 @@ const SettingsModal = ({ user, authToken, onUserUpdate, onSignOut, onClose }) =>
                 {isSubmitting ? 'Deleting…' : 'Permanently Delete Account'}
               </button>
             </form>
-=======
-            </>
->>>>>>> 8b7dfb4 (Pending changes to build backend the menus will be moved to the welcome screens and settigns pages once merges are completed.)
           )}
         </div>
 

--- a/phd-advisor-frontend/src/components/Sidebar.js
+++ b/phd-advisor-frontend/src/components/Sidebar.js
@@ -32,7 +32,8 @@ const Sidebar = ({
   onMobileToggle,
   onNavigateToCanvas,
   refreshTrigger,
-  onCurrentSessionDeleted
+  onCurrentSessionDeleted,
+  onOpenSettings,
 }) => {
   const { config } = useAppConfig();
   const canvasLabel = config?.app?.title ? `${config.app.title} Canvas` : 'Canvas';
@@ -245,7 +246,10 @@ const Sidebar = ({
                       <div className="user-menu">
                         <button
                           className="user-menu-item"
-                          onClick={() => { setShowSettings(true); setShowUserMenu(false); }}
+                          onClick={() => {
+                            setShowUserMenu(false);
+                            onOpenSettings?.();
+                          }}
                         >
                           <Settings size={16} />
                           <span>Settings</span>

--- a/phd-advisor-frontend/src/components/WelcomeModelPicker.js
+++ b/phd-advisor-frontend/src/components/WelcomeModelPicker.js
@@ -1,0 +1,162 @@
+import React, { useMemo, useState } from 'react';
+import { Cloud, Cpu, Server, ChevronDown, Settings2 } from 'lucide-react';
+import AdvisorConfigPanel from './AdvisorConfigPanel';
+
+// Welcome-state model picker. Lets a new user pick a uniform default backend
+// (Gemini / Ollama / vLLM) and optionally drill into per-advisor overrides.
+//
+// Primary picker → POSTs uniform mode.
+// Advanced expander → renders AdvisorConfigPanel; saving from here POSTs hybrid mode.
+
+const PROVIDER_META = {
+  gemini: { label: 'Gemini',  description: "Google's hosted Gemini",   icon: Cloud,  badge: 'Cloud' },
+  ollama: { label: 'Ollama',  description: 'Local LLM via Ollama',     icon: Cpu,    badge: 'Local' },
+  vllm:   { label: 'vLLM',    description: 'vLLM inference endpoint',  icon: Server, badge: 'API'   },
+};
+
+const card = {
+  background: 'var(--bg-primary)', border: '1px solid var(--border-primary)',
+  borderRadius: 16, padding: 20, boxShadow: 'var(--shadow-md)',
+  width: 'min(720px, 100%)', margin: '24px auto',
+};
+
+const optionGrid = {
+  display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+  gap: 12, marginTop: 12,
+};
+
+const optionStyle = (selected, disabled) => ({
+  display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 6,
+  padding: '14px 14px', borderRadius: 12,
+  border: `1px solid ${selected ? 'var(--accent-primary)' : 'var(--border-primary)'}`,
+  background: selected ? 'var(--feature-bg, var(--bg-secondary))' : 'var(--bg-secondary)',
+  color: 'var(--text-primary)', textAlign: 'left',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  opacity: disabled ? 0.55 : 1,
+  transition: 'border-color 0.15s ease, background 0.15s ease',
+});
+
+const advancedHeader = {
+  display: 'flex', alignItems: 'center', gap: 8, marginTop: 20,
+  padding: '10px 12px', borderRadius: 10,
+  background: 'transparent', border: '1px dashed var(--border-primary)',
+  color: 'var(--text-secondary)', cursor: 'pointer', width: '100%',
+  fontSize: 13.5, fontWeight: 500,
+};
+
+const WelcomeModelPicker = ({
+  advisors,
+  availableBackends,
+  llmConfig,
+  isSwitching,
+  onSelectUniform,
+  onSubmitHybrid,
+}) => {
+  const [advancedOpen, setAdvancedOpen] = useState(llmConfig?.mode === 'hybrid');
+  const [draft, setDraft] = useState(() => ({
+    default_backend: llmConfig?.default_backend || availableBackends[0] || 'gemini',
+    orchestrator_backend: llmConfig?.orchestrator_backend || llmConfig?.default_backend || availableBackends[0] || 'gemini',
+    persona_backends: llmConfig?.persona_backends || {},
+  }));
+
+  const providers = useMemo(
+    () => availableBackends.filter(b => PROVIDER_META[b]),
+    [availableBackends]
+  );
+
+  const isHybrid = llmConfig?.mode === 'hybrid';
+  const activeUniform = !isHybrid ? llmConfig?.default_backend : null;
+
+  return (
+    <div style={card}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
+        <h3 style={{ margin: 0, fontSize: 18, color: 'var(--text-primary)' }}>Choose your model</h3>
+        <span style={{ fontSize: 12.5, color: 'var(--text-secondary)' }}>
+          {isHybrid ? 'Hybrid configuration active' : `Active: ${PROVIDER_META[activeUniform]?.label || activeUniform || '—'}`}
+        </span>
+      </div>
+      <p style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: 13.5 }}>
+        Pick the backend that powers every advisor by default. You can mix and match in Advanced.
+      </p>
+
+      <div style={optionGrid}>
+        {providers.map(id => {
+          const meta = PROVIDER_META[id];
+          const Icon = meta.icon;
+          const selected = !isHybrid && activeUniform === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              style={optionStyle(selected, isSwitching)}
+              disabled={isSwitching}
+              onClick={() => onSelectUniform(id)}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+                <Icon size={18} />
+                <span style={{ fontWeight: 600, fontSize: 14 }}>{meta.label}</span>
+                <span
+                  style={{
+                    marginLeft: 'auto', fontSize: 11, padding: '2px 8px', borderRadius: 999,
+                    background: 'var(--bg-tertiary, var(--bg-primary))',
+                    color: 'var(--text-secondary)',
+                  }}
+                >
+                  {meta.badge}
+                </span>
+              </div>
+              <span style={{ fontSize: 12.5, color: 'var(--text-secondary)' }}>{meta.description}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        style={advancedHeader}
+        onClick={() => setAdvancedOpen(o => !o)}
+        aria-expanded={advancedOpen}
+      >
+        <Settings2 size={15} />
+        <span>Advanced — pick a different backend per advisor</span>
+        <ChevronDown
+          size={16}
+          style={{
+            marginLeft: 'auto',
+            transform: advancedOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 0.15s ease',
+          }}
+        />
+      </button>
+
+      {advancedOpen && (
+        <div style={{ marginTop: 16 }}>
+          <AdvisorConfigPanel
+            advisors={advisors}
+            availableBackends={availableBackends}
+            value={draft}
+            onChange={setDraft}
+            hideDefault
+            description="Default falls through to your selection above. Override the orchestrator or any advisor here."
+          />
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 16 }}>
+            <button
+              type="button"
+              onClick={() => onSubmitHybrid(draft)}
+              disabled={isSwitching}
+              style={{
+                padding: '8px 14px', borderRadius: 8, border: 'none',
+                background: 'var(--accent-primary)', color: '#fff',
+                cursor: isSwitching ? 'wait' : 'pointer', fontSize: 13.5, fontWeight: 600,
+              }}
+            >
+              {isSwitching ? 'Saving…' : 'Save advanced configuration'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WelcomeModelPicker;

--- a/phd-advisor-frontend/src/components/WelcomeModelPicker.js
+++ b/phd-advisor-frontend/src/components/WelcomeModelPicker.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Cloud, Cpu, Server, ChevronDown, Settings2 } from 'lucide-react';
-import AdvisorConfigPanel from './AdvisorConfigPanel';
+import AdvisorConfigPanel, { DEFAULT_BACKEND, stripDefaultBackends } from './AdvisorConfigPanel';
 
 // Welcome-state model picker. Lets a new user pick a uniform default backend
 // (Gemini / Ollama / vLLM) and optionally drill into per-advisor overrides.
@@ -55,7 +55,7 @@ const WelcomeModelPicker = ({
   const [advancedOpen, setAdvancedOpen] = useState(llmConfig?.mode === 'hybrid');
   const [draft, setDraft] = useState(() => ({
     default_backend: llmConfig?.default_backend || availableBackends[0],
-    orchestrator_backend: llmConfig?.orchestrator_backend || llmConfig?.default_backend || availableBackends[0],
+    orchestrator_backend: llmConfig?.orchestrator_backend || DEFAULT_BACKEND,
     persona_backends: llmConfig?.persona_backends || {},
   }));
 
@@ -142,7 +142,7 @@ const WelcomeModelPicker = ({
           <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 16 }}>
             <button
               type="button"
-              onClick={() => onSubmitHybrid(draft)}
+              onClick={() => onSubmitHybrid(stripDefaultBackends(draft))}
               disabled={isSwitching}
               style={{
                 padding: '8px 14px', borderRadius: 8, border: 'none',

--- a/phd-advisor-frontend/src/components/WelcomeModelPicker.js
+++ b/phd-advisor-frontend/src/components/WelcomeModelPicker.js
@@ -54,8 +54,8 @@ const WelcomeModelPicker = ({
 }) => {
   const [advancedOpen, setAdvancedOpen] = useState(llmConfig?.mode === 'hybrid');
   const [draft, setDraft] = useState(() => ({
-    default_backend: llmConfig?.default_backend || availableBackends[0] || 'gemini',
-    orchestrator_backend: llmConfig?.orchestrator_backend || llmConfig?.default_backend || availableBackends[0] || 'gemini',
+    default_backend: llmConfig?.default_backend || availableBackends[0],
+    orchestrator_backend: llmConfig?.orchestrator_backend || llmConfig?.default_backend || availableBackends[0],
     persona_backends: llmConfig?.persona_backends || {},
   }));
 

--- a/phd-advisor-frontend/src/contexts/AppConfigContext.js
+++ b/phd-advisor-frontend/src/contexts/AppConfigContext.js
@@ -61,6 +61,8 @@ const buildAdvisors = (personaItems, overrides = {}) => {
       darkBgColor: p.dark_bg_color || '#374151',
       icon: resolveIcon(isIcon ? image.replace('icon://', '') : null),
       avatarUrl,
+      defaultBackend: p.default_backend || null,
+      backendLocked: Boolean(p.brainforge || p.backend_locked),
     };
   }
   return advisors;

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -7,8 +7,8 @@ import MessageBubble from '../components/MessageBubble';
 import ThinkingIndicator from '../components/ThinkingIndicator';
 import SuggestionsPanel from '../components/SuggestionsPanel';
 import ThemeToggle from '../components/ThemeToggle';
-import ProviderDropdown from '../components/ProviderDropdown';
-import HybridConfigModal from '../components/HybridConfigModal';
+import WelcomeModelPicker from '../components/WelcomeModelPicker';
+import SettingsModal from '../components/SettingsModal';
 import ExportButton from '../components/ExportButton';
 import Sidebar from '../components/Sidebar';
 import { useAppConfig } from '../contexts/AppConfigContext';
@@ -34,9 +34,7 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
   });
   const [availableBackends, setAvailableBackends] = useState(['gemini', 'ollama', 'vllm']);
   const [isProviderSwitching, setIsProviderSwitching] = useState(false);
-  const [isHybridModalOpen, setIsHybridModalOpen] = useState(false);
-
-  const currentProvider = llmConfig.mode === 'hybrid' ? 'hybrid' : llmConfig.default_backend;
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [uploadedDocuments, setUploadedDocuments] = useState([]);
   const messagesEndRef = useRef(null);
   const { isDark } = useTheme();
@@ -137,10 +135,6 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
 
   const handleProviderSwitch = async (newProvider) => {
     if (isProviderSwitching) return;
-    if (newProvider === 'hybrid') {
-      setIsHybridModalOpen(true);
-      return;
-    }
     if (llmConfig.mode === 'uniform' && newProvider === llmConfig.default_backend) return;
 
     await submitProviderConfig(
@@ -154,7 +148,8 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
       { mode: 'hybrid', ...hybridConfig },
       'Hybrid configuration'
     );
-    if (ok) setIsHybridModalOpen(false);
+    if (ok) setIsSettingsOpen(false);
+    return ok;
   };
 
   const generateMessageId = () => {
@@ -768,6 +763,7 @@ const handleNewChat = async (sessionId = null) => {
         onMobileToggle={setIsMobileMenuOpen}
         onNavigateToCanvas={onNavigateToCanvas}
         refreshTrigger={sidebarRefreshTrigger}
+        onOpenSettings={() => setIsSettingsOpen(true)}
       />
       
       <div className={`main-chat-area ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
@@ -818,14 +814,6 @@ const handleNewChat = async (sessionId = null) => {
                   authToken={authToken}
                 />
 
-                {/* Provider Dropdown */}
-                <ProviderDropdown
-                  currentProvider={currentProvider}
-                  onProviderChange={handleProviderSwitch}
-                  isLoading={isProviderSwitching}
-                  onConfigureHybrid={() => setIsHybridModalOpen(true)}
-                />
-
                 {/* Theme Toggle */}
                 <ThemeToggle />
 
@@ -845,6 +833,14 @@ const handleNewChat = async (sessionId = null) => {
           <div className="chat-content">
             {!hasMessages ? (
               <div className="welcome-state">
+                <WelcomeModelPicker
+                  advisors={advisors}
+                  availableBackends={availableBackends}
+                  llmConfig={llmConfig}
+                  isSwitching={isProviderSwitching}
+                  onSelectUniform={handleProviderSwitch}
+                  onSubmitHybrid={handleHybridSubmit}
+                />
                 <AdvisorCarousel />
                 <SuggestionsPanel onSuggestionClick={handleSendMessage} />
               </div>
@@ -999,14 +995,15 @@ const handleNewChat = async (sessionId = null) => {
         </div>
       </div>
 
-      {isHybridModalOpen && (
-        <HybridConfigModal
+      {isSettingsOpen && (
+        <SettingsModal
+          user={user}
           advisors={advisors}
           availableBackends={availableBackends}
-          initialConfig={llmConfig}
+          llmConfig={llmConfig}
           isSaving={isProviderSwitching}
-          onSubmit={handleHybridSubmit}
-          onClose={() => setIsHybridModalOpen(false)}
+          onSubmitConfig={handleHybridSubmit}
+          onClose={() => setIsSettingsOpen(false)}
         />
       )}
     </div>

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -27,11 +27,11 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
   const [replyingTo, setReplyingTo] = useState(null);
   const [llmConfig, setLlmConfig] = useState({
     mode: 'uniform',
-    default_backend: 'gemini',
+    default_backend: null,
     orchestrator_backend: null,
     persona_backends: null,
   });
-  const [availableBackends, setAvailableBackends] = useState(['gemini', 'ollama', 'vllm']);
+  const [availableBackends, setAvailableBackends] = useState([]);
   const [isProviderSwitching, setIsProviderSwitching] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [uploadedDocuments, setUploadedDocuments] = useState([]);

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -8,6 +8,7 @@ import ThinkingIndicator from '../components/ThinkingIndicator';
 import SuggestionsPanel from '../components/SuggestionsPanel';
 import ThemeToggle from '../components/ThemeToggle';
 import ProviderDropdown from '../components/ProviderDropdown';
+import HybridConfigModal from '../components/HybridConfigModal';
 import ExportButton from '../components/ExportButton';
 import Sidebar from '../components/Sidebar';
 import { useAppConfig } from '../contexts/AppConfigContext';
@@ -25,8 +26,17 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
   const [thinkingAdvisors, setThinkingAdvisors] = useState([]);
   const [collectedInfo, setCollectedInfo] = useState({});
   const [replyingTo, setReplyingTo] = useState(null);
-  const [currentProvider, setCurrentProvider] = useState('gemini');
+  const [llmConfig, setLlmConfig] = useState({
+    mode: 'uniform',
+    default_backend: 'gemini',
+    orchestrator_backend: null,
+    persona_backends: null,
+  });
+  const [availableBackends, setAvailableBackends] = useState(['gemini', 'ollama', 'vllm']);
   const [isProviderSwitching, setIsProviderSwitching] = useState(false);
+  const [isHybridModalOpen, setIsHybridModalOpen] = useState(false);
+
+  const currentProvider = llmConfig.mode === 'hybrid' ? 'hybrid' : llmConfig.default_backend;
   const [uploadedDocuments, setUploadedDocuments] = useState([]);
   const messagesEndRef = useRef(null);
   const { isDark } = useTheme();
@@ -53,16 +63,18 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
   }, [messages, thinkingAdvisors]);
 
   useEffect(() => {
-    fetchCurrentProvider();
-  }, []);
+    if (authToken) fetchCurrentProvider();
+  }, [authToken]);
 
   const fetchCurrentProvider = async () => {
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/current-provider`);
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/current-provider`, {
+        headers: { 'Authorization': `Bearer ${authToken}` },
+      });
       if (response.ok) {
         const data = await response.json();
-        setCurrentProvider(data.current_provider);
-        console.log('Loaded provider:', data.current_provider, 'Available:', data.available_providers);
+        if (data.llm_config) setLlmConfig(data.llm_config);
+        if (Array.isArray(data.available_backends)) setAvailableBackends(data.available_backends);
       }
     } catch (error) {
       console.error('Error fetching current provider:', error);
@@ -71,55 +83,78 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
 
   
 
-  const handleProviderSwitch = async (newProvider) => {
-    if (newProvider === currentProvider || isProviderSwitching) return;
-
+  const submitProviderConfig = async (payload, label) => {
     setIsProviderSwitching(true);
     try {
       const response = await fetch(`${process.env.REACT_APP_API_URL}/switch-provider`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
         },
-        body: JSON.stringify({
-          provider: newProvider
-        }),
+        body: JSON.stringify(payload),
       });
 
       if (response.ok) {
         const data = await response.json();
-        setCurrentProvider(newProvider);
-        
-        const switchMessage = {
+        if (data.llm_config) {
+          setLlmConfig(data.llm_config);
+        } else {
+          setLlmConfig(payload);
+        }
+
+        setMessages(prev => [...prev, {
           id: generateMessageId(),
           type: 'system',
-          content: `✨ Switched to ${newProvider.charAt(0).toUpperCase() + newProvider.slice(1)} provider. Your advisors are now ready with the new AI model.`,
+          content: `✨ Switched to ${label}. Your advisors are now ready with the new configuration.`,
           timestamp: new Date()
-        };
-        setMessages(prev => [...prev, switchMessage]);
-      } else {
-        const error = await response.json();
-        console.error('Failed to switch provider:', error);
-        const errorMessage = {
-          id: generateMessageId(),
-          type: 'error',
-          content: `Failed to switch to ${newProvider}: ${error.detail || 'Unknown error'}`,
-          timestamp: new Date()
-        };
-        setMessages(prev => [...prev, errorMessage]);
+        }]);
+        return true;
       }
-    } catch (error) {
-      console.error('Error switching provider:', error);
-      const errorMessage = {
+
+      const error = await response.json().catch(() => ({}));
+      console.error('Failed to switch provider:', error);
+      setMessages(prev => [...prev, {
         id: generateMessageId(),
         type: 'error',
-        content: `Error switching to ${newProvider}. Please try again.`,
+        content: `Failed to switch to ${label}: ${error.detail || 'Unknown error'}`,
         timestamp: new Date()
-      };
-      setMessages(prev => [...prev, errorMessage]);
+      }]);
+      return false;
+    } catch (error) {
+      console.error('Error switching provider:', error);
+      setMessages(prev => [...prev, {
+        id: generateMessageId(),
+        type: 'error',
+        content: `Error switching to ${label}. Please try again.`,
+        timestamp: new Date()
+      }]);
+      return false;
     } finally {
       setIsProviderSwitching(false);
     }
+  };
+
+  const handleProviderSwitch = async (newProvider) => {
+    if (isProviderSwitching) return;
+    if (newProvider === 'hybrid') {
+      setIsHybridModalOpen(true);
+      return;
+    }
+    if (llmConfig.mode === 'uniform' && newProvider === llmConfig.default_backend) return;
+
+    await submitProviderConfig(
+      { mode: 'uniform', default_backend: newProvider },
+      newProvider.charAt(0).toUpperCase() + newProvider.slice(1)
+    );
+  };
+
+  const handleHybridSubmit = async (hybridConfig) => {
+    const ok = await submitProviderConfig(
+      { mode: 'hybrid', ...hybridConfig },
+      'Hybrid configuration'
+    );
+    if (ok) setIsHybridModalOpen(false);
   };
 
   const generateMessageId = () => {
@@ -517,6 +552,7 @@ const handleNewChat = async (sessionId = null) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`,
       },
       body: JSON.stringify({
         user_input: inputMessage,
@@ -594,6 +630,7 @@ const handleNewChat = async (sessionId = null) => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
         },
         body: JSON.stringify({
           user_input: expandPrompt,
@@ -786,6 +823,7 @@ const handleNewChat = async (sessionId = null) => {
                   currentProvider={currentProvider}
                   onProviderChange={handleProviderSwitch}
                   isLoading={isProviderSwitching}
+                  onConfigureHybrid={() => setIsHybridModalOpen(true)}
                 />
 
                 {/* Theme Toggle */}
@@ -960,6 +998,17 @@ const handleNewChat = async (sessionId = null) => {
           </div>
         </div>
       </div>
+
+      {isHybridModalOpen && (
+        <HybridConfigModal
+          advisors={advisors}
+          availableBackends={availableBackends}
+          initialConfig={llmConfig}
+          isSaving={isProviderSwitching}
+          onSubmit={handleHybridSubmit}
+          onClose={() => setIsHybridModalOpen(false)}
+        />
+      )}
     </div>
     </OnboardingTour>
   );

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -7,7 +7,6 @@ import MessageBubble from '../components/MessageBubble';
 import ThinkingIndicator from '../components/ThinkingIndicator';
 import SuggestionsPanel from '../components/SuggestionsPanel';
 import ThemeToggle from '../components/ThemeToggle';
-import WelcomeModelPicker from '../components/WelcomeModelPicker';
 import SettingsModal from '../components/SettingsModal';
 import ExportButton from '../components/ExportButton';
 import Sidebar from '../components/Sidebar';
@@ -131,16 +130,6 @@ const ChatPage = ({ user, authToken, onNavigateToHome, onNavigateToCanvas, onSig
     } finally {
       setIsProviderSwitching(false);
     }
-  };
-
-  const handleProviderSwitch = async (newProvider) => {
-    if (isProviderSwitching) return;
-    if (llmConfig.mode === 'uniform' && newProvider === llmConfig.default_backend) return;
-
-    await submitProviderConfig(
-      { mode: 'uniform', default_backend: newProvider },
-      newProvider.charAt(0).toUpperCase() + newProvider.slice(1)
-    );
   };
 
   const handleHybridSubmit = async (hybridConfig) => {
@@ -833,14 +822,6 @@ const handleNewChat = async (sessionId = null) => {
           <div className="chat-content">
             {!hasMessages ? (
               <div className="welcome-state">
-                <WelcomeModelPicker
-                  advisors={advisors}
-                  availableBackends={availableBackends}
-                  llmConfig={llmConfig}
-                  isSwitching={isProviderSwitching}
-                  onSelectUniform={handleProviderSwitch}
-                  onSubmitHybrid={handleHybridSubmit}
-                />
                 <AdvisorCarousel />
                 <SuggestionsPanel onSuggestionClick={handleSendMessage} />
               </div>
@@ -998,6 +979,9 @@ const handleNewChat = async (sessionId = null) => {
       {isSettingsOpen && (
         <SettingsModal
           user={user}
+          authToken={authToken}
+          onUserUpdate={onUserUpdate}
+          onSignOut={onSignOut}
           advisors={advisors}
           availableBackends={availableBackends}
           llmConfig={llmConfig}

--- a/phd-advisor-frontend/src/styles/ChatPage.css
+++ b/phd-advisor-frontend/src/styles/ChatPage.css
@@ -911,6 +911,12 @@
 .provider-badge.gemini { color: #4285f4; }
 .provider-badge.ollama { color: #10b981; }
 .provider-badge.vllm   { color: #ef4444; }
+.provider-badge.hybrid { color: #a855f7; }
+
+[data-theme="dark"] .provider-badge.hybrid,
+[data-theme="dark"] .provider-option-badge.hybrid {
+  color: #ffffff;
+}
 
 .clarification-message-container {
   display: flex;
@@ -1145,6 +1151,34 @@
 .provider-option-badge.vllm {
   background: rgba(239, 68, 68, 0.15);
   color: #ef4444;
+}
+
+.provider-option-badge.hybrid {
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+}
+
+.provider-option-configure {
+  margin-left: 8px;
+  background: transparent;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 6px;
+  padding: 4px 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary, #6b7280);
+}
+
+.provider-option-configure:hover {
+  background: var(--accent-primary);
+  color: #fff;
+  border-color: var(--accent-primary);
+}
+
+[data-theme="dark"] .provider-option-configure {
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .provider-option-description {

--- a/phd_config.yaml
+++ b/phd_config.yaml
@@ -174,10 +174,13 @@ mongodb:
 
 llm:
   gemini:
+    enabled: true
     model: "gemini-2.5-flash"
   ollama:
+    enabled: false
     model: "llama3.2:1b"
   vllm:
+    enabled: true
     api_url: https://rtx6000blackwell-1.neonaiservices2.com/vllm0
   brainforge:
     api_url: https://hana.neonaialpha.com

--- a/phd_config.yaml
+++ b/phd_config.yaml
@@ -173,6 +173,7 @@ mongodb:
   database_name: "phd_advisor"
 
 llm:
+  default_backend: gemini
   gemini:
     enabled: true
     model: "gemini-2.5-flash"


### PR DESCRIPTION
# Description

Adds per-user LLM backend selection, allowing each user to configure which LLM provider (Gemini, Ollama, vLLM) powers the orchestrator and each individual advisor. 

User configurations are persisted to the database via a new `llm_config` field on the User model. The backend resolves the correct LLM client per-persona at chat time based on the stored config. The frontend exposes this through an `AdvisorConfigPanel` component in the Settings modal, with backend health checks running periodically to keep the available backends list current.

Admins can now disable individual backends via `enabled: false` in `config.yaml`, and the default backend is resolved dynamically at startup — preferring Gemini but falling back to the first available. The frontend no longer hardcodes Gemini as a fallback; all UI selectors are driven by the available backends returned from the API.

BrainForge advisors are excluded from model configuration since they are bound to their own LLM backend.

# Issues

Closes #51 
Closes #59
Closes #71 

# Other Notes

- Backend health checks run on a configurable interval (`llm.health_check_interval` in `config.py`), which is currently set to 5 min.
- Backend config (`gemini`, `ollama`, `vllm`) now supports an `enabled` flag — defaults to `true`, set to `false` to hide from users.
- If no backends are available at startup, the app raises a `RuntimeError` with an actionable message rather than failing silently.
