### PR TITLE
Fix/disable all error

### DIFF
--- a/phd-advisor-frontend/src/components/SettingsModal.js
+++ b/phd-advisor-frontend/src/components/SettingsModal.js
@@ -115,7 +115,7 @@ const SettingsModal = ({
   const [message, setMessage] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const personaIds = useMemo(() => Object.keys(advisors || {}).filter(id => id !== 'aggregated'), [advisors]);
+  const personaIds = useMemo(() => Object.keys(advisors || {}), [advisors]);
   const [modelDraft, setModelDraft] = useState(() => {
     const fallback = llmConfig?.default_backend || availableBackends?.[0];
     const seed = llmConfig?.persona_backends || {};
@@ -274,7 +274,7 @@ const SettingsModal = ({
     }`,
   });
 
-  const advisorEntries = Object.entries(advisors || {}).filter(([id]) => id !== 'aggregated');
+  const advisorEntries = Object.entries(advisors || {});
   const enabledCount = advisorEntries.filter(([id]) => isAdvisorEnabled(id)).length;
   const setAll = (enabled) => setAllAdvisorsEnabled(enabled);
 
@@ -449,7 +449,7 @@ const SettingsModal = ({
           {activeTab === 'model' && (
             <>
               <AdvisorConfigPanel
-                advisors={Object.fromEntries(Object.entries(advisors || {}).filter(([id]) => id !== 'aggregated'))}
+                advisors={advisors || {}}
                 availableBackends={availableBackends || []}
                 value={modelDraft}
                 onChange={setModelDraft}

--- a/phd-advisor-frontend/src/contexts/AppConfigContext.js
+++ b/phd-advisor-frontend/src/contexts/AppConfigContext.js
@@ -1,7 +1,20 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import * as LucideIcons from 'lucide-react';
 
 const AppConfigContext = createContext(null);
+
+const SYNTHETIC_PERSONAS = {
+  aggregated: {
+    name: 'Orchestrator',
+    role: 'Synthesized Response',
+    description: 'A single combined response merging all advisor perspectives.',
+    color: '#7C3AED',
+    bgColor: '#F3E8FF',
+    darkColor: '#A78BFA',
+    darkBgColor: '#3B2A5E',
+    icon: LucideIcons.User,
+  },
+};
 
 const ADVISOR_PREFS_URL = `${process.env.REACT_APP_API_URL}/api/me/advisor-preferences`;
 
@@ -137,19 +150,6 @@ export const AppConfigProvider = ({ children }) => {
 
   useEffect(() => {
     const built = buildAdvisors(personaItems, avatarOverrides);
-    // Synthetic persona used for aggregated/synthesized responses — represents
-    // a single combined "Partner" voice rather than the panel of advisors.
-    built.aggregated = {
-      name: 'Orchestrator',
-      role: 'Synthesized Response',
-      description: 'A single combined response merging all advisor perspectives.',
-      color: '#7C3AED',
-      bgColor: '#F3E8FF',
-      darkColor: '#A78BFA',
-      darkBgColor: '#3B2A5E',
-      icon: LucideIcons.User,
-      avatarUrl: avatarOverrides.aggregated || null,
-    };
     setAdvisors(built);
   }, [personaItems, avatarOverrides]);
 
@@ -273,8 +273,8 @@ export const AppConfigProvider = ({ children }) => {
   }, [config]);
 
   const getAdvisorColors = buildGetAdvisorColors(advisors);
-  const allPersonas = advisors;
-  const getAllPersonaColors = getAdvisorColors;
+  const allPersonas = useMemo(() => ({ ...advisors, ...SYNTHETIC_PERSONAS }), [advisors]);
+  const getAllPersonaColors = buildGetAdvisorColors(allPersonas);
 
   const value = {
     config,

--- a/phd-advisor-frontend/src/pages/ChatPage.js
+++ b/phd-advisor-frontend/src/pages/ChatPage.js
@@ -919,9 +919,7 @@ const handleNewChat = async (sessionId = null) => {
             
             <div className="header-right">
               <AdvisorStatusDropdown
-                advisors={Object.fromEntries(
-                  Object.entries(advisors).filter(([id]) => id !== 'aggregated')
-                )}
+                advisors={advisors}
                 thinkingAdvisors={thinkingAdvisors}
                 getAdvisorColors={getAdvisorColors}
                 isDark={isDark}


### PR DESCRIPTION
# Description
Moved the synthetic orchestrator persona (`aggregated`) out of the `advisors` object and into a separate `SYNTHETIC_PERSONAS` constant. It is now only accessible through `allPersonas`, which `MessageBubble` uses for rendering. This prevents the synthetic ID from leaking into settings, preferences, and the "Disable All" flow — which was causing a 400 from `/api/me/advisor-preferences` because the backend rejected the unrecognized `aggregated` ID. Also removed the now-unnecessary `filter(id !== 'aggregated')` guards from `SettingsModal.js` and `ChatPage.js`.

# Issues
Closes #83

# Other Notes
- `advisors` is now safe to iterate without filtering synthetic personas.
- Aggregated message rendering (name, color, icon) is unchanged — `MessageBubble` consumes `allPersonas` which still includes the orchestrator definition.