### PR TITLE
fixed path for bundled avatar URIs.

### DIFF
--- a/multi_llm_chatbot_backend/app/config.py
+++ b/multi_llm_chatbot_backend/app/config.py
@@ -154,8 +154,7 @@ class PersonaItemConfig(_IconValidatorMixin):
                 self.avatar, self.id,
             )
             return f"icon://{self.icon}"
-        base = os.getenv("REACT_APP_API_URL", "http://localhost:8000").rstrip("/")
-        return f"{base}/api/avatars/bundled/{self.avatar}"
+        return f"/api/avatars/bundled/{self.avatar}"
 
     def to_frontend_config(self) -> dict:
         return {

--- a/multi_llm_chatbot_backend/app/tests/unit/test_avatar_resolution.py
+++ b/multi_llm_chatbot_backend/app/tests/unit/test_avatar_resolution.py
@@ -1,6 +1,5 @@
 import unittest
 import tempfile
-import os
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
@@ -113,11 +112,10 @@ class TestResolveImage(unittest.TestCase):
         persona = PersonaItemConfig(
             id="test", name="Test", icon="Brain", avatar="advisor1.png",
         )
-        with patch.dict(os.environ, {"REACT_APP_API_URL": "http://localhost:8000"}):
-            self.assertEqual(
-                persona._resolve_image(),
-                "http://localhost:8000/api/avatars/bundled/advisor1.png",
-            )
+        self.assertEqual(
+            persona._resolve_image(),
+            "/api/avatars/bundled/advisor1.png",
+        )
 
     @patch("app.utils.avatar_helpers.get_bundled_avatar_path")
     def test_bundled_avatar_missing_falls_back_to_icon(self, mock_get_path):


### PR DESCRIPTION
# Description
The backend was returning absolute avatar URLs using `REACT_APP_API_URL` (which wasn't available on the backend in deployment and fell back to `http://localhost:8000`), causing a CORS error. Changed to return a server-relative path (`/api/avatars/bundled/...`) instead.

# Issues
- Closes #79 

# Other Notes
None